### PR TITLE
Additional proposal questions on the proposal form

### DIFF
--- a/src/pretalx/cfp/flow.py
+++ b/src/pretalx/cfp/flow.py
@@ -19,6 +19,9 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import TemplateResponseMixin
+
+from django_context_decorator import context
+
 from i18nfield.strings import LazyI18nString
 from i18nfield.utils import I18nJSONEncoder
 
@@ -26,6 +29,7 @@ from pretalx.cfp.signals import cfp_steps
 from pretalx.common.exceptions import SendMailException
 from pretalx.common.phrases import phrases
 from pretalx.common.utils import language
+from pretalx.common.views import is_form_bound
 from pretalx.person.forms import SpeakerProfileForm, UserForm
 from pretalx.person.models import User
 from pretalx.submission.forms import InfoForm, QuestionsForm
@@ -407,29 +411,7 @@ class QuestionsStep(GenericFlowStep, FormFlowStep):
         )
 
     def is_applicable(self, request):
-        self.request = request
-        info_data = self.cfp_session.get("data", {}).get("info", {})
-        track = info_data.get("track")
-        if track:
-            questions = self.event.questions.exclude(
-                Q(target=QuestionTarget.SUBMISSION)
-                & (
-                    (~Q(tracks__in=[info_data.get("track")]) & Q(tracks__isnull=False))
-                    | (
-                        ~Q(submission_types__in=[info_data.get("submission_type")])
-                        & Q(submission_types__isnull=False)
-                    )
-                )
-            )
-        else:
-            questions = self.event.questions.exclude(
-                Q(target=QuestionTarget.SUBMISSION)
-                & (
-                    ~Q(submission_types__in=[info_data.get("submission_type")])
-                    & Q(submission_types__isnull=False)
-                )
-            )
-        return questions.exists()
+        return False
 
     def get_form_kwargs(self):
         result = super().get_form_kwargs()
@@ -536,6 +518,18 @@ class ProfileStep(GenericFlowStep, FormFlowStep):
         if email:
             result["gravatar_parameter"] = User(email=email).gravatar_parameter
         return result
+
+    @context
+    @cached_property
+    def questions_form(self):
+        bind = is_form_bound(self.request, "questions")
+        return QuestionsForm(
+            data=self.request.POST if bind else None,
+            files=self.request.FILES if bind else None,
+            speaker=self.request.user,
+            event=self.request.event,
+            target="speaker",
+        )
 
     def done(self, request, draft=False):
         form = self.get_form(from_storage=True)

--- a/src/pretalx/cfp/templates/cfp/event/submission_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_profile.html
@@ -24,6 +24,7 @@
 
     {% bootstrap_field form.name layout='event' %}
     {% if form.biography %}{% bootstrap_field form.biography layout='event' %}{% endif %}
+    {% if questions_form %}{% bootstrap_form questions_form layout='event' %}{% endif %}
     {% if form.availabilities %}
         {% compress js %}
             <script defer src="{% static "vendored/moment-with-locales.js" %}"></script>


### PR DESCRIPTION
Fixes: #13

this is still work in progress for testing only.

proposal questions are now shown at the bottom of the proposal form.

speaker/profile question are shown in the profile form above the availability question (because the availability is such a huge box that i felt a one line question below it might be skipped)

the question form has been disabled (but no code removed), which breaks several tests in tests/cfp/views/test_cfp_wizard.py

two different methods have been used to import the questions into the forms. this is intentional. while the second method (used on the profile form) is simpler, it may not allow reordering questions later. so i want to try both to see which one will be better later.