### PR TITLE
Show avatar_source, avatar_license fields

### DIFF
--- a/src/pretalx/common/templates/common/avatar.html
+++ b/src/pretalx/common/templates/common/avatar.html
@@ -26,6 +26,18 @@
         </div>
     </div>
 </div>
+<div class="avatar-form form-group row">
+    <label class="col-md-3 col-form-label">{{ _('Profile picture source') }}</label>
+    <div class="col-md-9">
+        {{ form.avatar_source.as_widget }}
+    </div>
+</div>
+<div class="avatar-form form-group row">
+    <label class="col-md-3 col-form-label">{{ _('Profile picture license') }}</label>
+    <div class="col-md-9">
+        {{ form.avatar_license.as_widget }}
+    </div>
+</div>
 
 {% compress css %}
     <link rel="stylesheet" href="{% static "common/css/avatar.css" %}">

--- a/src/pretalx/orga/views/cfp.py
+++ b/src/pretalx/orga/views/cfp.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from collections import defaultdict
 
 from csp.decorators import csp_update
@@ -53,6 +54,8 @@ from pretalx.submission.models import (
     SubmitterAccessCode,
     Track,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class CfPTextDetail(PermissionRequired, ActionFromUrl, UpdateView):
@@ -802,9 +805,11 @@ class CfPFlowEditor(EventPermissionRequired, TemplateView):
         return ctx
 
     def post(self, request, *args, **kwargs):
+        # TODO: Improve validation
         try:
             data = json.loads(request.body.decode())
-        except Exception:
+        except json.JSONDecodeError as e:
+            logger.warning("Request body is not JSON: %s", e)
             return JsonResponse({"error": "Invalid data"}, status=400)
 
         flow = CfPFlow(self.request.event)

--- a/src/pretalx/person/forms.py
+++ b/src/pretalx/person/forms.py
@@ -214,6 +214,8 @@ class SpeakerProfileForm(
 
         if not self.event.cfp.request_avatar:
             self.fields.pop("avatar", None)
+            self.fields.pop("avatar_source", None)
+            self.fields.pop("avatar_license", None)
             self.fields.pop("get_gravatar", None)
         elif "avatar" in self.fields:
             self.fields["avatar"].required = False


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #287 

## How has this been tested?

In CFP submision form

![image](https://github.com/user-attachments/assets/c57698ee-edf3-4c8b-9d6d-f83aa1188bf1)

In profile page

![image](https://github.com/user-attachments/assets/2f108cf1-ef14-419f-b2fd-b42521c5a332)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

New Features:
- Adds fields for specifying the source and license of profile pictures in the CFP submission form and profile page.