### PR TITLE
Change default color and some messages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,5 +92,5 @@ jobs:
           filename: covbadge.json
           label: coverage
           message: ${{ env.TOTAL_COV }}%
-          color: "#3aa57c"
+          color: "#2185d0"
         if: env.TOTAL_COV && github.ref == 'refs/heads/development'

--- a/doc/_themes/pretalx_theme/static/css/pretalx.css
+++ b/doc/_themes/pretalx_theme/static/css/pretalx.css
@@ -135,7 +135,7 @@ main {
 
 header {
     height: 70px;
-    background-color: #3aa57c;
+    background-color: #2185d0;
     width: 100%;
     position: fixed;
     z-index: 100;
@@ -194,8 +194,8 @@ header #related .dropdown .dropdown-body .dropdown-item a {
     color: #2c3e50;
 }
 header #related .dropdown .dropdown-body .dropdown-item a:hover {
-    color: #3aa57c;
-    border-bottom: 2px solid #3aa57c;
+    color: #2185d0;
+    border-bottom: 2px solid #2185d0;
 }
 header #related .dropdown .dropdown-title {
     color: white;
@@ -286,7 +286,7 @@ footer a.fa {
 }
 
 a, a:hover {
-    color: #3aa57c;
+    color: #2185d0;
     font-weight: bold;
     text-decoration: none;
     cursor: pointer
@@ -453,11 +453,11 @@ legend {
     background: #4697c9
 }
 .hint, .important, .tip {
-    border: 1px solid #3aa57c;
+    border: 1px solid #2185d0;
     background: white;
 }
 .hint .admonition-title, .important .admonition-title, .tip .admonition-title {
-    background: #3aa57c
+    background: #2185d0
 }
 .note p:last-child, .attention p:last-child, .caution p:last-child, .danger p:last-child, .error p:last-child, .hint p:last-child, .important p:last-child, .tip p:last-child, .warning p:last-child, .seealso p:last-child, .admonition-todo p:last-child {
     margin-bottom: 0
@@ -749,7 +749,7 @@ div[class^='highlight'] pre {
     color: #7f8c8d;
 }
 #toctree a:hover {
-    border-bottom: 2px #3aa57c solid;
+    border-bottom: 2px #2185d0 solid;
 }
 #toctree .toctree-l1 > a {
     color: #2c3e50;
@@ -765,11 +765,11 @@ div[class^='highlight'] pre {
     padding-left: 1.5em;
 }
 #toctree .toctree-l2.current > a, #toctree .toctree-l3.current > a, #toctree .toctree-l4.current > a {
-    color: #3aa57c;
+    color: #2185d0;
     font-weight: bold;
 }
 #toctree .toctree-l2.current a, #toctree .toctree-l3.current a, #toctree .toctree-l4.current a {
-    color: #3aa57c;
+    color: #2185d0;
 }
 #toctree code {
     border: none;
