### PR TITLE
Add co-speaker feature broken

### DIFF
--- a/src/pretalx/cfp/views/user.py
+++ b/src/pretalx/cfp/views/user.py
@@ -38,6 +38,8 @@ from pretalx.submission.forms import InfoForm, QuestionsForm, ResourceForm
 from pretalx.submission.models import Resource, Submission, SubmissionStates
 
 
+logger = logging.getLogger(__name__)
+
 @method_decorator(csp_update(IMG_SRC="https://www.gravatar.com"), name="dispatch")
 class ProfileView(LoggedInEventPageMixin, TemplateView):
     template_name = "cfp/event/user_profile.html"
@@ -404,7 +406,7 @@ class SubmissionsEditView(LoggedInEventPageMixin, SubmissionViewMixin, UpdateVie
                         form.instance.send_invite(to=[form.cleaned_data.get('additional_speaker')],
                                                _from=self.request.user)
                     except SendMailException as exception:
-                        logging.getLogger("").warning(str(exception))
+                        logger.warning('Failed to send email with error: %s', exception)
                         messages.warning(self.request,
                                          phrases.cfp.submission_email_fail)
                 form.instance.log_action(

--- a/src/pretalx/sso_provider/providers.py
+++ b/src/pretalx/sso_provider/providers.py
@@ -1,4 +1,5 @@
 import requests
+from urllib.parse import urlencode
 
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 from allauth.socialaccount.providers.base import AuthAction, ProviderAccount
@@ -8,7 +9,6 @@ from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.helpers import render_authentication_error
 from django.conf import settings
 from django.urls import reverse
-from urllib.parse import urlencode
 
 from .views import EventyayTicketOAuth2Adapter
 

--- a/src/pretalx/sso_provider/providers.py
+++ b/src/pretalx/sso_provider/providers.py
@@ -8,6 +8,7 @@ from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.helpers import render_authentication_error
 from django.conf import settings
 from django.urls import reverse
+from urllib.parse import urlencode
 
 from .views import EventyayTicketOAuth2Adapter
 


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #129 . It does so by:
- In Proposal edit, if 'Additional Speaker' is filled, invitation will be send.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new feature that sends an invitation email to an additional speaker when specified in the proposal edit form. It includes error handling for email sending failures.

- **New Features**:
    - Added functionality to send an invitation email when an 'Additional Speaker' is specified in the proposal edit form.

<!-- Generated by sourcery-ai[bot]: end summary -->