### PR TITLE
Fix: Speaker name in Talk is overwritten

### DIFF
--- a/src/pretalx/common/middleware/event.py
+++ b/src/pretalx/common/middleware/event.py
@@ -78,7 +78,7 @@ class EventPermissionMiddleware:
                 user, created = User.objects.get_or_create(email=payload["email"])
                 if created:
                     user.set_unusable_password()
-                logger.info("JWT payload: %s", payload)
+                logger.debug("JWT payload: %s", payload)
                 upstream_name = payload.get("name", "")
                 # Only update user's name if it's not set.
                 if not user.name and upstream_name:

--- a/src/pretalx/common/middleware/event.py
+++ b/src/pretalx/common/middleware/event.py
@@ -78,7 +78,7 @@ class EventPermissionMiddleware:
                 user, created = User.objects.get_or_create(email=payload["email"])
                 if created:
                     user.set_unusable_password()
-                logger.info('JWT payload: %s', payload)
+                logger.info("JWT payload: %s", payload)
                 upstream_name = payload.get("name", "")
                 # Only update user's name if it's not set.
                 if not user.name and upstream_name:
@@ -89,7 +89,7 @@ class EventPermissionMiddleware:
                 user.timezone = payload.get("timezone", user.timezone)
                 user.code = payload.get("customer_identifier", user.code)
                 user.save()
-                logger.info('Saved new data for user: %s', user.email)
+                logger.info("Saved new data for user: %s", user.email)
                 login(
                     request, user, backend="django.contrib.auth.backends.ModelBackend"
                 )

--- a/src/pretalx/common/middleware/event.py
+++ b/src/pretalx/common/middleware/event.py
@@ -78,13 +78,18 @@ class EventPermissionMiddleware:
                 user, created = User.objects.get_or_create(email=payload["email"])
                 if created:
                     user.set_unusable_password()
-                user.name = payload.get("name", "")
+                logger.info('JWT payload: %s', payload)
+                upstream_name = payload.get("name", "")
+                # Only update user's name if it's not set.
+                if not user.name and upstream_name:
+                    user.name = upstream_name
                 user.is_active = True
                 user.is_staff = payload.get("is_staff", False)
                 user.locale = payload.get("locale", user.locale)
                 user.timezone = payload.get("timezone", user.timezone)
                 user.code = payload.get("customer_identifier", user.code)
                 user.save()
+                logger.info('Saved new data for user: %s', user.email)
                 login(
                     request, user, backend="django.contrib.auth.backends.ModelBackend"
                 )


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #278 

Check if user name has a value, before update it with the value from JWT when logging in.

## How has this been tested?

Before logging out, speaker name is "Quan Outlook"
![image](https://github.com/user-attachments/assets/aafde99c-eade-4643-8695-290f4e5f7f4c)

Logging out
![image](https://github.com/user-attachments/assets/0c462397-475f-4d2c-80c4-eb35507522d8)

Logging in again: The name is still as before.
![image](https://github.com/user-attachments/assets/513a15b4-60ce-4a6f-9c1a-53022b014a57)

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
