### PR TITLE
Color of menu buttons should adhere to Main Event Color

### DIFF
--- a/src/pretalx/static/agenda/scss/_agenda.scss
+++ b/src/pretalx/static/agenda/scss/_agenda.scss
@@ -44,11 +44,8 @@ header {
 }
 
 @function is-dark($color) {
-  $r: red($color);
-  $g: green($color);
-  $b: blue($color);
-  $brightness: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
-  @return $brightness < 128;
+  $luminance: (0.2126 * red($color) + 0.7152 * green($color) + 0.0722 * blue($color)) / 255;
+  @return $luminance < 0.5;
 }
 
 @mixin contrast-color($bg-color) {
@@ -56,6 +53,20 @@ header {
     color: #fff;
   } @else {
     color: #000;
+  }
+}
+
+@mixin active-state($color) {
+    background-color: $color;
+    @include contrast-color($color);
+}
+
+@mixin outline-button($color) {
+  color: $color;
+  border-color: $color;
+
+  &:hover, &.active {
+    @include active-state($color);
   }
 }
 
@@ -75,17 +86,11 @@ header {
     }
 
     .btn-outline-success {
-      color: $brand-primary;
-      border-color: $brand-primary;
+      @include outline-button($brand-primary);
+    }
 
-      &:hover {
-        background-color: $brand-primary;
-        @include contrast-color($brand-primary);
-      }
-        &.active {
-        background-color: $brand-primary;
-        @include contrast-color($brand-primary);
-      }
+    .btn-outline-info {
+      @include outline-button($brand-primary);
     }
 
   form {

--- a/src/pretalx/static/agenda/scss/_agenda.scss
+++ b/src/pretalx/static/agenda/scss/_agenda.scss
@@ -43,20 +43,50 @@ header {
   }
 }
 
-#schedule-nav {
-  display: flex;
-  flex-direction: row;
-  align-content: space-between;
-  z-index: 900;
+@function is-dark($color) {
+  $r: red($color);
+  $g: green($color);
+  $b: blue($color);
+  $brightness: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  @return $brightness < 128;
+}
 
-  a {
-    font-size: 16px;
-    font-weight: normal;
-    border-radius: 0;
-    margin: 0;
-    &.active {
-    }
+@mixin contrast-color($bg-color) {
+  @if is-dark($bg-color) {
+    color: #fff;
+  } @else {
+    color: #000;
   }
+}
+
+#schedule-nav {
+    display: flex;
+    flex-direction: row;
+    align-content: space-between;
+    z-index: 900;
+
+    a {
+        font-size: 16px;
+        font-weight: normal;
+        border-radius: 0;
+        margin: 0;
+        &.active {
+        }
+    }
+
+    .btn-outline-success {
+      color: $brand-primary;
+      border-color: $brand-primary;
+
+      &:hover {
+        background-color: $brand-primary;
+        @include contrast-color($brand-primary);
+      }
+        &.active {
+        background-color: $brand-primary;
+        @include contrast-color($brand-primary);
+      }
+    }
 
   form {
     max-width: 250px;
@@ -73,6 +103,8 @@ header {
       summary {
         height: 100%;
         margin-bottom: 3px;
+        color: $brand-primary;
+        border-color: $brand-primary;
       }
     }
   }


### PR DESCRIPTION
…color should be available for scroll over

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #206 . It does so by use the main color to set the button color

![image](https://github.com/user-attachments/assets/06b4b8fd-96fa-488c-b474-513fad73a9e4)


## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the menu button colors to adhere to the main event color, enhancing the visual consistency of the interface. Introduce a function and mixin to dynamically adjust text color based on background brightness for improved readability.

Enhancements:
- Implement a function to determine if a color is dark and a mixin to set contrast color for better readability.
- Update the styling of menu buttons to use the main event color, ensuring consistent theming across the interface.

<!-- Generated by sourcery-ai[bot]: end summary -->