### PR TITLE
Improving development setup documentation

### DIFF
--- a/doc/developer/setup.rst
+++ b/doc/developer/setup.rst
@@ -196,6 +196,10 @@ directory of your git repository, and then run::
 
     (env)$ pip install --upgrade-strategy eager -Ur doc/requirements.txt
 
+Next, navigate to the ``doc`` subdirectory::
+
+    (env)$ cd doc
+
 Then, to build the documentation, run the following command::
 
     (env)$ make html


### PR DESCRIPTION
While trying to build the documentation at https://docs.pretalx.org/developer/setup.html, I came across a step that might have been missed, specifically that of leaving the root directory and cd'ing into doc subdirectory first, before make html.

![image](https://github.com/fossasia/eventyay-talk/assets/84177184/eee82738-1725-41af-b252-de94c6966950)



## How has this been tested?
I built and ran the docs on my localhost, and this is how it looks now:
![image](https://github.com/fossasia/eventyay-talk/assets/84177184/d641c61d-d7ac-4208-9c6f-c43767c20c62)


## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
