### PR TITLE
Disable the subheader login link when there is already login button

### DIFF
--- a/src/pretalx/cfp/views/auth.py
+++ b/src/pretalx/cfp/views/auth.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import logging
 
 from django.conf import settings
 from django.contrib import messages
@@ -20,6 +21,7 @@ from pretalx.common.views import GenericLoginView, GenericResetView
 from pretalx.person.models import User
 
 SessionStore = import_string(f"{settings.SESSION_ENGINE}.SessionStore")
+logger = logging.getLogger(__name__)
 
 
 class LogoutView(View):
@@ -42,6 +44,7 @@ class LoginView(GenericLoginView):
 
     def dispatch(self, request, *args, **kwargs):
         if not request.event.is_public:
+            logger.info("Event %s is not public. Blocking access.", request.event.slug)
             raise Http404()
         return super().dispatch(request, *args, **kwargs)
 
@@ -58,6 +61,8 @@ class LoginView(GenericLoginView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["register_url"] = settings.EVENTYAY_TICKET_BASE_PATH
+        # We already have a primary login button in this page, disable the subheader login link.
+        context["subheader_login_link_disabled"] = True
         return context
 
 

--- a/src/pretalx/common/templates/common/base.html
+++ b/src/pretalx/common/templates/common/base.html
@@ -139,7 +139,7 @@
                                     </form>
                                 </div>
                             </details>
-                        {% elif not is_html_export %}
+                        {% elif not subheader_login_link_disabled and not is_html_export %}
                             {% if request.event %}
                                 <a href="{{ request.event.urls.login }}?next={{ request.path|urlencode }}">login</a>
                             {% else %}


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #276 

The issue is that, in the _/talk/\<event\>/login/_ page, we have a login button and a top-right login link, which lead to different locations (and hence, different behavior).

The top-right link is global and seems to serve different purpose (for upstream pretalx setup), I don't know how to change its location in a safe way (to not break other pages and to keep it easy to maintain). So I choose to hide it in the _/talk/\<event\>/login/_. This page already have a prominent login button which we want users to focus in, having more link will confuse users.

To do this, I introduce a context variable `subheader_login_link_disabled`, to be passed to templates and let the link show / hide according to this variable.
I name it `subheader` because calling it `top-right` will confuse the Arabic UI user. In the future, we may support right-to-left languages and when displaying in those languages, the layout will be switched, the login link will be rendered on the left side.

## How has this been tested?

![image](https://github.com/user-attachments/assets/554975a7-d5fb-494c-b2bb-9ad796fbe04b)

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

This pull request disables the subheader login link on the event login page to avoid user confusion caused by having multiple login links. It introduces a context variable to control the visibility of the subheader login link.

Bug Fixes:
- Fixes an issue where the login page for an event displayed two login links, potentially confusing users.

Enhancements:
- Introduces a `subheader_login_link_disabled` context variable to control the visibility of the subheader login link in templates.