### PR TITLE
Fix URL in href attribute.

### DIFF
--- a/src/pretalx/orga/templates/orga/cfp/access_code_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/access_code_view.html
@@ -55,10 +55,10 @@
                                 {{ code.redeemed|default:0 }} / {{ code.maximum_uses|default:'∞' }}
                             </td>
                             <td class="action-column">
-                                <div data-destination="{{ code.urls.cfp_url.full }}"
+                                <div data-destination="{{ code.urls.cfp_url }}"
                                      title="{% translate 'Copy access code link' %}"
                                      class="btn btn-sm btn-info copyable-text">
-                                    <i class="fa fa-link"></i>
+                                    <i class="fa fa-copy"></i>
                                 </div>
                                 <a href="{{ code.urls.send }}"
                                    title="{% translate 'Send access code as email' %}"

--- a/src/pretalx/orga/templates/orga/cfp/submission_type_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/submission_type_view.html
@@ -52,7 +52,7 @@
                                     Make default
                                 </a>
                             {% endif %}
-                            <a href="{{ type.urls.prefilled_cfp.full }}"
+                            <a href="{{ type.urls.prefilled_cfp }}"
                                title="{% translate 'Go to pre-filled CfP form' %}"
                                class="btn btn-sm btn-info">
                                 <i class="fa fa-link"></i>

--- a/src/pretalx/orga/templates/orga/cfp/track_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/track_view.html
@@ -44,7 +44,7 @@
                             </a>
                         </td>
                         <td class="action-column">
-                            <a href="{{ track.urls.prefilled_cfp.full }}"
+                            <a href="{{ track.urls.prefilled_cfp }}"
                                title="{% translate 'Go to pre-filled CfP form' %}"
                                class="btn btn-sm btn-info">
                                 <i class="fa fa-link"></i>


### PR DESCRIPTION
![Screenshot from 2024-03-21 16-26-23](https://github.com/fossasia/eventyay-talk/assets/110410015/55ea2675-88d3-46bd-a767-2e0d5cfb687e)
![Screenshot from 2024-03-21 16-26-43](https://github.com/fossasia/eventyay-talk/assets/110410015/b7d75e76-84b5-45fb-a31a-3c49498f27c1)
In session type,access code and track page the buttons was heading to localhost and the connection was refused, 

![Screenshot from 2024-03-21 20-29-56](https://github.com/fossasia/eventyay-talk/assets/110410015/ccff6218-fbb7-45c5-ab5f-c0e6eaeceaff)
Also the copy button's icon was wrong in the access_code page.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.

