### PR TITLE
Added Github Actions for testing PRs for Docker Builds

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,0 +1,17 @@
+name: Docker PR Build
+
+on:
+  pull_request:
+    branches: [development, main]
+
+jobs:
+  build_docker_image:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build Docker image
+        run: docker build -t eventyay-talk:${{ github.sha }} .


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow (docker-pr.yml) to automate the building of Docker images for the eventyay-talk project. The workflow is triggered whenever a pull request is opened or updated targeting the development or main branches. 

- Tries to solve issue #99 

### Changes Made
- Added a new workflow file `docker-pr.yml` in the `.github/workflows` directory.
- Ensured that the workflow only runs for pull requests targeting the development or main branches.
- Tested the workflow locally to ensure proper functionality.

### ScreenShot

>This is a screenshot of example test that was tested with my local fork of eventyay-talk

#### Success message of the test while trying to create a PR in-between to local branches aimed at development branch

<img width="1470" alt="Screenshot 2024-05-24 at 11 04 06" src="https://github.com/fossasia/eventyay-talk/assets/75414859/91de3a02-5eb7-4d92-ae7a-3d24d5db347f">
