### PR TITLE
Create speaker account with SSO as part of the answer to Call for Proposals

### DIFF
--- a/src/pretalx/cfp/templates/cfp/event/login.html
+++ b/src/pretalx/cfp/templates/cfp/event/login.html
@@ -18,5 +18,5 @@
             or if you are participating in the event as a speaker or organizer.
         {% endblocktranslate %}
     </p>
-    {% include "common/auth.html" with hide_register=True %}
+    {% include "common/auth.html" with hide_register=True next_url=request.get_full_path %}
 {% endblock %}

--- a/src/pretalx/cfp/templates/cfp/event/submission_base.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_base.html
@@ -20,12 +20,14 @@
 {% block content %}
     <div id="submission-steps" class="stages">
         {% for stp in cfp_flow %}
+            {% if stp.identifier != 'user' %}
             <a {% if stp.resolved_url %}href="{{ stp.resolved_url }}"{% endif %} class="step step-{% if stp.is_before %}done{% elif stp.identifier == step.identifier %}current{% else %}tbd{% endif %}">
                 <div class="step-icon">
                     <span class="fa {% if stp.is_before %}fa-check{% elif stp.icon %}fa-{{ stp.icon }}{% else %}fa-pencil{% endif %}"></span>
                 </div>
                 <div class="step-label">{{ stp.label }}</div>
             </a>
+            {% endif %}
         {% endfor %}
         <div class="step step-tbd">
             <div class="step-icon">
@@ -35,6 +37,7 @@
         </div>
     </div>
     {% block cfp_form %}
+        {% if request.user.is_authenticated %}
         <form method="post"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
             {% csrf_token %}
             {{ wizard.management_form }}
@@ -78,5 +81,10 @@
                 </div>
             {% endblock buttons %}
         </form>
+        {% else %}
+            <h2>{% translate "You are required to be logged in to submit a proposal" %}</h2>
+            <p>{% translate "To create your proposal, you need an account on this page. This not only gives us a way to contact you, it also gives you the possibility to edit your proposal or to view its current state." %}</p>
+            {% include "common/auth.html" with form=form no_form=True no_buttons=True next_url=request.get_full_path %}
+        {% endif %}
     {% endblock cfp_form %}
 {% endblock content %}

--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -26,7 +26,8 @@
     {% if not hide_login %}
         <div class="panel panel-default">
             <div class="panel-heading text-center" id="headingOne">
-                <a class="btn btn-lg btn-primary btn-block mt-3" href='{% url "eventyay_common:oauth2_provider.login" %}?next={{ next_url|urlencode }}'>
+                <a class="btn btn-lg btn-primary btn-block mt-3" 
+                   href='{% url "eventyay_common:oauth2_provider.login" %}{% if next_url %}?next={{ next_url|urlencode }}{% endif %}'>
                     {% translate "Login with SSO" %}
                 </a>
             </div>
@@ -36,7 +37,8 @@
         <hr>
         <div class="panel panel-default">
             <div class="panel-heading text-center" id="headingTwo">
-                <a class="btn btn-lg btn-primary btn-block mt-3" href='{% url "eventyay_common:register.account"" %}?next={{ next_url|urlencode }}'>
+                <a class="btn btn-lg btn-primary btn-block mt-3" 
+                   href='{% url "eventyay_common:register.account" %}{% if next_url %}?next={{ next_url|urlencode }}{% endif %}'>
                     {% translate "Register Speaker Account" %}
                 </a>
             </div>

--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -26,7 +26,7 @@
     {% if not hide_login %}
         <div class="panel panel-default">
             <div class="panel-heading text-center" id="headingOne">
-                <a class="btn btn-lg btn-primary btn-block mt-3" href='{% url "eventyay_common:oauth2_provider.login" %}'>
+                <a class="btn btn-lg btn-primary btn-block mt-3" href='{% url "eventyay_common:oauth2_provider.login" %}?next={{ next_url|urlencode }}'>
                     {% translate "Login with SSO" %}
                 </a>
             </div>
