### PR TITLE
Trigger hide/unhidden schedule to tickets system

### DIFF
--- a/src/pretalx/orga/tasks.py
+++ b/src/pretalx/orga/tasks.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urljoin
 
 import jwt
@@ -15,8 +15,8 @@ def generate_sso_token(user_email):
     jwt_payload = {
         "email": user_email,
         "has_perms": "orga.edit_schedule",
-        "exp": datetime.utcnow() + timedelta(hours=1),
-        "iat": datetime.utcnow(),
+        "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+        "iat": datetime.now(timezone.utc),
     }
     jwt_token = jwt.encode(jwt_payload, settings.SECRET_KEY, algorithm="HS256")
     return jwt_token
@@ -53,8 +53,9 @@ def trigger_public_schedule(
         response.raise_for_status()  # Raise exception for bad status codes
     except requests.RequestException as e:
         logger.error(
-            f"Error occurred when triggering hide/unhide schedule for tickets "
-            f"component. Event: {event_slug}, Organiser: {organiser_slug}. Error: {e}",
+            "Error occurred when triggering hide/unhide schedule for tickets component."
+            "Event: %s, Organiser: %s. Error: %s",
+            event_slug, organiser_slug, e,
         )
         # Retry the task if an exception occurs (with exponential backoff by default)
         try:

--- a/src/pretalx/orga/tasks.py
+++ b/src/pretalx/orga/tasks.py
@@ -1,0 +1,63 @@
+import logging
+from datetime import datetime, timedelta
+from urllib.parse import urljoin
+
+import jwt
+import requests
+from django.conf import settings
+
+from pretalx.celery_app import app
+
+logger = logging.getLogger(__name__)
+
+
+def generate_sso_token(user_email):
+    jwt_payload = {
+        "email": user_email,
+        "has_perms": "orga.edit_schedule",
+        "exp": datetime.utcnow() + timedelta(hours=1),
+        "iat": datetime.utcnow(),
+    }
+    jwt_token = jwt.encode(jwt_payload, settings.SECRET_KEY, algorithm="HS256")
+    return jwt_token
+
+
+def set_header_token(user_email):
+    token = generate_sso_token(user_email)
+    # Define the headers, including the Authorization header with the Bearer token
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    return headers
+
+
+@app.task(
+    bind=True,
+    name="pretalx.orga.trigger_public_schedule",
+    max_retries=3,
+    default_retry_delay=60,
+)
+def trigger_public_schedule(
+    self, is_show_schedule, event_slug, organiser_slug, user_email
+):
+    try:
+        headers = set_header_token(user_email)
+        payload = {"is_show_schedule": is_show_schedule}
+        # Send the POST request with the payload and the headers
+        ticket_uri = urljoin(
+            settings.EVENTYAY_TICKET_BASE_PATH,
+            f"api/v1/{organiser_slug}/{event_slug}/schedule-public/",
+        )
+        response = requests.post(ticket_uri, json=payload, headers=headers)
+        response.raise_for_status()  # Raise exception for bad status codes
+    except requests.RequestException as e:
+        logger.error(
+            "Error happen when trigger hide/unhidden schedule to tickets component: %s",
+            e,
+        )
+        # Retry the task if an exception occurs (with exponential backoff by default)
+        try:
+            self.retry(exc=e)
+        except self.MaxRetriesExceededError:
+            logger.error("Max retries exceeded for sending organizer webhook.")

--- a/src/pretalx/orga/tasks.py
+++ b/src/pretalx/orga/tasks.py
@@ -53,8 +53,8 @@ def trigger_public_schedule(
         response.raise_for_status()  # Raise exception for bad status codes
     except requests.RequestException as e:
         logger.error(
-            "Error happen when trigger hide/unhidden schedule to tickets component: %s",
-            e,
+            f"Error occurred when triggering hide/unhide schedule for tickets "
+            f"component. Event: {event_slug}, Organiser: {organiser_slug}. Error: {e}",
         )
         # Retry the task if an exception occurs (with exponential backoff by default)
         try:

--- a/src/pretalx/orga/views/schedule.py
+++ b/src/pretalx/orga/views/schedule.py
@@ -250,7 +250,7 @@ class ScheduleToggleView(EventPermissionRequired, View):
                 },
                 ignore_result=True,
             )
-        except Exception as e:
+        except Exception:
             # Ignore the error if the task fails
             pass
         return redirect(self.request.event.orga_urls.schedule)

--- a/src/pretalx/orga/views/schedule.py
+++ b/src/pretalx/orga/views/schedule.py
@@ -256,9 +256,10 @@ class ScheduleToggleView(EventPermissionRequired, View):
                 ignore_result=True,
             )
         except (TaskError, ConnectionError) as e:
-            logger.warning(f"Task failed: {e}")
+            logger.warning("Unexpected error when trying to trigger "
+                           "schedule's state to external system: %s", e)
         except Exception as e:
-            logger.error(f"Unexpected error in task: {e}")
+            logger.error("Unexpected error in task: %s", e)
         return redirect(self.request.event.orga_urls.schedule)
 
 


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is part of issue https://github.com/fossasia/eventyay-tickets/issues/353
This PR implement:
1. When schedule is hide/unhidden, will trigger an API call to tickets system. (using jwt token for authorize)

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Trigger an API call to the tickets system when the schedule visibility changes, using a Celery task with JWT authorization and retry logic.

New Features:
- Implement a feature to trigger an API call to the tickets system when the schedule is hidden or unhidden, using a JWT token for authorization.

Enhancements:
- Add a Celery task to handle the API call for triggering the public schedule, with retry logic and error handling.

<!-- Generated by sourcery-ai[bot]: end summary -->