### PR TITLE
Fix error on login page

### DIFF
--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load static %}
 {% load socialaccount %}
-{% load socialapp_extras %}
 
 {% include "common/forms/errors.html" %}
 {% if no_form %}


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR resolves issue about login page got internal error due to template tag "socialapp_extras" is not found.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] I have added tests to cover my changes.

## Summary by Sourcery

Bug Fixes:
- Remove the unnecessary template tag 'socialapp_extras' from the login page to fix an internal error.