### PR TITLE
stay on same browser when click ticket in menu

### DIFF
--- a/src/pretalx/agenda/templates/agenda/header_row.html
+++ b/src/pretalx/agenda/templates/agenda/header_row.html
@@ -14,7 +14,7 @@
             <i class="fa fa-group"></i> {% translate "Speakers" %}
         </a>
         {% if request.event.display_settings.ticket_link %}
-            <a href="{{ request.event.display_settings.ticket_link }}" target="_blank" class="btn btn-outline-success">
+            <a href="{{ request.event.display_settings.ticket_link }}" class="btn btn-outline-success">
                 <i class="fa fa-group"></i> {% translate "Tickets" %}
             </a>
         {% endif %}


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue to stay same browser when click menu. It does so by remove target blank

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the ticket link in the menu to open in the same browser tab instead of a new one by removing the target='_blank' attribute.

Bug Fixes:
- Ensure ticket link in the menu opens in the same browser tab by removing the target='_blank' attribute.

<!-- Generated by sourcery-ai[bot]: end summary -->