### PR TITLE
Fix issue 404 redirect after login as attendee with tickets

### DIFF
--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -23,7 +23,7 @@
             {% if eventyay_exists %}
                 {% if not no_buttons %}
                 <div class="text-center">
-                    <a class="btn btn-lg btn-primary btn-block mt-3" href="{% provider_login_url request.event.organiser.slug %}?next=/{{ request.event.slug }}/schedule/">
+                    <a class="btn btn-lg btn-primary btn-block mt-3" href="{% provider_login_url request.event.organiser.slug %}?next={{ request.path }}">
                         {% translate "Login as Attendee with Eventyay-Ticket" %}
                     </a>
                 </div>


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fix issue  404 redirect after login as attendee with tickets by get current path.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the 404 redirect issue for attendees logging in with tickets by ensuring the redirect URL uses the current path.

Bug Fixes:
- Fix the 404 redirect issue after logging in as an attendee with tickets by updating the redirect URL to use the current path.

<!-- Generated by sourcery-ai[bot]: end summary -->