### PR TITLE
Fix background color on login page

### DIFF
--- a/src/pretalx/static/orga/css/auth.css
+++ b/src/pretalx/static/orga/css/auth.css
@@ -1,5 +1,5 @@
 body {
-  background: var(--color-primary);
+  background: var(--color-bg);
 }
 
 #wrapper {


### PR DESCRIPTION
This PR resolves #238 

Change background color on login page from blue (#2185d0) to white (#fff)

## Summary by Sourcery

Bug Fixes:
- Correct the background color on the login page by changing the CSS variable from --color-primary to --color-bg.