### PR TITLE
Feat: Update primary theme colors to new brand palette

### DIFF
--- a/src/pretalx/static/common/scss/_variables.scss
+++ b/src/pretalx/static/common/scss/_variables.scss
@@ -1,9 +1,9 @@
 /* colors */
-$brand-primary: #3aa57c !default;
-$brand-success: #3aa57c !default;
+$brand-primary: #2185d0 !default;
+$brand-success: #2185d0 !default;
 $brand-info: #4697c9 !default;
 $brand-warning: #f9a557 !default;
-$brand-danger: #b23e65 !default;
+$brand-danger: #db2828 !default;
 $link-color: $brand-success !default;
 
 $body-color: rgba(0, 0, 0, 0.87) !default;


### PR DESCRIPTION
#### Description
FYI: Fixes #7 

This PR introduces changes to update the primary theme color across the web app to align with our new theme. 

#### Changes

- Updated the `$brand-primary` variable in the SCSS files from `#3aa57c` to `#2185d0`.
- Updated the `$brand-danger` variable in the SCSS files from `#b23e65` to `#db2828`. 


#### Visuals


- **Event Theme**
      <img width="778" alt="event_theme" src="https://github.com/fossasia/eventyay-talk/assets/38150419/a2d475d3-8afe-4d61-b5f2-ae262cef9e7b">


- **Side Navigation (All semi transparent area)**
      <img width="397" alt="side_bar_color" src="https://github.com/fossasia/eventyay-talk/assets/38150419/d4fce5e6-d725-4ac2-b3ff-8b87fc5f0a6b">

- **Primary success button colour (Save/Other success action buttons)**
    <img width="519" alt="primary_clour_change_buttton" src="https://github.com/fossasia/eventyay-talk/assets/38150419/6f20890d-d067-4057-b089-e740da100f66">

- **Frontpage Header**
    <img width="1788" alt="frontpage_header" src="https://github.com/fossasia/eventyay-talk/assets/38150419/b0028752-4c31-466a-8d39-420f2bff8421">