@@ -36,7 +36,7 @@
         <hr>
         <div class="panel panel-default">
             <div class="panel-heading text-center" id="headingTwo">
-                <a class="btn btn-lg btn-primary btn-block mt-3" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+                <a class="btn btn-lg btn-primary btn-block mt-3" href='{% url "eventyay_common:register.account"" %}?next={{ next_url|urlencode }}'>
                     {% translate "Register Speaker Account" %}
                 </a>
             </div>

--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% load socialaccount %}
+{% load oauth_tags %}
 
 {% include "common/forms/errors.html" %}
 {% if no_form %}
@@ -26,8 +27,7 @@
     {% if not hide_login %}
         <div class="panel panel-default">
             <div class="panel-heading text-center" id="headingOne">
-                <a class="btn btn-lg btn-primary btn-block mt-3" 
-                   href='{% url "eventyay_common:oauth2_provider.login" %}{% if next_url %}?next={{ next_url|urlencode }}{% endif %}'>
+                <a class="btn btn-lg btn-primary btn-block mt-3" href="{% oauth_login_url next_url %}">
                     {% translate "Login with SSO" %}
                 </a>
             </div>
@@ -37,8 +37,7 @@
         <hr>
         <div class="panel panel-default">
             <div class="panel-heading text-center" id="headingTwo">
-                <a class="btn btn-lg btn-primary btn-block mt-3" 
-                   href='{% url "eventyay_common:register.account" %}{% if next_url %}?next={{ next_url|urlencode }}{% endif %}'>
+                <a class="btn btn-lg btn-primary btn-block mt-3" href="{% register_account_url next_url %}">
                     {% translate "Register Speaker Account" %}
                 </a>
             </div>

--- a/src/pretalx/common/templatetags/oauth_tags.py
+++ b/src/pretalx/common/templatetags/oauth_tags.py
@@ -13,7 +13,7 @@ def oauth_login_url(next_url: Optional[str] = None) -> str:
     Generate the OAuth login URL with an optional next parameter.
     Usage: {% oauth_login_url next_url %}
     """
-    base_url = reverse('eventyay_common:oauth2_provider.login')
+    base_url = reverse("eventyay_common:oauth2_provider.login")
     if next_url:
         return f"{base_url}?next={quote(next_url)}"
     return base_url

--- a/src/pretalx/common/templatetags/oauth_tags.py
+++ b/src/pretalx/common/templatetags/oauth_tags.py
@@ -14,7 +14,6 @@ def oauth_login_url(next_url: Optional[str] = None) -> str:
     Usage: {% oauth_login_url next_url %}
     """
     base_url = reverse('eventyay_common:oauth2_provider.login')
-
     if next_url:
         return f"{base_url}?next={quote(next_url)}"
     return base_url

--- a/src/pretalx/common/templatetags/oauth_tags.py
+++ b/src/pretalx/common/templatetags/oauth_tags.py
@@ -1,0 +1,32 @@
+from typing import Optional
+from urllib.parse import quote
+
+from django import template
+from django.urls import reverse
+
+register = template.Library()
+
+
+@register.simple_tag
+def oauth_login_url(next_url: Optional[str] = None) -> str:
+    """
+    Generate the OAuth login URL with an optional next parameter.
+    Usage: {% oauth_login_url next_url %}
+    """
+    base_url = reverse('eventyay_common:oauth2_provider.login')
+
+    if next_url:
+        return f"{base_url}?next={quote(next_url)}"
+    return base_url
+
+
+@register.simple_tag
+def register_account_url(next_url: Optional[str] = None) -> str:
+    """
+    Generate the registration URL with an optional next parameter.
+    Usage: {% register_account_url next_url %}
+    """
+    base_url = reverse("eventyay_common:register.account")
+    if next_url:
+        return f"{base_url}?next={quote(next_url)}"
+    return base_url

