### PR TITLE
Fix: Customized field label not loaded

### DIFF
--- a/src/pretalx/cfp/forms/cfp.py
+++ b/src/pretalx/cfp/forms/cfp.py
@@ -38,4 +38,3 @@ class CfPFormMixin:
             )
         if field_data.get("label"):
             field.label = field_data["label"]
-            logger.info("field.label: %s", field.label)

--- a/src/pretalx/cfp/forms/cfp.py
+++ b/src/pretalx/cfp/forms/cfp.py
@@ -1,3 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 class CfPFormMixin:
     """All forms used in the CfP step process should use this mixin.
 
@@ -33,3 +38,4 @@ class CfPFormMixin:
             )
         if field_data.get("label"):
             field.label = field_data["label"]
+            logger.info("field.label: %s", field.label)

--- a/src/pretalx/cfp/views/user.py
+++ b/src/pretalx/cfp/views/user.py
@@ -63,14 +63,19 @@ class ProfileView(LoggedInEventPageMixin, TemplateView):
     @cached_property
     def profile_form(self):
         bind = is_form_bound(self.request, "profile")
+        cfp_flow_config = self.request.event.cfp_flow.config
+        try:
+            # TODO: There may be a mismatch somewhere else between how the config was saved and how it is loaded.
+            # We should use Pydantic model for saving and loading, to make sure the data is consistent.
+            field_configuration = cfp_flow_config["steps"]["profile"]["fields"]
+        except KeyError:
+            field_configuration = None
         return SpeakerProfileForm(
             user=self.request.user,
             event=self.request.event,
             read_only=False,
             with_email=False,
-            field_configuration=self.request.event.cfp_flow.config.get(
-                "profile", {}
-            ).get("fields"),
+            field_configuration=field_configuration,
             data=self.request.POST if bind else None,
             files=self.request.FILES if bind else None,
         )

--- a/src/pretalx/common/templates/common/avatar.html
+++ b/src/pretalx/common/templates/common/avatar.html
@@ -27,13 +27,13 @@
     </div>
 </div>
 <div class="avatar-form form-group row">
-    <label class="col-md-3 col-form-label">{{ _('Profile picture source') }}</label>
+    <label class="col-md-3 col-form-label">{{ form.avatar_source.field.label }}</label>
     <div class="col-md-9">
         {{ form.avatar_source.as_widget }}
     </div>
 </div>
 <div class="avatar-form form-group row">
-    <label class="col-md-3 col-form-label">{{ _('Profile picture license') }}</label>
+    <label class="col-md-3 col-form-label">{{ form.avatar_license.field.label }}</label>
     <div class="col-md-9">
         {{ form.avatar_license.as_widget }}
     </div>

--- a/src/pretalx/orga/views/cfp.py
+++ b/src/pretalx/orga/views/cfp.py
@@ -816,5 +816,6 @@ class CfPFlowEditor(EventPermissionRequired, TemplateView):
         if "action" in data and data["action"] == "reset":
             flow.reset()
         else:
+            logger.debug("Saving new CfP flow configuration: %s", data)
             flow.save_config(data)
         return JsonResponse({"success": True})


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #287

After the previous PR, one issue remains: The field appears in Profile view with original label, instead of the customized.
This PR is to fix that.

## How has this been tested?

The organizer customized field label:
![image](https://github.com/user-attachments/assets/9d4ea62a-f36b-49c2-86f7-b619796b9d95)

The customized label is shown in profile view:

![image](https://github.com/user-attachments/assets/c9f17b8e-99d0-4806-887c-85cbbc2d503f)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Fixes an issue where customized field labels were not being loaded in the profile view. This was due to an incorrect path being used to retrieve the field configuration.

Bug Fixes:
- Fixes an issue where customized field labels were not being loaded in the profile view.
- Ensures that customized field labels are displayed correctly in the profile view by correctly retrieving the field configuration.