### PR TITLE
Fix issue plugins not show when enabled

### DIFF
--- a/src/pretalx/orga/context_processors.py
+++ b/src/pretalx/orga/context_processors.py
@@ -27,7 +27,7 @@ def orga_events(request):
     context["site_config"] = site_config
     context["base_path"] = settings.BASE_PATH
 
-    if not request.path.startswith("/orga/"):
+    if not request.path_info.startswith("/orga/"):
         return {}
 
     if not getattr(request, "user", None) or not request.user.is_authenticated:


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue with plugin not showing in setting when enabled, rootcause is it using path to check instead of path_info

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue with plugins not showing in settings when enabled by correcting the request path check to use 'path_info'.

Bug Fixes:
- Fix the issue where plugins were not displayed in settings when enabled by using 'path_info' instead of 'path' to check the request path.

<!-- Generated by sourcery-ai[bot]: end summary -->