### PR TITLE
Fix: pretalx is mentioned in irrelevant context

### DIFF
--- a/src/pretalx/cfp/views/locale.py
+++ b/src/pretalx/cfp/views/locale.py
@@ -52,7 +52,7 @@ class LocaleSet(View):
                     str(
                         _(
                             "Your locale preferences have been saved. We like to think that we have excellent support "
-                            "for English in pretalx, but if you encounter issues or errors, please contact us!"
+                            "for English, but if you encounter issues or errors, please contact us!"
                         )
                     ),
                 )


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #289 

## How has this been tested?

![image](https://github.com/user-attachments/assets/776c8759-c92f-4460-8a8b-5b2f58041380)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Bug Fixes:
- Remove the mention of 'pretalx' from the locale preferences saved message to make it more generic.