### PR TITLE
Better docker development tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11-bookworm
+ARG UID=999
+ARG GID=999
 
 RUN apt-get update && \
     apt-get install -y git gettext libpq-dev locales libmemcached-dev build-essential \
@@ -14,9 +16,9 @@ RUN apt-get update && \
     mkdir /etc/pretalx && \
     mkdir /data && \
     mkdir /public && \
-    groupadd -g 999 pretalxuser && \
-    useradd -r -u 999 -g pretalxuser -d /pretalx -ms /bin/bash pretalxuser && \
-    echo 'pretalxuser ALL=(ALL) NOPASSWD: /usr/bin/supervisord' >> /etc/sudoers
+    groupadd -g $GID pretalxuser && \
+    useradd -r -u $UID -g pretalxuser -d /pretalx -ms /bin/bash pretalxuser && \
+    echo 'pretalxuser ALL=(ALL) NOPASSWD:SETENV: /usr/bin/supervisord' >> /etc/sudoers
 
 ENV LC_ALL=C.UTF-8
 ENV BASE_PATH=/talk

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include CNAME
 include README.rst
 include src/pretalx.example.cfg
 include Dockerfile
+include Makefile
 
 recursive-include deployment *.bash
 recursive-include deployment *.conf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+
+local:
+	docker buildx build --progress=plain -f Dockerfile --platform=linux/amd64 \
+		--build-arg UID=`id -u` --build-arg GID=`id -g`  \
+		-t eventyay/eventyay-talk:local .


### PR DESCRIPTION
* make hard-coded UID/GID in Dockerfile configurable
* add a Makefile to build the local docker image
* Allow pretalx to take argument `devel` for hot reloading gunicorn

## Summary by Sourcery

Configure the Docker image build process for local development.  Add a Makefile to build the image locally with configurable UID/GID. Allow enabling hot reloading of gunicorn and setting the log level to debug when running the container with the `devel` argument.

Build:
- Add a Makefile to build the Docker image locally with buildx.
- Make the UID/GID of the pretalx user in the Dockerfile configurable via build arguments, allowing for easier volume mounting during local development

Deployment:
- Add a `devel` argument to the pretalx.bash entrypoint script to enable hot reloading of gunicorn and set the log level to debug during development.
- Allow configuration of gunicorn's log level and reload behavior via environment variables in the pretalx.bash entrypoint script