### PR TITLE
Rename CfP to Call for Speakers in organiser view sidebar

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`orga:sidebar` Renamed CfP to Call for Speakers for clarity
 - :feature:`orga,1619` Organisers can now add new team members in bulk instead of one by one.
 - :feature:`orga:schedule,1587` A hint now shows when users click the "New break" box, informing them that they have to drag it to the schedule instead.
 - :feature:`orga:schedule` Breaks now also show their start time and duration in the schedule editor.

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -222,7 +222,7 @@
                                 <span class="has-children">
                                     <a class="nav-link nav-link-inner" href="{{ request.event.cfp.urls.text }}">
                                         <i class="fa fa-bullhorn"></i>
-                                        <span class="sidebar-text">{% translate "CfP" %}</span>
+                                        <span class="sidebar-text">{% translate "Call for Speakers" %}</span>
                                     </a>
                                     <a class="arrow nav-link" data-toggle="collapse" href="#collapseCfP" aria-controls="collapseCfP">
                                         <i class="fa fa-angle-down"></i>


### PR DESCRIPTION
For better clarity, instead of using the acronym "CfP" we can instead use "Call for Speakers" directly.

fixes: #9

![image](https://github.com/fossasia/eventyay-talk/assets/34372791/5c382672-4984-4be9-a2ce-812586804de6)


## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.
