### PR TITLE
Fix: Django not detect that our site is HTTPS

### DIFF
--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -597,6 +597,9 @@ STORAGES = {
     },
 }
 
+# We need this for Django to detect correctly that our website is served via HTTPS
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 VITE_DEV_SERVER_PORT = 8080
 VITE_DEV_SERVER = f"http://localhost:{VITE_DEV_SERVER_PORT}"
 VITE_DEV_MODE = DEBUG


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #267 

Add `SECURE_PROXY_SSL_HEADER` settings. This guides Django to look into Nginx header to detect that our website is in HTTPS. We need this settings because the TLS termination is done on Nginx, not on Django, so Django originally cannot know if our site is HTTP or HTTPS.

## How has this been tested?

This is the page where user see the link:

![image](https://github.com/user-attachments/assets/de1f7d6c-c477-49b9-bd97-0847adea2b57)

Before this PR, user will see this after clicking the link:

![image](https://github.com/user-attachments/assets/32c5a713-bef6-4727-915b-4282b6d76592)


User no longer sees this page after this PR.

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where Django was unable to detect that the site was being served over HTTPS due to TLS termination occurring at the Nginx proxy level.