### PR TITLE
Modify the return value of session_type

### DIFF
--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -676,12 +676,8 @@ class Schedule(PretalxModel):
                         ),
                         "do_not_record": talk.submission.do_not_record,
                         "tags": talk.submission.get_tag(),
-                        "session_type": (
-                            str(talk.submission.submission_type.name)
-                            + " ("
-                            + str(talk.submission.submission_type.default_duration)
-                            + " minutes)"
-                        ),
+                        "session_type":
+                            talk.submission.submission_type.name
                     }
                 )
             else:


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR support filter by user language in video component make by this PR: https://github.com/fossasia/eventyay-video/pull/239
return object with multiple language instead of string value.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the 'session_type' return value in the schedule model to return only the submission type name, simplifying the data structure.

Enhancements:
- Modify the return value of 'session_type' to return the name of the submission type instead of a string with the name and duration.

<!-- Generated by sourcery-ai[bot]: end summary -->