### PR TITLE
Making absolute image embeddings to relative image embeddings (Issue #20)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,10 +94,10 @@ If you want to look at conferences using pretalx, head over to the wiki for a
 `list of events`_. And if you use pretalx for your event, please add it to the
 list (or tell us about it, and we'll add it)!
 
-.. |logo| image:: https://raw.githubusercontent.com/pretalx/pretalx/main/assets/logo.svg
+.. |logo| image:: assets/logo.svg
    :alt: pretalx logo
    :target: https://pretalx.com
-.. |screenshots| image:: https://raw.githubusercontent.com/pretalx/pretalx/main/assets/screenshots.png
+.. |screenshots| image:: assets/screenshots.png
    :target: https://pretalx.com/p/features
    :alt: Screenshots of pretalx pages
 .. _issues: https://github.com/pretalx/pretalx/issues/


### PR DESCRIPTION


This PR closes issue #20 

## How has this been tested?
I ran these two commands:
rst2html.py README.rst > README.html
open README.html

And this was the result (zoomed out 50%):
![image](https://github.com/fossasia/eventyay-talk/assets/84177184/77f852ca-3260-4a7d-871c-8d3647f6255f)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
