### PR TITLE
Add plugin to import events to auto-deployment 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
   "jwt~=1.3.1",
   'pretalx_pages @ git+https://github.com/fossasia/eventyay-talk-pages.git@main',
   'pretalx_venueless @ git+https://github.com/fossasia/eventyay-talk-video.git@main',
+  'pretalx-downstream @ git+https://github.com/fossasia/eventyay-talk-downstream.git@main',
   "django-allauth~=0.63.3",
   "PyJWT~=2.8.0",
 ]


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue add plugin to import events to auto-deployment:
plugin to be installed: [eventyay-talk-downstream](https://github.com/fossasia/eventyay-talk-downstream)

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