@@ -980,7 +980,7 @@ dl:not(.docutils) .property {
 }
 .sectionbox .fa {
   font-size: 48px;
-  color: #3aa57c;
+  color: #2185d0;
   margin-right: 8px;
 }
 .sectionbox .content {
@@ -990,7 +990,7 @@ dl:not(.docutils) .property {
   margin-top: 10px;
 }
 .sectionbox .heading {
-    color: #3aa57c;
+    color: #2185d0;
     font-size: 20px;
 }
 .sectionbox .text p {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,11 +103,11 @@ build-backend = "setuptools.build_meta"
 requires = ["setuptools", "wheel"]
 
 [project.urls]
-Homepage = "https://pretalx.com"
-Documentation = "https://docs.pretalx.org"
-Repository = "https://github.com/pretalx/pretalx"
-Changelog = "https://docs.pretalx.org/changelog/"
-Issues = "https://github.com/pretalx/pretalx/issues"
+Homepage = "https://eventyay.com"
+Documentation = "https://docs.eventyay.org"
+Repository = "https://github.com/fossasia/eventyay-talk"
+Changelog = "https://docs.eventyay.org/changelog/"
+Issues = "https://github.com/fossasia/eventyay-talk/issues"
 
 [tool.setuptools]
 include-package-data = true

--- a/src/pretalx/api/templates/rest_framework/api.html
+++ b/src/pretalx/api/templates/rest_framework/api.html
@@ -14,8 +14,8 @@
 {% endblock bootstrap_theme %}
 
 {% block branding %}
-    <a class="navbar-brand" rel="nofollow" href="https://docs.pretalx.org/en/latest/api/index.html">
-        <img loading="lazy" src="{% static "common/img/icons/icon.svg" %}" alt="{% translate "The pretalx logo" %}">
-        <span>pretalx API</span>
+    <a class="navbar-brand" rel="nofollow" href="#">
+        <img loading="lazy" src="{% static "common/img/icons/icon.svg" %}" alt="{% translate "The eventyay logo" %}">
+        <span>eventyay API</span>
     </a>
 {% endblock branding %}

--- a/src/pretalx/common/management/commands/create_test_event.py
+++ b/src/pretalx/common/management/commands/create_test_event.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
         self.catch_phrase = self.fake.catch_phrase()
         intro = f"We provide a {self.catch_phrase.lower()} to {self.bs}."
         disclaimer = """This is an automatically generated event to test and showcase pretalx features.
-Feel free to look around, but don\'t be alarmed if something doesn\'t quite make sense. You can always create your own free test event at [pretalx.com](https://pretalx.com)!"""
+Feel free to look around, but don\'t be alarmed if something doesn\'t quite make sense. You can always create your own free test event at [eventyay.com](https://eventyay.com)!"""
         with scopes_disabled():
             event = Event.objects.create(
                 name="DemoCon",

--- a/src/pretalx/common/models/settings.py
+++ b/src/pretalx/common/models/settings.py
@@ -94,8 +94,8 @@ These links may be helpful in the coming days and weeks:
 - Your schedule editor: {event_schedule}
 
 If there is anything you’re missing, come tell us about it
-at https://github.com/pretalx/pretalx/issues/new or via an
-email to support@pretalx.com!
+at https://github.com/fossasia/eventyay-talk/issues/new or via an
+email to support@eventyay.com!
 """
         )
     ),
@@ -140,7 +140,7 @@ statistics you might find interesting:
 
 If there is anything you’re missing, come tell us about it
 at https://github.com/pretalx/pretalx/issues/new or via an
-email to support@pretalx.com!
+email to support@eventyay.com!
 """
         )
     ),

--- a/src/pretalx/common/models/settings.py
+++ b/src/pretalx/common/models/settings.py
@@ -86,7 +86,7 @@ hierarkey.add_default(
         gettext_noop(
             """Hi,
 
-we hope you’re happy with pretalx as your event’s CfP system.
+we hope you’re happy with eventyay as your event’s CfP system.
 These links may be helpful in the coming days and weeks:
 
 - Your event’s dashboard: {event_dashboard}
@@ -139,7 +139,7 @@ statistics you might find interesting:
 - Over the course of the event, you sent {mail_count} mails.
 
 If there is anything you’re missing, come tell us about it
-at https://github.com/pretalx/pretalx/issues/new or via an
+at https://github.com/fossasia/eventyay-talk/issues/new or via an
 email to support@eventyay.com!
 """
         )

--- a/src/pretalx/common/templates/400.html
+++ b/src/pretalx/common/templates/400.html
@@ -16,7 +16,7 @@
     <h3>
         <p class="ml-auto mr-auto text-center">
             {% blocktranslate trimmed %}
-                It looks as if the communication between you and pretalx went wrong in
+                It looks as if the communication between you and eventyay went wrong in
                 some way.
                 <br>
                 Please return to the last page and try again!

--- a/src/pretalx/common/templates/500.html
+++ b/src/pretalx/common/templates/500.html
@@ -12,14 +12,5 @@
         <br>
     </p>
     </h2>
-    <h5>
-        <p>
-            {% if development_mode %}
-                {% blocktranslate with link="https://github.com/pretalx/pretalx/issues/new?template=bug_report.md&title=Error+on+"|add:request_path trimmed %}
-                    Please help us to fix this by submitting <a href="{{ link }}" rel=noopener>a bug report</a>!
-                {% endblocktranslate %}
-            {% endif %}
-        </p>
-    </h5>
 {% endblock error_message %}
 {% block error_code %}500{% endblock error_code %}

--- a/src/pretalx/common/templates/common/base.html
+++ b/src/pretalx/common/templates/common/base.html
@@ -20,7 +20,7 @@
             <meta name="robots" content="index, follow">
         {% endif %}
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="theme-color" content="{% if request.event %}{{ request.event.visible_primary_color }}{% else %}#3aa57c{% endif %}">
+        <meta name="theme-color" content="{% if request.event %}{{ request.event.visible_primary_color }}{% else %}#2185d0{% endif %}">
         <meta name="HandheldFriendly" content="True"/>
         {% block meta_image %}{% if request.event %}<meta property="thumbnail" content="{{ request.event.urls.social_image.full }}">
             <meta property="og:image" content="{{ request.event.urls.social_image.full }}">

--- a/src/pretalx/common/templates/common/user_api_token.html
+++ b/src/pretalx/common/templates/common/user_api_token.html
@@ -8,8 +8,8 @@
         <h3>{% translate "API Access" %}</h3>
         <div>
             <p>
-                {% blocktranslate trimmed with apiurl='href="/api/events/" target="_blank" rel="noopener"' docurl='href="https://docs.pretalx.org/en/latest/api/index.html" target="_blank" rel="noopener"' %}
-                    This token can be used to access the <a {{ apiurl }}>pretalx API</a>.
+                {% blocktranslate trimmed with apiurl='href="/api/events/" target="_blank" rel="noopener"' docurl='href="#" target="_blank" rel="noopener"' %}
+                    This token can be used to access the <a {{ apiurl }}>eventyay API</a>.
                     You can generate a new token, which will invalidate the old one.
                     To find out more, please have a look at the <a {{ docurl }}>
                         API documentation</a>.

--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -218,7 +218,7 @@ class Event(PretalxModel):
         ],
         verbose_name=_("Main event colour"),
         help_text=_(
-            "Provide a hex value like #00ff00 if you want to style pretalx in your event’s colour scheme."
+            "Provide a hex value like #00ff00 if you want to style eventyay in your event’s colour scheme."
         ),
     )
     custom_css = models.FileField(

--- a/src/pretalx/frontend/schedule-editor/src/App.vue
+++ b/src/pretalx/frontend/schedule-editor/src/App.vue
@@ -540,7 +540,7 @@ export default {
 				#btn-save
 					margin-left: auto
 					font-weight: bold;
-					button-style(color: #3aa57c)
+					button-style(color: #2185d0)
 				[type=submit]
 					display: none
 			.data

--- a/src/pretalx/orga/forms/event.py
+++ b/src/pretalx/orga/forms/event.py
@@ -58,7 +58,7 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
         choices=[],
         widget=MultipleLanguagesWidget,
         help_text=_(
-            "Users will be able to use pretalx in these languages, and you will be able to provide all texts in these"
+            "Users will be able to use eventyay in these languages, and you will be able to provide all texts in these"
             " languages. If you don’t provide a text in the language a user selects, it will be shown in your event’s"
             " default language instead."
         ),
@@ -573,7 +573,7 @@ class WidgetSettingsForm(JsonSubfieldMixin, forms.Form):
     show_widget_if_not_public = forms.BooleanField(
         label=_("Show the widget even if the schedule is not public"),
         help_text=_(
-            "Set to allow external pages to show the schedule widget, even if the schedule is not shown here using pretalx."
+            "Set to allow external pages to show the schedule widget, even if the schedule is not shown here using eventyay."
         ),
         required=False,
     )

--- a/src/pretalx/orga/forms/widgets.py
+++ b/src/pretalx/orga/forms/widgets.py
@@ -38,7 +38,7 @@ class MultipleLanguagesWidget(CheckboxSelectMultiple):
                 (
                     _("Community translations"),
                     _(
-                        "These translations are not maintained by the pretalx team. "
+                        "These translations are not maintained by the eventyay team. "
                         "We cannot vouch for their correctness, and new or recently changed features "
                         "might not be translated and will show in English instead. "
                         'You can <a href="{url}" target="_blank">contribute to the translations</a>.'

--- a/src/pretalx/orga/templates/orga/admin/admin.html
+++ b/src/pretalx/orga/templates/orga/admin/admin.html
@@ -29,7 +29,7 @@
     {% endif %}
 
     <p>
-        {% translate "Your pretalx version is:" %} <strong>{{ pretalx_version|copyable }}</strong>.
+        {% translate "Your eventyay version is:" %} <strong>{{ pretalx_version|copyable }}</strong>.
         {% url 'orga:admin.update' as update_url %}
         {% blocktranslate trimmed %}
             You can check for updates <a href="{{ update_url }}">here</a>.

--- a/src/pretalx/orga/templates/orga/admin/update.html
+++ b/src/pretalx/orga/templates/orga/admin/update.html
@@ -27,9 +27,9 @@
         <div class="alert alert-danger">
             {% translate "The last update check was not successful." %}
             {% if gs.settings.update_check_result.error == "http_error" %}
-                {% translate "The pretalx.com server returned an error code." %}
+                {% translate "The eventyay.com server returned an error code." %}
             {% elif gs.settings.update_check_result.error == "unavailable" %}
-                {% translate "The pretalx.com server could not be reached." %}
+                {% translate "The eventyay.com server could not be reached." %}
             {% elif gs.settings.update_check_result.error == "development" %}
                 {% translate "This installation appears to be a development installation." %}
             {% endif %}

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -129,7 +129,7 @@
             <div class="global-top-warning">
                 <i class="fa fa-exclamation-triangle"></i>
                 {% blocktranslate with link=link trimmed %}
-                    You’re using pretalx as a superuser. This is not recommended.
+                    You’re using eventyay as a superuser. This is not recommended.
                 {% endblocktranslate %}
                 <a href="{% url "orga:user.subuser" %}?next={{ request.path|urlencode }}">
                     {% translate "Please click here to switch to an administrator account." %}
@@ -140,8 +140,8 @@
             <div class="global-top-warning">
                 <a href="{% url "orga:admin.update" %}">
                     {% blocktranslate trimmed %}
-                        Starting with version 1.1.0, pretalx automatically checks for updates in the background.
-                        During this check, anonymous data is transmitted to servers operated by the pretalx
+                        Starting with version 1.1.0, eventyay automatically checks for updates in the background.
+                        During this check, anonymous data is transmitted to servers operated by the eventyay
                         developers. Click on this message to find out more, disable this feature or enter your
                         email address to get notified via email if a new update arrives. This message will
                         disappear once you clicked it.

--- a/src/pretalx/orga/templates/orga/event_list.html
+++ b/src/pretalx/orga/templates/orga/event_list.html
@@ -19,7 +19,7 @@
     {% if not hide_speaker_events and speaker_events %}
         <div class="alert alert-info">
             <div>
-                {% translate "You are currently in the organiser area of pretalx. To view your submitted proposals, please go directly to the event page:" %}
+                {% translate "You are currently in the organiser area of eventyay. To view your submitted proposals, please go directly to the event page:" %}
                 {% if speaker_events|length == 1 %}
                     <a href="{{ event.urls.user_submissions.full }}">{{ event.name }}</a>
                 {% else %}

--- a/src/pretalx/orga/templates/orga/review/assignment-import.html
+++ b/src/pretalx/orga/templates/orga/review/assignment-import.html
@@ -10,7 +10,7 @@
 {% block content %}
     <h2>{% translate "Assign reviewers" %}</h2>
     <p>
-        {% blocktranslate trimmed with href="https://github.com/pretalx/pretalx/blob/main/doc/user/review-assignments.json" %}
+        {% blocktranslate trimmed with href="#" %}
             You can upload your reviewer assignments from a JSON file here. You can either have the proposal codes (e.g. “UX3N1”) as keys, and user identification as values, or the other way around. User identification can be either the reviewer’s email address or their user code (e.g. “34KJN”). You can find an example file <a href="{{ href }}">here</a>.
         {% endblocktranslate %}
     </p>

--- a/src/pretalx/orga/templates/orga/review/export.html
+++ b/src/pretalx/orga/templates/orga/review/export.html
@@ -63,7 +63,7 @@
             <pre> curl -H "Authorization: Token {{ request.user.auth_token.key }}" {{ request.event.api_urls.reviews.full }} </pre>
 
         <div class="submit-group"><span></span><span>
-            <a class="btn btn-lg btn-info" href="https://docs.pretalx.org/en/latest/api/index.html">
+            <a class="btn btn-lg btn-info" href="#">
                 <i class="fa fa-book"></i>
                 {% translate "Documentation" %}
             </a>

--- a/src/pretalx/orga/templates/orga/schedule/export.html
+++ b/src/pretalx/orga/templates/orga/schedule/export.html
@@ -45,7 +45,7 @@
 
     <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="true">
         {% blocktranslate trimmed %}
-            pretalx provides a range of exports. If none of these match what you are looking
+            eventyay provides a range of exports. If none of these match what you are looking
             for, you can also provide a custom plugin to export the data – please ask
             your administrator to install the plugin.
         {% endblocktranslate %}
@@ -132,7 +132,7 @@
  curl -H "Authorization: Token {{ request.user.auth_token.key }}" {{ request.event.api_urls.submissions.full }} </pre>
 
         <div class="submit-group"><span></span><span>
-            <a class="btn btn-lg btn-info" href="https://docs.pretalx.org/en/latest/api/index.html">
+            <a class="btn btn-lg btn-info" href="#">
                 <i class="fa fa-book"></i>
                 {% translate "Documentation" %}
             </a>

--- a/src/pretalx/orga/templates/orga/settings/widget.html
+++ b/src/pretalx/orga/templates/orga/settings/widget.html
@@ -30,7 +30,7 @@
     <dialog id="info-dialog">
         <div class="alert alert-info flip ml-auto">
             {% blocktranslate trimmed %}
-                You can configure a pretalx schedule widget to show your event schedule
+                You can configure a eventyay schedule widget to show your event schedule
                 on your homepage, instead of using this page. If you want to disable the
                 schedule on here entirely, please activate the setting below.
             {% endblocktranslate %}
@@ -42,7 +42,7 @@
     <h2>{% translate "Widget generation" %}</h2>
     <p>
         {% blocktranslate trimmed %}
-            The pretalx schedule widget is a way to embed your schedule into your event website. This way, your attendees can see your schedule without leaving your website, and you can style the schedule to fit right in with your website.
+            The eventyay schedule widget is a way to embed your schedule into your event website. This way, your attendees can see your schedule without leaving your website, and you can style the schedule to fit right in with your website.
         {% endblocktranslate %}
     </p>
 
@@ -87,7 +87,7 @@
             <span class="text-success">
                 <i class="fa fa-info-circle"></i>
             </span>
-            {% blocktranslate trimmed with link="https://docs.pretalx.org/user/event/widget.html" %}
+            {% blocktranslate trimmed with link="#" %}
 
                 Please look at <a href="{{ link }}">our documentation</a> for more information.
             {% endblocktranslate %}
@@ -102,7 +102,7 @@
                     This is roughly what your widget will look like if you choose the grid format:
                 {% endblocktranslate %}
             </p>
-            <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.event.locale }}" style="--pretalx-clr-primary: {{ request.event.primary_color|default:"#3aa57c" }}"></pretalx-schedule>
+            <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.event.locale }}" style="--pretalx-clr-primary: {{ request.event.primary_color|default:"#2185d0" }}"></pretalx-schedule>
       </div>
    <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
         <noscript>

--- a/src/pretalx/orga/templates/orga/speaker/export.html
+++ b/src/pretalx/orga/templates/orga/speaker/export.html
@@ -53,7 +53,7 @@
     <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="true">
         <p>
             {% blocktranslate trimmed %}
-                pretalx provides a range of exports. If none of these match what you are looking
+                eventyay provides a range of exports. If none of these match what you are looking
                 for, you can also provide a custom plugin to export the data – please ask
                 your administrator to install the plugin.
             {% endblocktranslate %}
@@ -106,7 +106,7 @@
             <pre> curl -H "Authorization: Token {{ request.user.auth_token.key }}" {{ request.event.api_urls.speakers.full }} </pre>
 
         <div class="submit-group"><span></span><span>
-            <a class="btn btn-lg btn-info" href="https://docs.pretalx.org/en/latest/api/index.html">
+            <a class="btn btn-lg btn-info" href="#">
                 <i class="fa fa-book"></i>
                 {% translate "Documentation" %}
             </a>

--- a/src/pretalx/orga/templates/orga/widgets/multi_languages_widget.html
+++ b/src/pretalx/orga/templates/orga/widgets/multi_languages_widget.html
@@ -3,7 +3,7 @@
 {% include "django/forms/widgets/input_option.html" %}
 {% if not widget.official %}
     {% if widget.percentage %}
-        <a href="https://translate.pretalx.com/engage/pretalx/{{ widget.value }}/">
+        <a href="#">
             <span class="badge badge-pill color-{% if widget.percentage >= 90 %}success{% elif widget.percentage >= 80 %}warning{% else %}danger{% endif %}">
                 {% blocktranslate trimmed with percentage=widget.percentage %}{{ percentage }} % translated{% endblocktranslate %}</span></a> {# We need to avoid trailing whitespace here, sadly #}
     {% endif %}

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -207,7 +207,7 @@ class FrabJsonExporter(ScheduleData):
                 "daysCount": self.event.duration,
                 "timeslot_duration": "00:05",
                 "time_zone_name": self.event.timezone,
-                "colors": {"primary": self.event.primary_color or "#3aa57c"},
+                "colors": {"primary": self.event.primary_color or "#2185d0"},
                 "rooms": [
                     {
                         "name": str(room.name),

--- a/src/pretalx/static/common/css/_variables.css
+++ b/src/pretalx/static/common/css/_variables.css
@@ -6,7 +6,7 @@
   --color-text-lighter: rgb(0 0 0 / 0.6);
 
   /* We're making the text colour version of the primary colour a tad darker for contrast */
-  --color-pretalx: #3aa57c;
+  --color-pretalx: #2185d0;
 
   --color-primary: var(--color-pretalx);
   --color-primary-text: color-mix(in srgb, var(--color-primary), black 10%);

--- a/src/pretalx/static/common/js/availabilities.js
+++ b/src/pretalx/static/common/js/availabilities.js
@@ -99,7 +99,7 @@ const initAvailabilities = (element) => {
         eventDurationEditable: editable,
         allDayMaintainDuration: true,
         eventsSet: save_events,
-        eventColor: "#3aa57c",
+        eventColor: "#2185d0",
         eventConstraint: constraints ? "mainConstraint" : null,
         eventOverlap: !!constraints, // we can't use element with constraints, because those are also only background events
         selectOverlap: !!constraints, // we have to set element, otherwise events can only be created *outside* our available times

--- a/src/pretalx/static/orga/js/cfp_flow.js
+++ b/src/pretalx/static/orga/js/cfp_flow.js
@@ -381,7 +381,7 @@ Vue.component("step", {
 var app = new Vue({
     el: "#flow",
     template: `
-    <div :class="currentModal.data ? 'defocused' : 'focused'" :style="{'--color': eventConfiguration.primary_color || '#3aa57c'}">
+    <div :class="currentModal.data ? 'defocused' : 'focused'" :style="{'--color': eventConfiguration.primary_color || '#2185d0'}">
       <div id="flow-modal" v-if="currentModal.data">
         <form>
           <field :field="currentModal.data" :isModal="true" key="modal" :locales="locales"></field>

--- a/src/pretalx/static/orga/js/stats.js
+++ b/src/pretalx/static/orga/js/stats.js
@@ -59,7 +59,7 @@ const drawTimeline = () => {
                 },
             },
         },
-        colors: ["#3aa57c", "#4697c9", "#cccccc"],
+        colors: ["#2185d0", "#4697c9", "#cccccc"],
         fill: {
             type: ["gradient", "gradient", "gradient"],
         },

--- a/src/tests/orga/views/test_orga_views_admin.py
+++ b/src/tests/orga/views/test_orga_views_admin.py
@@ -44,7 +44,7 @@ def test_update_notice_displayed(client, user):
 
     r = client.get("/orga/", follow=True)
     assert (
-        "pretalx automatically checks for updates in the background"
+        "eventyay automatically checks for updates in the background"
         not in r.content.decode()
     )
 
@@ -52,14 +52,14 @@ def test_update_notice_displayed(client, user):
     user.save()
     r = client.get("/orga/", follow=True)
     assert (
-        "pretalx automatically checks for updates in the background"
+        "eventyay automatically checks for updates in the background"
         in r.content.decode()
     )
 
     client.get("/orga/admin/update/")  # Click it
     r = client.get("/orga/", follow=True)
     assert (
-        "pretalx automatically checks for updates in the background"
+        "eventyay automatically checks for updates in the background"
         not in r.content.decode()
     )
 


### PR DESCRIPTION
Update default color for Eventyay-talk after it got impacted after synced upstream

## Summary by Sourcery

Change the default color scheme to #2185d0 and update branding references from 'pretalx' to 'eventyay' throughout the project.

Enhancements:
- Update default color scheme from #3aa57c to #2185d0 across various components and styles.

Chores:
- Replace references from 'pretalx' to 'eventyay' in URLs, email addresses, and documentation links.