### PR TITLE
Redirect User to schedule page after logged in with SSO

### DIFF
--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -33,7 +33,7 @@
           {% if eventyay_exists %}
             {% if not no_buttons %}
               <div class="text-center">
-                  <a class="btn btn-lg btn-primary btn-block mt-3" href="{% provider_login_url request.event.organiser.slug %}">
+                  <a class="btn btn-lg btn-primary btn-block mt-3" href="{% provider_login_url request.event.organiser.slug %}?next=/{{ request.event.slug }}/schedule/">
                       {% translate "Login with Eventyay-ticket" %}
                   </a>
               </div>


### PR DESCRIPTION
Instead of home page and facing cors policy issue with extra nginx config, after User logged in with SSO, redirect them to current schedule page.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the login flow to redirect users to the schedule page after logging in with SSO, addressing potential CORS policy issues with the home page.

- **Enhancements**:
    - Redirect users to the schedule page after logging in with SSO instead of the home page.

<!-- Generated by sourcery-ai[bot]: end summary -->