### PR TITLE
Fix: User name is overwritten when logging in via Wikimedia SSO

### DIFF
--- a/src/pretalx/eventyay_common/views/auth.py
+++ b/src/pretalx/eventyay_common/views/auth.py
@@ -136,7 +136,10 @@ def oauth2_callback(request):
     user, created = User.objects.get_or_create(email=user_info["email"])
     if created:
         user.set_unusable_password()
-    user.name = user_info.get("name", "")
+    upstream_name = user_info.get("name", "")
+    # Only update user's name if it's not set.
+    if not user.name and upstream_name:
+        user.name = user_info.get("name", "")
     user.is_active = True
     user.is_staff = user_info.get("is_staff", False)
     user.locale = user_info.get("locale", None)


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

More fix for #278 

The previous fix #279 is not enough, because it solves the case that user logins with email address.
This PR solves the case when user logins via Wikimedia SSO

## How has this been tested?

There is no screenshot because I cannot reproduce the bug in my localhost: Wikimedia refuses logging-in, may be because the domain I use for localhost is not valid.

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where a user's name was overwritten when logging in via Wikimedia SSO, by only updating the user's name if it is not already set.