### PR TITLE
fix-141: Show "do not record" icon on schedule calendar view

### DIFF
--- a/src/pretalx/agenda/templates/agenda/talk.html
+++ b/src/pretalx/agenda/templates/agenda/talk.html
@@ -68,10 +68,12 @@
                     </div>
                 {% endif %}
                 {% if submission.do_not_record %}
-                    <span class="fa-stack">
-                        <i class="fa fa-video-camera fa-stack-1x"></i>
-                        <i class="fa fa-ban do-not-record fa-stack-2x" aria-hidden="true" alt="{{ phrases.agenda.schedule_do_not_record }}"></i>
-                    </span>
+                    <div>
+                        <span class="fa-stack fa-2x">
+                            <i class="fa fa-video-camera fa-stack-1x"></i>
+                            <i class="fa fa-ban fa-stack-2x"></i>
+                        </span>
+                    </div>
                     <em>{{ phrases.agenda.schedule.do_not_record }}</em>
                 {% endif %}
             </small>

--- a/src/pretalx/agenda/templates/agenda/talk.html
+++ b/src/pretalx/agenda/templates/agenda/talk.html
@@ -70,8 +70,8 @@
                 {% if submission.do_not_record %}
                     <div>
                         <span class="fa-stack fa-2x">
-                            <i class="fa fa-video-camera fa-stack-1x"></i>
-                            <i class="fa fa-ban fa-stack-2x"></i>
+                            <i class="fa fa-video-camera fa-stack-1x" aria-hidden="true"></i>
+                            <i class="fa fa-ban fa-stack-2x" aria-hidden="true"></i>
                         </span>
                     </div>
                     <em>{{ phrases.agenda.schedule.do_not_record }}</em>


### PR DESCRIPTION
This PR closes/references issue #141 . It does so by changing the fav icon css class to correct one

## How has this been tested?
![fix-141-2](https://github.com/user-attachments/assets/799009dc-00b9-4375-b4b1-c810f4390323)
![fix-141-1](https://github.com/user-attachments/assets/95ea51b7-dfc0-46c5-a87f-47ca29e77fcf)

## Checklist

- [x] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes issue #141 by updating the CSS class for the 'do not record' icon in the schedule calendar view to ensure it displays correctly.

- **Bug Fixes**:
    - Corrected the CSS class for the 'do not record' icon in the schedule calendar view.

<!-- Generated by sourcery-ai[bot]: end summary -->