### PR TITLE
Fix: Login button label is missing

### DIFF
--- a/src/pretalx/cfp/flow.py
+++ b/src/pretalx/cfp/flow.py
@@ -2,10 +2,8 @@ import copy
 import json
 import logging
 from collections import OrderedDict
-from configparser import RawConfigParser
 from contextlib import suppress
 from pathlib import Path
-from typing import cast
 
 from django.conf import settings
 from django.contrib import messages
@@ -27,7 +25,7 @@ from i18nfield.utils import I18nJSONEncoder
 from pretalx.cfp.signals import cfp_steps
 from pretalx.common.exceptions import SendMailException
 from pretalx.common.language import language
-from pretalx.common.text.phrases import CALL_FOR_SPEAKER_LOGIN_BTN_LABELS, phrases
+from pretalx.common.text.phrases import phrases
 from pretalx.person.forms import SpeakerProfileForm, UserForm
 from pretalx.person.models import User
 from pretalx.submission.forms import InfoForm, QuestionsForm
@@ -186,19 +184,6 @@ class TemplateFlowStep(TemplateResponseMixin, BaseCfPStep):
                 if step.is_applicable(self.request)
             ],
         )
-        # Select label for login button
-        config = cast(RawConfigParser, settings.CONFIG)
-        try:
-            key = config["site"]["call_for_speaker_login_button_label"]
-        except KeyError:
-            # TODO: The logs cannot be observed with the development Docker setup. Should be fixed.
-            logger.info("Config file misses `call_for_speaker_login_button_label` key!")
-            key = "default"
-        try:
-            button_label = CALL_FOR_SPEAKER_LOGIN_BTN_LABELS[key]
-        except KeyError:
-            button_label = CALL_FOR_SPEAKER_LOGIN_BTN_LABELS["default"]
-        kwargs.setdefault("login_button_label", button_label)
         return kwargs
 
     def render(self, **kwargs):

--- a/src/pretalx/orga/context_processors.py
+++ b/src/pretalx/orga/context_processors.py
@@ -5,10 +5,8 @@ from typing import cast
 from django.conf import settings
 from django.utils.module_loading import import_string
 
-
 from pretalx.common.text.phrases import CALL_FOR_SPEAKER_LOGIN_BTN_LABELS
 from pretalx.orga.signals import html_head, nav_event, nav_event_settings, nav_global
-
 
 SessionStore = import_string(f"{settings.SESSION_ENGINE}.SessionStore")
 logger = logging.getLogger(__name__)

--- a/src/pretalx/orga/context_processors.py
+++ b/src/pretalx/orga/context_processors.py
@@ -36,13 +36,9 @@ def orga_events(request):
     context["site_config"] = site_config
     context["base_path"] = settings.BASE_PATH
     # Login button label
-    try:
-        key = site_config["call_for_speaker_login_button_label"]
-    except KeyError:
-        key = "default"
-    try:
-        button_label = CALL_FOR_SPEAKER_LOGIN_BTN_LABELS[key]
-    except KeyError:
+    key = site_config.get("login_button_label", "default")
+    button_label = CALL_FOR_SPEAKER_LOGIN_BTN_LABELS.get(key)
+    if not button_label:
         logger.warning("%s does not exist in CALL_FOR_SPEAKER_LOGIN_BTN_LABELS", key)
         button_label = CALL_FOR_SPEAKER_LOGIN_BTN_LABELS["default"]
     context["login_button_label"] = button_label

--- a/src/pretalx/orga/context_processors.py
+++ b/src/pretalx/orga/context_processors.py
@@ -34,7 +34,7 @@ def orga_events(request):
     context["site_config"] = site_config
     context["base_path"] = settings.BASE_PATH
     # Login button label
-    key = site_config.get("login_button_label", "default")
+    key = site_config.get("call_for_speaker_login_button_label", "default")
     button_label = CALL_FOR_SPEAKER_LOGIN_BTN_LABELS.get(key)
     if not button_label:
         logger.warning("%s does not exist in CALL_FOR_SPEAKER_LOGIN_BTN_LABELS", key)

--- a/src/pretalx/orga/context_processors.py
+++ b/src/pretalx/orga/context_processors.py
@@ -1,9 +1,17 @@
+import logging
+from configparser import RawConfigParser
+from typing import cast
+
 from django.conf import settings
 from django.utils.module_loading import import_string
 
+
+from pretalx.common.text.phrases import CALL_FOR_SPEAKER_LOGIN_BTN_LABELS
 from pretalx.orga.signals import html_head, nav_event, nav_event_settings, nav_global
 
+
 SessionStore = import_string(f"{settings.SESSION_ENGINE}.SessionStore")
+logger = logging.getLogger(__name__)
 
 
 def collect_signal(signal, kwargs):
@@ -23,12 +31,26 @@ def orga_events(request):
     # Extract site specific values from settings.CONFIG.items('site') and add them to the context
     # This is a bit of a hack, but it's the only way to get the site specific values into the context
     # rather than using the settings object directly in the template
-    site_config = dict(settings.CONFIG.items("site"))
+    config = cast(RawConfigParser, settings.CONFIG)
+    site_config = dict(config.items("site"))
     context["site_config"] = site_config
     context["base_path"] = settings.BASE_PATH
+    # Login button label
+    try:
+        key = site_config["call_for_speaker_login_button_label"]
+    except KeyError:
+        key = "default"
+    try:
+        button_label = CALL_FOR_SPEAKER_LOGIN_BTN_LABELS[key]
+    except KeyError:
+        logger.warning("%s does not exist in CALL_FOR_SPEAKER_LOGIN_BTN_LABELS", key)
+        button_label = CALL_FOR_SPEAKER_LOGIN_BTN_LABELS["default"]
+    context["login_button_label"] = button_label
 
     if not request.path_info.startswith("/orga/"):
-        return {}
+        return {
+            "login_button_label": button_label,
+        }
 
     if not getattr(request, "user", None) or not request.user.is_authenticated:
         return context


### PR DESCRIPTION
Many pages share a common button template, so we need to compute it in context processors.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes part of #276

This PR fixes the button label first.
For the top-right "login" link, I haven't figured out how it should be yet.

## How has this been tested?

![image](https://github.com/user-attachments/assets/f49280de-91da-46f4-b27f-380df0e7254e)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
