### PR TITLE
feat: deploy Sphinx Documentation automatically to gh-pages using GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,10 @@ jobs:
 
       - name: Build documentation
         run: make html
-        working-directory: docs  # Adjust to your Sphinx docs directory
+        working-directory: doc  # Adjust to your Sphinx docs directory
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_build/html
+          publish_dir: doc/_build/html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: pip install --upgrade-strategy eager -Ur doc/requirements.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.9'
 
       - name: Install dependencies
-        run: pip install sphinx sphinx-rtd-theme
+        run: pip install --upgrade-strategy eager -Ur doc/requirements.txt
 
       - name: Build documentation
         run: make html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy Sphinx Documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  # Adjust this to your default branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: pip install sphinx sphinx-rtd-theme
+
+      - name: Build documentation
+        run: make html
+        working-directory: docs  # Adjust to your Sphinx docs directory
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Sphinx Documentation to GitHub Pages
 on:
   push:
     branches:
-      - main  # Adjust this to your default branch
+      - deployment  # Adjust this to your default branch
 
 jobs:
   deploy:
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+          cache: 'pip'
       
       - name: Install system packages
         run: sudo apt update && sudo apt install libffi-dev gettext

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      
+      - name: Install system packages
+        run: sudo apt update && sudo apt install libffi-dev gettext
 
       - name: Install dependencies
         run: pip install --upgrade-strategy eager -Ur doc/requirements.txt

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+etalk.eventyay.com

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include _build/backend.py
 include LICENSE
+include CNAME
 include README.rst
 include src/pretalx.example.cfg
 include Dockerfile


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes issue #256. It does so by automating the deployment of Sphinx documentation (development) to the gh-pages branch using GitHub Actions. With this workflow, every update to the documentation triggers a deployment, ensuring that the latest changes are always reflected on GitHub Pages.

## How has this been tested?
- Verified that the GitHub Actions workflow runs without errors and deploys the documentation to the `gh-pages` branch.
- Checked that the generated documentation appears correctly on GitHub Pages.
- Verified that the deployment works with updates to the documentation.

<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->
![image](https://github.com/user-attachments/assets/ab15bc5a-7824-4b8c-af20-dc4aca3a0739)

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] Prepare Your Sphinx Documentation
- [x] Create the gh-pages Branch
- [x] Configure Automated Deployment via GitHub Actions
- [x] Add the Custom Subdomain
- [x] Configure DNS to point to `etalk.eventyay.com`
- [x]  Verify the Deployment

## Summary by Sourcery

Set up a GitHub Actions workflow to automatically deploy the Sphinx documentation to GitHub Pages on every push to the "deployment" branch.

CI:
- Add a GitHub Actions workflow to deploy the Sphinx documentation to GitHub Pages.

Documentation:
- Deploy the generated documentation to GitHub Pages, ensuring the latest documentation is always available.