### PR TITLE
Enable video plugin

### DIFF
--- a/src/pretalx/eventyay_common/tasks.py
+++ b/src/pretalx/eventyay_common/tasks.py
@@ -141,7 +141,7 @@ def process_event_webhook(event_data):
                     date_from=datetime.fromisoformat(event_data.get("date_from")),
                     date_to=datetime.fromisoformat(event_data.get("date_to")),
                     plugins=(
-                        enable_video_plugin()
+                        get_video_plugin()
                         if event_data.get("is_video_creation")
                         else None
                     ),
@@ -162,9 +162,9 @@ def process_event_webhook(event_data):
             event.timezone = event_data.get("timezone")
             event.locale = event_data.get("locale")
             event.plugins = (
-                add_plugin(event, enable_video_plugin())
+                add_plugin(event, get_video_plugin())
                 if event_data.get("is_video_creation")
-                else None
+                else event.plugins
             )
             event.save()
             logger.info(f"Event for organiser {organiser.name} created successfully.")
@@ -180,10 +180,10 @@ def process_event_webhook(event_data):
         logger.error("Error saving organiser:", e)
 
 
-def enable_video_plugin():
+def get_video_plugin():
     """
-    Enable the video plugin if it is installed.
-    @return: The plugin if it is installed, otherwise None.
+    Check if the video plugin is installed.
+    @return: If the video plugin is installed, return the plugin name, otherwise None.
     """
     video_plugin = get_installed_plugin("pretalx_venueless")
     if video_plugin:
@@ -214,6 +214,8 @@ def add_plugin(event, plugin_name):
     @param plugin_name: A string representing the name of the plugin to add.
     @return: The updated list of plugins for the event.
     """
+    if plugin_name is None:
+        return event.plugins
     if not event.plugins:
         return plugin_name
     plugins = set(event.plugins.split(","))

--- a/src/pretalx/eventyay_common/tasks.py
+++ b/src/pretalx/eventyay_common/tasks.py
@@ -1,5 +1,7 @@
+import importlib.util
 import logging
 from datetime import datetime
+from importlib import import_module
 
 from celery import shared_task
 from django.core.exceptions import ValidationError
@@ -138,6 +140,7 @@ def process_event_webhook(event_data):
                     locale=event_data.get("locale"),
                     date_from=datetime.fromisoformat(event_data.get("date_from")),
                     date_to=datetime.fromisoformat(event_data.get("date_to")),
+                    plugins=enable_video_plugin() if event_data.get("is_video_creation") else None,
                 )
                 event.save()
         elif action == Action.UPDATE:
@@ -154,6 +157,7 @@ def process_event_webhook(event_data):
             event.content_locale_array = ",".join(event_data.get("locales"))
             event.timezone = event_data.get("timezone")
             event.locale = event_data.get("locale")
+            event.plugins = add_plugin(event, enable_video_plugin()) if event_data.get("is_video_creation") else None
             event.save()
             logger.info(f"Event for organiser {organiser.name} created successfully.")
 
@@ -166,3 +170,40 @@ def process_event_webhook(event_data):
         logger.error("Validation error:", e.message_dict)
     except Exception as e:
         logger.error("Error saving organiser:", e)
+
+
+def enable_video_plugin():
+    video_plugin = get_installed_plugin('pretalx_venueless')
+    if video_plugin:
+        plugins = 'pretalx_venueless'
+        return plugins
+    else:
+        logger.error("Video plugin not installed.")
+        return None
+
+
+def get_installed_plugin(plugin_name):
+    """
+    Check if a plugin is installed.
+    @param plugin_name: A string representing the name of the plugin to check.
+    @return: The installed plugin if it exists, otherwise None.
+    """
+    if importlib.util.find_spec(plugin_name) is not None:
+        installed_plugin = import_module(plugin_name)
+    else:
+        installed_plugin = None
+    return installed_plugin
+
+
+def add_plugin(event, plugin_name):
+    """
+    Add a plugin
+    @param event: The event instance to which the plugin should be added.
+    @param plugin_name: A string representing the name of the plugin to add.
+    @return: The updated list of plugins for the event.
+    """
+    if not event.plugins:
+        return plugin_name
+    plugins = set(event.plugins.split(','))
+    plugins.add(plugin_name)
+    return ','.join(plugins)

--- a/src/pretalx/eventyay_common/tasks.py
+++ b/src/pretalx/eventyay_common/tasks.py
@@ -181,6 +181,10 @@ def process_event_webhook(event_data):
 
 
 def enable_video_plugin():
+    """
+    Enable the video plugin if it is installed.
+    @return: The plugin if it is installed, otherwise None.
+    """
     video_plugin = get_installed_plugin("pretalx_venueless")
     if video_plugin:
         plugins = "pretalx_venueless"

--- a/src/pretalx/eventyay_common/tasks.py
+++ b/src/pretalx/eventyay_common/tasks.py
@@ -140,7 +140,11 @@ def process_event_webhook(event_data):
                     locale=event_data.get("locale"),
                     date_from=datetime.fromisoformat(event_data.get("date_from")),
                     date_to=datetime.fromisoformat(event_data.get("date_to")),
-                    plugins=enable_video_plugin() if event_data.get("is_video_creation") else None,
+                    plugins=(
+                        enable_video_plugin()
+                        if event_data.get("is_video_creation")
+                        else None
+                    ),
                 )
                 event.save()
         elif action == Action.UPDATE:
@@ -157,7 +161,11 @@ def process_event_webhook(event_data):
             event.content_locale_array = ",".join(event_data.get("locales"))
             event.timezone = event_data.get("timezone")
             event.locale = event_data.get("locale")
-            event.plugins = add_plugin(event, enable_video_plugin()) if event_data.get("is_video_creation") else None
+            event.plugins = (
+                add_plugin(event, enable_video_plugin())
+                if event_data.get("is_video_creation")
+                else None
+            )
             event.save()
             logger.info(f"Event for organiser {organiser.name} created successfully.")
 
@@ -173,9 +181,9 @@ def process_event_webhook(event_data):
 
 
 def enable_video_plugin():
-    video_plugin = get_installed_plugin('pretalx_venueless')
+    video_plugin = get_installed_plugin("pretalx_venueless")
     if video_plugin:
-        plugins = 'pretalx_venueless'
+        plugins = "pretalx_venueless"
         return plugins
     else:
         logger.error("Video plugin not installed.")
@@ -204,6 +212,6 @@ def add_plugin(event, plugin_name):
     """
     if not event.plugins:
         return plugin_name
