### PR TITLE
Accessing the video link does not direct user with ticket to the video room

### DIFF
--- a/src/pretalx/common/middleware/event.py
+++ b/src/pretalx/common/middleware/event.py
@@ -59,7 +59,10 @@ class EventPermissionMiddleware:
     @staticmethod
     def _handle_login(request):
         # If the user is already authenticated, no need to auto-login
-        if request.user.is_authenticated:
+
+        if request.user.is_authenticated or any(
+            path in request.path for path in ["/callback", "/signup"]
+        ):
             return
 
         # Check for the presence of the SSO token
@@ -80,6 +83,7 @@ class EventPermissionMiddleware:
                 user.is_staff = payload.get("is_staff", False)
                 user.locale = payload.get("locale", user.locale)
                 user.timezone = payload.get("timezone", user.timezone)
+                user.code = payload.get("customer_identifier", user.code)
                 user.save()
                 login(
                     request, user, backend="django.contrib.auth.backends.ModelBackend"


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #220 . It does so by:
root cause is that attendee identifier from talk and ticket not matches when using auto login.
solution: when login using cookie, also consider attendee identifier

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Resolve the issue of users not being directed to the video room when accessing the video link by updating the auto-login process to consider the attendee identifier.

Bug Fixes:
- Fix the issue where accessing the video link does not direct users with a ticket to the video room by ensuring the attendee identifier is considered during auto-login.