### PR TITLE
Fix join online video button after customer feature is removed

### DIFF
--- a/src/pretalx/agenda/views/talk.py
+++ b/src/pretalx/agenda/views/talk.py
@@ -296,9 +296,7 @@ class OnlineVideoJoin(EventPermissionRequired, View):
         if not organizer or not event or not base_url:
             return HttpResponse(status=403, content="missing_configuration")
 
-        check_payload = {
-            'user_email': request.user.email
-        }
+        check_payload = {"user_email": request.user.email}
 
         # call to ticket to check if user order ticket yet or not
         response = requests.post(

--- a/src/pretalx/agenda/views/talk.py
+++ b/src/pretalx/agenda/views/talk.py
@@ -15,6 +15,7 @@ from django.views.generic import FormView, TemplateView, View
 from django_context_decorator import context
 
 from pretalx.agenda.signals import register_recording_provider
+from pretalx.agenda.views.utils import encode_email
 from pretalx.cfp.views.event import EventPageMixin
 from pretalx.common.text.phrases import phrases
 from pretalx.common.views.mixins import (
@@ -295,9 +296,13 @@ class OnlineVideoJoin(EventPermissionRequired, View):
         if not organizer or not event or not base_url:
             return HttpResponse(status=403, content="missing_configuration")
 
+        check_payload = {
+            'user_email': request.user.email
+        }
+
         # call to ticket to check if user order ticket yet or not
-        response = requests.get(
-            f"{base_url}/api/v1/{organizer}/{event}/customer/{request.user.code}/ticket-check"
+        response = requests.post(
+            f"{base_url}/api/v1/{organizer}/{event}/ticket-check", json=check_payload
         )
 
         if response.status_code != 200:
@@ -321,7 +326,7 @@ class OnlineVideoJoin(EventPermissionRequired, View):
                 "aud": request.event.venueless_settings.audience,
                 "exp": exp,
                 "iat": iat,
-                "uid": request.user.code,
+                "uid": encode_email(request.user.email),
                 "profile": profile,
                 "traits": list(
                     {

--- a/src/pretalx/agenda/views/utils.py
+++ b/src/pretalx/agenda/views/utils.py
@@ -1,3 +1,6 @@
+import hashlib
+import random
+import string
 from contextlib import suppress
 
 from pretalx.common.signals import register_data_exporters, register_my_data_exporters
@@ -39,3 +42,20 @@ def find_schedule_exporter(request, name, public=False):
         if exporter.identifier == name:
             return exporter
     return None
+
+
+def encode_email(email):
+    """
+    Encode email to a short hash and get first 7 characters
+    @param email: User's email
+    @return: encoded string
+    """
+    hash_object = hashlib.sha256(email.encode())
+    hash_hex = hash_object.hexdigest()
+    short_hash = hash_hex[:7]
+    characters = string.ascii_letters + string.digits
+    random_suffix = "".join(
+        random.choice(characters) for _ in range(7 - len(short_hash))
+    )
+    final_result = short_hash + random_suffix
+    return final_result.upper()

--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load static %}
 {% load socialaccount %}
-{% load socialapp_extras %}
 
 {% include "common/forms/errors.html" %}
 {% if no_form %}


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fix issue join online video not work after removed customer feature in eventyay-tickets

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Fix the 'Join Online Video' button functionality by updating the API request method and payload after the removal of the customer feature. Enhance the system by adding a utility function to encode user emails into a short hash for improved API interactions.

Bug Fixes:
- Fix the issue with the 'Join Online Video' button not working after the removal of the customer feature by updating the API endpoint and payload.

Enhancements:
- Introduce a new utility function to encode user emails into a short hash for use in API requests.