--- a/src/pretalx/eventyay_common/urls.py
+++ b/src/pretalx/eventyay_common/urls.py
@@ -11,7 +11,8 @@ app_name = "eventyay_common"
 
 urlpatterns = [
     path("oauth2/", include("oauth2_provider.urls", namespace="oauth2_provider")),
-    path("login/", auth.oauth2_login_view, name="oauth2_provider.login"),
+    path("login/", auth.OAuth2LoginView.as_view(), name="oauth2_provider.login"),
+    path("register/", auth.register, name="register.account"),
     path("oauth2/callback/", auth.oauth2_callback, name="oauth2_callback"),
     path("webhook/organiser/", organiser_webhook, name="webhook.organiser"),
     path("webhook/team/", team_webhook, name="webhook.team"),

--- a/src/pretalx/eventyay_common/views/auth.py
+++ b/src/pretalx/eventyay_common/views/auth.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from typing import Optional, Tuple
-from urllib.parse import urljoin, quote
+from urllib.parse import quote, urljoin
 
 from allauth.socialaccount.models import SocialApp
 from django.conf import settings
@@ -27,7 +27,7 @@ os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = (
 def register(request: HttpRequest) -> HttpResponse:
     """
     Register a new user account and redirect to the previous page.
-    
+
     This function constructs a registration URL with a 'next' parameter
     to ensure the user is redirected back to their original location
     after registration.

--- a/src/pretalx/eventyay_common/views/auth.py
+++ b/src/pretalx/eventyay_common/views/auth.py
@@ -33,7 +33,7 @@ def register(request: HttpRequest) -> HttpResponse:
     after registration.
     """
     register_url = urljoin(settings.EVENTYAY_TICKET_BASE_PATH, "/control/register")
-    next_url = request.GET.get('next') or request.POST.get('next')
+    next_url = request.GET.get("next") or request.POST.get("next")
     full_next_url = request.build_absolute_uri(next_url)
     next_param = f"?next={quote(full_next_url)}"
     return redirect(f"{register_url}{next_param}")
@@ -42,9 +42,9 @@ def register(request: HttpRequest) -> HttpResponse:
 class OAuth2LoginView(View):
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         # Store the 'next' URL in the session, for redirecting user back after login
-        next_url = request.GET.get('next') or request.POST.get('next')
+        next_url = request.GET.get("next") or request.POST.get("next")
         if next_url:
-            request.session['next'] = next_url
+            request.session["next"] = next_url
 
         sso_provider = self.get_sso_provider()
         if not sso_provider:
@@ -132,5 +132,5 @@ def oauth2_callback(request):
     # Log the user into the session
     login(request, user, backend="django.contrib.auth.backends.ModelBackend")
     # If a 'next' URL was stored in the session, use it for redirecting user back after login
-    next_url = request.session.pop('next', None)
-    return redirect(next_url or reverse('cfp:root.main'))
+    next_url = request.session.pop("next", None)
+    return redirect(next_url or reverse("cfp:root.main"))

--- a/src/pretalx/eventyay_common/views/auth.py
+++ b/src/pretalx/eventyay_common/views/auth.py
@@ -1,12 +1,16 @@
 import logging
 import os
+from typing import Optional, Tuple
+from urllib.parse import urljoin, quote
 
 from allauth.socialaccount.models import SocialApp
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.views import View
 from requests_oauthlib import OAuth2Session
 
 from pretalx.person.models import User
@@ -20,34 +24,58 @@ os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = (
 )
 
 
-def oauth2_login_view(request, *args, **kwargs):
-    sso_provider = SocialApp.objects.filter(
-        provider=settings.EVENTYAY_SSO_PROVIDER
-    ).first()
-    if not sso_provider:
+def register(request: HttpRequest) -> HttpResponse:
+    """
+    Register a new user account, redirects to previous page
+    """
+    register_url = urljoin(settings.EVENTYAY_TICKET_BASE_PATH, "/control/register")
+    next = request.GET.get('next') or request.POST.get('next')
+    next_url = request.build_absolute_uri(next)
+    next_param = f"?next={quote(next_url)}"
+    return redirect(f"{register_url}{next_param}")
+
+
+class OAuth2LoginView(View):
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        # Store the 'next' URL in the session, for redirecting user back after login
+        next_url = request.GET.get('next') or request.POST.get('next')
+        if next_url:
+            request.session['next'] = next_url
+
+        sso_provider = self.get_sso_provider()
+        if not sso_provider:
+            return self.handle_sso_not_configured(request)
+
+        oauth2_session = self.create_oauth2_session(sso_provider)
+        authorization_url, state = self.get_authorization_url(oauth2_session)
+        request.session["oauth2_state"] = state
+
+        return redirect(authorization_url)
+
+    @staticmethod
+    def get_sso_provider() -> Optional[SocialApp]:
+        return SocialApp.objects.filter(provider=settings.EVENTYAY_SSO_PROVIDER).first()
+
+    @staticmethod
+    def handle_sso_not_configured(request: HttpRequest) -> HttpResponse:
         messages.error(
             request,
             "SSO not configured yet, please contact the "
             "administrator or come back later.",
         )
         return redirect(reverse("orga:login"))
-    # Create an OAuth2 session using the client ID and redirect URI
-    oauth2_session = OAuth2Session(
-        client_id=sso_provider.client_id,
-        redirect_uri=settings.OAUTH2_PROVIDER["REDIRECT_URI"],
-        scope=settings.OAUTH2_PROVIDER["SCOPE"],
-    )
 
-    # Generate the authorization URL for the SSO provider
-    authorization_url, state = oauth2_session.authorization_url(
-        settings.OAUTH2_PROVIDER["AUTHORIZE_URL"]
-    )
+    @staticmethod
+    def create_oauth2_session(sso_provider: SocialApp) -> OAuth2Session:
+        return OAuth2Session(
+            client_id=sso_provider.client_id,
+            redirect_uri=settings.OAUTH2_PROVIDER["REDIRECT_URI"],
+            scope=settings.OAUTH2_PROVIDER["SCOPE"],
+        )
 
-    # Save the OAuth2 session state to the user's session for security
-    request.session["oauth2_state"] = state
-
-    # Redirect to the SSO provider's login page
-    return redirect(authorization_url)
+    @staticmethod
+    def get_authorization_url(oauth2_session: OAuth2Session) -> Tuple[str, str]:
+        return oauth2_session.authorization_url(settings.OAUTH2_PROVIDER["AUTHORIZE_URL"])
 
 
 def oauth2_callback(request):
@@ -98,4 +126,5 @@ def oauth2_callback(request):
 
     # Log the user into the session
     login(request, user, backend="django.contrib.auth.backends.ModelBackend")
-    return redirect(reverse("cfp:root.main"))
+    next_url = request.session.pop('next', None)
+    return redirect(next_url or reverse('cfp:root.main'))

--- a/src/pretalx/orga/templates/orga/auth/login.html
+++ b/src/pretalx/orga/templates/orga/auth/login.html
@@ -3,5 +3,5 @@
 {% load static %}
 {% block title %}{% translate "Sign in" %}{% endblock title %}
 {% block content %}
-    {% include "common/auth.html" with hide_register=True %}
+    {% include "common/auth.html" with hide_register=True next_url=request.get_full_path %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/invitation.html
+++ b/src/pretalx/orga/templates/orga/invitation.html
@@ -24,7 +24,7 @@
         </div>
         <hr>
 
-        {% include "common/auth.html" %}
+        {% include "common/auth.html" with next_url=request.get_full_path %}
 
     {% else %}
         <form method="post" class="col-md-6 ml-auto mr-auto">


### PR DESCRIPTION
Description:
- Implement Register Speaker Account button
- Make Login with SSO button to return to previous page after login

![image](https://github.com/user-attachments/assets/702b101e-b20b-46d6-bcc2-13bf5643db63)
The user is now required to login before submitting a proposal

This PR resolves #257

## Summary by Sourcery

New Features:
- Speakers can now create an account directly from the Call for Proposals page.