### PR TITLE
Change naming of form questions

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`orga:form` Change “Choose one from a list” to “Radio button (Choose one option)” and “Choose multiple from a list” to “Checkbox (Choose one or several options)” for better clarity about their purpose.
 - :feature:`orga:sidebar` Renamed CfP to Call for Speakers for clarity
 - :feature:`orga,820` Restricted tracks now link to the page where you can create access codes for that track.
 - :announcement:`admin,1678` Due to its incomplete and complex nature, the ``import_schedule`` admin command has been removed. If you want to import a schedule, despite all the complexities, please use the pretalx-downstream plugin instead.

--- a/src/pretalx/submission/models/question.py
+++ b/src/pretalx/submission/models/question.py
@@ -51,8 +51,8 @@ class QuestionVariant(Choices):
         (DATETIME, _("Date and time")),
         (BOOLEAN, _("Yes/No")),
         (FILE, _("File upload")),
-        (CHOICES, _("Choose one from a list")),
-        (MULTIPLE, _("Choose multiple from a list")),
+        (CHOICES, _("Radio button (Choose one option)")),
+        (MULTIPLE, _("Checkbox (Choose one or several options)")),
     ]
 
 


### PR DESCRIPTION
Form questions:

Change naming ->
1. “Choose one from a list” to “Radio button (Choose one option)” 
2. “Choose multiple from a list” to “Checkbox (Choose one or several options)”

This is done to better reflect what these options do.

fixes: fossasia/eventyay-tickets#994

![image](https://github.com/fossasia/eventyay-talk/assets/34372791/a2e9fa10-3314-4508-bbe8-a84882348736)


## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
