### PR TITLE
Add `less` command to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
             supervisor \
             sudo \
             locales \
+            less \
             --no-install-recommends && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
@@ -18,7 +19,7 @@ RUN apt-get update && \
     mkdir /public && \
     groupadd -g $GID pretalxuser && \
     useradd -r -u $UID -g pretalxuser -d /pretalx -ms /bin/bash pretalxuser && \
-    echo 'pretalxuser ALL=(ALL) NOPASSWD:SETENV: /usr/bin/supervisord' >> /etc/sudoers
+    echo 'pretalxuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 ENV LC_ALL=C.UTF-8
 ENV BASE_PATH=/talk

--- a/deployment/docker/pretalx.bash
+++ b/deployment/docker/pretalx.bash
@@ -55,7 +55,7 @@ if [ "$AUTOMIGRATE" = "yes" ]; then
 fi
 
 if [ "$1" == "all" ]; then
-    exec sudo /usr/bin/supervisord -n -c /etc/supervisord.conf
+    exec sudo -E /usr/bin/supervisord -n -c /etc/supervisord.conf
 fi
 
 if [ "$1" == "webworker" ]; then


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #283 
This PR also enables `pretixuser` to run any command with `sudo`. Before that, this user cannot run `supervisorctl`, cannot view the logs written down by `supervisord`.

## How has this been tested?

Can use `less` with `sudo`:

![image](https://github.com/user-attachments/assets/df3b861f-f1d5-4db2-9e2f-bbe7e741d733)

With `less`, can search with highlight in logs

![image](https://github.com/user-attachments/assets/fba6cf59-13af-4233-a0ac-68154ba8d4b6)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Add the `less` command to the Docker image and grant the `pretixuser` unrestricted sudo privileges.

Build:
- Add the `less` command to the Docker image.
- Grant the `pretixuser` unrestricted sudo privileges to allow executing commands like `supervisorctl` and viewing logs.