### PR TITLE
add-video-link

### DIFF
--- a/src/pretalx/agenda/templates/agenda/header_row.html
+++ b/src/pretalx/agenda/templates/agenda/header_row.html
@@ -18,6 +18,11 @@
                 <i class="fa fa-group"></i> {% translate "Tickets" %}
             </a>
         {% endif %}
+        {% if request.event.display_settings.video_link %}
+        <a href="{{ request.event.display_settings.video_link }}" target="_blank" class="btn btn-outline-success">
+            <i class="fas fa-video"></i> {% translate "Videos" %}
+        </a>
+        {% endif %}
     </div>
     <div class="header-right">
         {% if with_extra %}

--- a/src/pretalx/orga/forms/event.py
+++ b/src/pretalx/orga/forms/event.py
@@ -120,6 +120,16 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
         }),
         required=False,
     )
+    video_link = forms.URLField(
+        label=_("Online Video URL"),
+        help_text=(
+            "Online video link will be shown on event menu."
+        ),
+        widget=forms.TextInput(attrs={
+            'placeholder': ' e.g: https://www.youtube.com/'
+        }),
+        required=False,
+    )
     header_pattern = forms.ChoiceField(
         label=_("Frontpage header pattern"),
         help_text=_(
@@ -368,6 +378,7 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
             "export_html_on_release": "feature_flags",
             "html_export_url": "display_settings",
             "ticket_link": "display_settings",
+            "video_link": "display_settings",
             "header_pattern": "display_settings",
             "meta_noindex": "display_settings",
         }

--- a/src/pretalx/orga/templates/orga/settings/form.html
+++ b/src/pretalx/orga/templates/orga/settings/form.html
@@ -50,6 +50,7 @@
                 {% bootstrap_field form.html_export_url layout='event' %}
                 {% bootstrap_field form.meta_noindex layout='event' %}
                 {% bootstrap_field form.ticket_link layout='event' %}
+                {% bootstrap_field form.video_link layout='event' %}
 
             </fieldset>
             <fieldset>


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #133 . It does so by providing an URL in the events general settings 

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ x] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new feature allowing users to add an online video URL to the event settings. The event header will display a 'Videos' button linking to this URL if provided. Tests have been added to ensure the new functionality works as expected.

- **New Features**:
    - Added a new 'video_link' field to the event settings form, allowing users to specify an online video URL.
- **Enhancements**:
    - Updated the event header template to display a 'Videos' button if a video link is provided in the event settings.
- **Tests**:
    - Included tests to cover the new 'video_link' field functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->