### PR TITLE
Fix Issue #54: Anonymous users should see submit a proposal only

### DIFF
--- a/src/pretalx/cfp/templates/cfp/event/cfp.html
+++ b/src/pretalx/cfp/templates/cfp/event/cfp.html
@@ -38,16 +38,18 @@
                     {% translate "View schedule preview" %}
                 </a>
             {% endif %}
+            {% if request.user.is_authenticated %}
             {% if has_submissions or request.user.is_anonymous %}
-                <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user_submissions }}">
-                    {% translate "Edit or view your proposals" %}
-                </a>
-            {% endif %}
+            <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user_submissions }}">
+                {% translate "Edit or view your proposals" %}
+            </a>
+        {% endif %}
 
-            {% if has_submissions or request.user.is_anonymous %}
-                <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user }}">
-                    {% translate "View or edit speaker profile" %}
-                </a>
+        {% if has_submissions or request.user.is_anonymous %}
+            <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user }}">
+                {% translate "View or edit speaker profile" %}
+            </a>
+        {% endif %}
             {% endif %}
 
             <a class="btn btn-success btn-lg btn-block {% if not cfp.is_open and not access_code.is_valid %}disabled{% endif %}"

--- a/src/pretalx/cfp/templates/cfp/event/index.html
+++ b/src/pretalx/cfp/templates/cfp/event/index.html
@@ -4,40 +4,41 @@
 {% load rules %}
 
 {% block content %}
-    {% with cfp=request.event.cfp %}
-        {% has_perm 'agenda.view_featured_submissions' request.user request.event as can_view_featured_submissions %}
-        {% if request.event.landing_page_text %}
-            {{ request.event.landing_page_text|rich_text }}
-        {% endif %}
-        <div class="row mb-4 url-links">
-            {% if has_submissions or request.user.is_anonymous %}
-                {% if not is_html_export %}
-                    <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user_submissions }}">
-                        {% translate "Edit or view your proposals" %}
-                    </a>
-                {% endif %}
+{% with cfp=request.event.cfp %}
+{% has_perm 'agenda.view_featured_submissions' request.user request.event as can_view_featured_submissions %}
+{% if request.event.landing_page_text %}
+{{ request.event.landing_page_text|rich_text }}
+{% endif %}
+<div class="row mb-4 url-links">
+    {% if request.user.is_authenticated %}
+    {% if has_submissions or request.user.is_anonymous %}
+    {% if not is_html_export %}
+    <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user_submissions }}">
+        {% translate "Edit or view your proposals" %}
+    </a>
+    {% endif %}
 
-                {% if not is_html_export %}
-                    <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user }}">
-                        {% translate "View or edit speaker profile" %}
-                    </a>
-                {% endif %}
-
-            {% endif %}
-            {% if request.event.current_schedule and request.event.feature_flags.show_schedule %}
-                <a class="btn btn-success btn-lg btn-block" href="{{ request.event.urls.schedule }}">
-                    {% translate "View conference schedule" %}
-                </a>
-            {% elif can_view_featured_submissions and has_featured %}
-                <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.featured }}">
-                    {% translate "View schedule preview" %}
-                </a>
-            {% endif %}
-            {% if cfp.is_open and not is_html_export %}
-                <a class="btn btn-info btn-lg btn-block" href="{{ request.event.cfp.urls.public }}{{ submit_qs }}">
-                    {% translate "Go to CfP" %}
-                </a>
-            {% endif %}
-        </div>
-    {% endwith %}
+    {% if not is_html_export %}
+    <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user }}">
+        {% translate "View or edit speaker profile" %}
+    </a>
+    {% endif %}
+    {% endif %}
+    {% endif %}
+    {% if request.event.current_schedule and request.event.feature_flags.show_schedule %}
+    <a class="btn btn-success btn-lg btn-block" href="{{ request.event.urls.schedule }}">
+        {% translate "View conference schedule" %}
+    </a>
+    {% elif can_view_featured_submissions and has_featured %}
+    <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.featured }}">
+        {% translate "View schedule preview" %}
+    </a>
+    {% endif %}
+    {% if cfp.is_open and not is_html_export %}
+    <a class="btn btn-info btn-lg btn-block" href="{{ request.event.cfp.urls.public }}{{ submit_qs }}">
+        {% translate "Go to CfP" %}
+    </a>
+    {% endif %}
+</div>
+{% endwith %}
 {% endblock %}


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #54.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->
When visiting the link http://127.0.0.1:8000/, I get to the following page.

![p1](https://github.com/fossasia/eventyay-talk/assets/26376179/b048760b-8110-47a8-aab8-1b944234eee8)

Clicking on the first event, takes me to the page shown below.

http://127.0.0.1:8000/sunburn-festival-2024/
![p2](https://github.com/fossasia/eventyay-talk/assets/26376179/94383845-fa4a-4503-9d71-962bf0d28a21)

As you can see above, I'm visiting the page as an anonymous user (not logged-in). It only displays "Go to CfP" which is the expected outcome.

Now, the same page above when logged in, is shown below.

http://127.0.0.1:8000/sunburn-festival-2024/
![p3](https://github.com/fossasia/eventyay-talk/assets/26376179/06ead668-9208-4cb4-b53e-93e0d6088fd5)

This is what is expected in the issue.

When I click "Go to CfP" as shown above, I get to the following page.

(Logged In)
http://127.0.0.1:8000/sunburn-festival-2024/cfp
![p4](https://github.com/fossasia/eventyay-talk/assets/26376179/bbc16c33-5727-417c-b932-871f1b93882b)

Similarly, clicking on "Go to CfP" when logged out (anonymous), it displays the following page.

(Logged-out or Anonymous user)
![p5](https://github.com/fossasia/eventyay-talk/assets/26376179/f07f8c16-c7ae-471d-adf8-f46050fa660f)

Hope this solves the issue.