### PR TITLE
Provide export of personal schedule

### DIFF
--- a/src/pretalx/agenda/templates/agenda/header_row.html
+++ b/src/pretalx/agenda/templates/agenda/header_row.html
@@ -45,6 +45,25 @@
                             {% endif %}
                         </a></li>
                     {% endif %}{% endfor %}
+                    <div class="export-break" style="grid-area: slice-08-07-00-00 / 1 / slice-08-08-00-00;"></div>
+                    {% for exporter in my_exporters %}{% if exporter.public %}
+                        <li><a class="dropdown-item" href="{{ exporter.urls.base }}">
+                            {% if exporter.icon|slice:":3" == "fa-" %}
+                                <span class="fa {{ exporter.icon }} export-icon"></span>
+                            {% else %}
+                                <span class="export-icon">{{ exporter.icon }}</span>
+                            {% endif %}
+                            {{ exporter.verbose_name }}
+                            {% if exporter.show_qrcode %}
+                                <span class="export-qrcode">
+                                    <div class="btn btn-default btn-sm">
+                                        <i class="fa fa-qrcode"></i>
+                                    </div>
+                                    <div class="export-qrcode-image btn btn-default">{{ exporter.get_qrcode }}</div>
+                                </span>
+                            {% endif %}
+                        </a></li>
+                    {% endif %}{% endfor %}
                 </ul>
             </details>
         {% endif %}

--- a/src/pretalx/common/signals.py
+++ b/src/pretalx/common/signals.py
@@ -202,6 +202,8 @@ than expected.
 """
 
 register_data_exporters = EventPluginSignal()
+
+register_my_data_exporters = EventPluginSignal()
 """
 This signal is sent out to get all known data exporters. Receivers should return a
 subclass of pretalx.common.exporter.BaseExporter

--- a/src/pretalx/schedule/signals.py
+++ b/src/pretalx/schedule/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import receiver
 
-from pretalx.common.signals import EventPluginSignal, register_data_exporters
+from pretalx.common.signals import EventPluginSignal, register_data_exporters, register_my_data_exporters
 
 schedule_release = EventPluginSignal()
 """
@@ -22,11 +22,25 @@ def register_ical_exporter(sender, **kwargs):
     return ICalExporter
 
 
+@receiver(register_my_data_exporters, dispatch_uid="exporter_builtin_my_ical")
+def register_my_ical_exporter(sender, **kwargs):
+    from .exporters import MyICalExporter
+
+    return MyICalExporter
+
+
 @receiver(register_data_exporters, dispatch_uid="exporter_builtin_xml")
 def register_xml_exporter(sender, **kwargs):
     from .exporters import FrabXmlExporter
 
     return FrabXmlExporter
+
+
+@receiver(register_my_data_exporters, dispatch_uid="exporter_builtin_my_xml")
+def register_my_xml_exporter(sender, **kwargs):
+    from .exporters import MyFrabXmlExporter
+
+    return MyFrabXmlExporter
 
 
 @receiver(register_data_exporters, dispatch_uid="exporter_builtin_xcal")
@@ -36,8 +50,23 @@ def register_xcal_exporter(sender, **kwargs):
     return FrabXCalExporter
 
 
+@receiver(register_my_data_exporters, dispatch_uid="exporter_builtin_my_xcal")
+def register_my_xcal_exporter(sender, **kwargs):
+    from .exporters import MyFrabXCalExporter
+
+    return MyFrabXCalExporter
+
+
 @receiver(register_data_exporters, dispatch_uid="exporter_builtin_json")
 def register_json_exporter(sender, **kwargs):
     from .exporters import FrabJsonExporter
 
     return FrabJsonExporter
+
+
+@receiver(register_my_data_exporters, dispatch_uid="exporter_builtin_my_json")
+def register_my_json_exporter(sender, **kwargs):
+    from .exporters import MyFrabJsonExporter
+
+    return MyFrabJsonExporter
+

--- a/src/pretalx/static/common/scss/_pretalx.scss
+++ b/src/pretalx/static/common/scss/_pretalx.scss
@@ -108,6 +108,10 @@ table td.numeric-left {
   position: absolute;
   background: white;
 }
+.export-break {
+  height: 1px;
+  background: #B0B0B0;
+}
 .export-qrcode:hover .export-qrcode-image,
 .qrcode:hover .qrcode-image {
   display: block;


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #162 . It does so by:
- Add 4 options in drop down for user's favorite session.

![image](https://github.com/user-attachments/assets/d53e3190-4c31-48fb-a802-358d0ccadb06)

- Require user to login in order to use this feature, if User not logged in, redirect to login page.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add personal schedule export functionality with support for XML, XCal, JSON, and iCal formats. Require user login to access these features and filter exported events based on user favorites.

New Features:
- Introduce new export options for personal schedules, including XML, XCal, JSON, and iCal formats.
- Add a requirement for users to log in to access personal schedule export features.

Enhancements:
- Update the schedule export functionality to filter events based on user favorites.

<!-- Generated by sourcery-ai[bot]: end summary -->