### PR TITLE
Fix issue schedule on organiser interface loading eternally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
     echo 'pretalxuser ALL=(ALL) NOPASSWD: /usr/bin/supervisord' >> /etc/sudoers
 
 ENV LC_ALL=C.UTF-8
+ENV BASE_PATH=/talk
 
 COPY pyproject.toml /pretalx
 COPY src /pretalx/src

--- a/src/pretalx/frontend/schedule-editor/src/api.js
+++ b/src/pretalx/frontend/schedule-editor/src/api.js
@@ -1,5 +1,6 @@
+const basePath = process.env.BASE_PATH || '/talk';
 const api = {
-	eventSlug: window.location.pathname.split("/")[3],
+	eventSlug: basePath ? window.location.pathname.split("/")[4] : window.location.pathname.split("/")[3],
 	http (verb, url, body) {
 		var fullHeaders = {}
 		fullHeaders['Content-Type'] = 'application/json'
@@ -42,7 +43,7 @@ const api = {
 	},
 	fetchTalks (options) {
 		options = options || {}
-		let url = `/orga/event/${api.eventSlug}/schedule/api/talks/`
+		let url = `${basePath}/orga/event/${api.eventSlug}/schedule/api/talks/`
 		if (window.location.search) {
 			url += window.location.search + '&'
 		} else {
@@ -57,15 +58,15 @@ const api = {
 		return api.http('GET', url, null)
 	},
 	fetchAvailabilities () {
-		const url = `/orga/event/${api.eventSlug}/schedule/api/availabilities/`
+		const url = `${basePath}/orga/event/${api.eventSlug}/schedule/api/availabilities/`
 		return api.http('GET', url, null)
 	},
 	fetchWarnings () {
-		const url = `/orga/event/${api.eventSlug}/schedule/api/warnings/`
+		const url = `${basePath}/orga/event/${api.eventSlug}/schedule/api/warnings/`
 		return api.http('GET', url, null)
 	},
 	fetchRooms () {
-		return api.getList(`/api/events/${api.eventSlug}/rooms`)
+		return api.getList(`${basePath}/api/events/${api.eventSlug}/rooms`)
 	},
 	saveTalk (talk, {action = 'PATCH'} = {}) {
 		// Only call from App.saveTalk, which knows which data to update


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #202 . It does so by add the base path for API call

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Resolve the eternal loading issue in the organiser interface by incorporating a base path for API requests, ensuring correct URL formation for fetching data.

Bug Fixes:
- Fix the issue of the schedule on the organiser interface loading indefinitely by adding a base path for API calls.

<!-- Generated by sourcery-ai[bot]: end summary -->