### PR TITLE
Auto login with attendee cookie set by tickets component

### DIFF
--- a/src/pretalx/cfp/views/auth.py
+++ b/src/pretalx/cfp/views/auth.py
@@ -31,6 +31,7 @@ class LogoutView(View):
         )
         # Remove the JWT cookie
         response.delete_cookie("sso_token")  # Same domain used when setting the cookie
+        response.delete_cookie("customer_sso_token")
         return response
 
 

--- a/src/pretalx/common/middleware/event.py
+++ b/src/pretalx/common/middleware/event.py
@@ -63,7 +63,9 @@ class EventPermissionMiddleware:
             return
 
         # Check for the presence of the SSO token
-        sso_token = request.COOKIES.get("sso_token")
+        sso_token = request.COOKIES.get("sso_token") or request.COOKIES.get(
+            "customer_sso_token"
+        )
         if sso_token:
             try:
                 # Decode and validate the JWT token
@@ -76,8 +78,8 @@ class EventPermissionMiddleware:
                 user.name = payload.get("name", "")
                 user.is_active = True
                 user.is_staff = payload.get("is_staff", False)
-                user.locale = payload.get("locale", None)
-                user.timezone = payload.get("timezone", None)
+                user.locale = payload.get("locale", user.locale)
+                user.timezone = payload.get("timezone", user.timezone)
                 user.save()
                 login(
                     request, user, backend="django.contrib.auth.backends.ModelBackend"
@@ -89,6 +91,10 @@ class EventPermissionMiddleware:
             except jwt.InvalidTokenError as e:
                 # Invalid token
                 logger.error(f"Invalid SSO token: {str(e)}\n{traceback.format_exc()}")
+                pass
+            except Exception as e:
+                # Invalid token
+                logger.error(f"Unexpected error happened: {str(e)}\n{traceback.format_exc()}")
                 pass
 
     @staticmethod

--- a/src/pretalx/orga/views/auth.py
+++ b/src/pretalx/orga/views/auth.py
@@ -46,6 +46,7 @@ def logout_view(request):
     )
     # Remove the JWT cookie
     response.delete_cookie("sso_token")  # Same domain used when setting the cookie
+    response.delete_cookie("customer_sso_token")
     return response
 
 


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue [#203](https://github.com/fossasia/eventyay-talk/issues/203). It does so by get the customer_sso_token from cookie which set by tickets component for auto login

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
