### PR TITLE
Using same user_code for talk and ticket

### DIFF
--- a/src/pretalx/sso_provider/views.py
+++ b/src/pretalx/sso_provider/views.py
@@ -83,6 +83,7 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
 
     def save_user(self, request, sociallogin, form=None):
         try:
+            sociallogin.user.code = sociallogin.account.extra_data.get('sub')
             user = super().save_user(request, sociallogin, form)
         except IntegrityError as e:
             # bypass the error if the user with this email created in eventyay-talk


### PR DESCRIPTION
When using SSO for log in with eventyay-ticket, if new user, create it with the same code which will be using for favorite schedule and link to video platform