### PR TITLE
Fix: Page width is wider than necessary

### DIFF
--- a/src/pretalx/cfp/templates/cfp/event/submission_base.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_base.html
@@ -67,7 +67,7 @@
                             </button>
                             <button type="submit" class="btn btn-link text-center" name="action" value="draft">
                                 {% translate "or save as draft for now" %}
-                                <i class="fa fa-question-circle" data-toggle="tooltip" title="{% translate "You can save your proposal as a draft and submit it later. Organisers will not be able to see your proposal, though they will be able to send you reminder emails about the upcoming deadline." %}"></i>
+                                <i class="fa fa-question-circle" title="{% translate "You can save your proposal as a draft and submit it later. Organisers will not be able to see your proposal, though they will be able to send you reminder emails about the upcoming deadline." %}"></i>
                             </button>
                         {% endif %}
                     </div>


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #266 

Due to wrong usage of tooltip library, the page is wider than necessary and cause horizontal scroll just for blank margin.

To have a quick fix, I delete the usage of tooltip. We will recover it in the future, because the CSS seems to be messy.

## How has this been tested?

![image](https://github.com/user-attachments/assets/e9baceb2-2a9e-46ed-b432-9ab79453cc28)


## Checklist

- [ ] I have added tests to cover my changes.
