### PR TITLE
work around missing min and max length fields caused by changing

### DIFF
--- a/src/pretalx/orga/forms/cfp.py
+++ b/src/pretalx/orga/forms/cfp.py
@@ -75,14 +75,14 @@ class CfPSettingsForm(
             self.fields[field_name] = forms.IntegerField(
                 required=False,
                 min_value=0,
-                initial=obj.cfp.fields[attribute].get("min_length"),
+                initial=obj.cfp.fields.get(attribute,{"min_length":None}).get("min_length"),
             )
             self.fields[field_name].widget.attrs["placeholder"] = ""
             field_name = f"cfp_{attribute}_max_length"
             self.fields[field_name] = forms.IntegerField(
                 required=False,
                 min_value=0,
-                initial=obj.cfp.fields[attribute].get("max_length"),
+                initial=obj.cfp.fields.get(attribute,{"max_length":None}).get("max_length"),
             )
             self.fields[field_name].widget.attrs["placeholder"] = ""
         for attribute in self.request_require_fields:


### PR DESCRIPTION
caused by changing avatar_source and avatar_license from varchar to text. once deployed the data can be fixed and this workaround can be removed