-    plugins = set(event.plugins.split(','))
+    plugins = set(event.plugins.split(","))
     plugins.add(plugin_name)
-    return ','.join(plugins)
+    return ",".join(plugins)

--- a/src/pretalx/eventyay_common/views/auth.py
+++ b/src/pretalx/eventyay_common/views/auth.py
@@ -25,8 +25,11 @@ def oauth2_login_view(request, *args, **kwargs):
         provider=settings.EVENTYAY_SSO_PROVIDER
     ).first()
     if not sso_provider:
-        messages.error(request, "SSO not configured yet, please contact the "
-                                "administrator or come back later.")
+        messages.error(
+            request,
+            "SSO not configured yet, please contact the "
+            "administrator or come back later.",
+        )
         return redirect(reverse("orga:login"))
     # Create an OAuth2 session using the client ID and redirect URI
     oauth2_session = OAuth2Session(
@@ -52,8 +55,11 @@ def oauth2_callback(request):
         provider=settings.EVENTYAY_SSO_PROVIDER
     ).first()
     if not sso_provider:
-        messages.error(request, "SSO not configured yet, please contact the "
-                                "administrator or come back later.")
+        messages.error(
+            request,
+            "SSO not configured yet, please contact the "
+            "administrator or come back later.",
+        )
         return redirect(reverse("orga:login"))
     oauth2_session = OAuth2Session(
         sso_provider.client_id,


### PR DESCRIPTION
This pull request resolves fossasia/eventyay-tickets#465.
- Automatically enable the video plugin for the talk project if it is installed, and activate it when the user selects is_video_creation during the event creation process in the ticket project.

## Summary by Sourcery

Enable the video plugin automatically for events when the 'is_video_creation' option is selected during event creation, and improve error message formatting in OAuth2 views.

New Features:
- Automatically enable the video plugin for events when the 'is_video_creation' option is selected during event creation.

Enhancements:
- Refactor error message formatting in the OAuth2 login and callback views for better readability.