### PR TITLE
Issue #17 fixed

### DIFF
--- a/src/pretalx/cfp/templates/cfp/event/cfp.html
+++ b/src/pretalx/cfp/templates/cfp/event/cfp.html
@@ -43,6 +43,13 @@
                     {% translate "Edit or view your proposals" %}
                 </a>
             {% endif %}
+
+            {% if has_submissions or request.user.is_anonymous %}
+            <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user }}">
+                {% translate "View or edit speaker profile" %}
+            </a>
+        {% endif %}
+
             <a class="btn btn-success btn-lg btn-block {% if not cfp.is_open and not access_code.is_valid %}disabled{% endif %}"
                href="{{ request.event.urls.submit }}{{ submit_qs }}">
                 {% if cfp.is_open or access_code.is_valid %}

--- a/src/pretalx/cfp/templates/cfp/event/cfp.html
+++ b/src/pretalx/cfp/templates/cfp/event/cfp.html
@@ -45,10 +45,10 @@
             {% endif %}
 
             {% if has_submissions or request.user.is_anonymous %}
-            <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user }}">
-                {% translate "View or edit speaker profile" %}
-            </a>
-        {% endif %}
+                <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user }}">
+                    {% translate "View or edit speaker profile" %}
+                </a>
+            {% endif %}
 
             <a class="btn btn-success btn-lg btn-block {% if not cfp.is_open and not access_code.is_valid %}disabled{% endif %}"
                href="{{ request.event.urls.submit }}{{ submit_qs }}">

--- a/src/pretalx/cfp/templates/cfp/event/index.html
+++ b/src/pretalx/cfp/templates/cfp/event/index.html
@@ -16,6 +16,13 @@
                         {% translate "Edit or view your proposals" %}
                     </a>
                 {% endif %}
+
+                {% if not is_html_export %}
+                    <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user }}">
+                        {% translate "View or edit speaker profile" %}
+                    </a>
+                {% endif %}
+
             {% endif %}
             {% if request.event.current_schedule and request.event.feature_flags.show_schedule %}
                 <a class="btn btn-success btn-lg btn-block" href="{{ request.event.urls.schedule }}">


### PR DESCRIPTION
Add button link to view or edit speaker profile #17

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #17.

## How has this been tested?
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! --> Here's a screenshot of the fixed for both pages.

1) Solution for the first screenshot.
![screenshot1](https://github.com/fossasia/eventyay-talk/assets/26376179/0ebc2436-7028-4c96-a971-5affbc0f00c8)

A new button called "View or edit speaker profile" now exists as requested. Clicking on it shows the following page below.

![profile_ss1](https://github.com/fossasia/eventyay-talk/assets/26376179/0a16ace3-7380-4102-9038-3f2f4664a5c5)


2)  Solution for the second screenshot.
![screenshot2](https://github.com/fossasia/eventyay-talk/assets/26376179/47393a26-de5f-478a-b96f-32e2c8497b1a)
Similarly, a new button called "View or edit speaker profile" now exists as requested. Clicking on it shows the following page below.

![profile_ss1](https://github.com/fossasia/eventyay-talk/assets/26376179/7080c3c5-c5e8-4d34-b98c-d8c674c73e0d)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] I have tested the new buttons added on my local machine and it works to cover my changes.
- [x] I have strictly adhered to the contributing guidelines and code of conduct.
