### PR TITLE
Fix duplicate avatar source field

### DIFF
--- a/src/pretalx/cfp/templates/cfp/event/user_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_profile.html
@@ -33,6 +33,8 @@
         {% if request.event.cfp.request_avatar %}
             {% include "common/avatar.html" with user=request.user form=profile_form %}
         {% endif %}
+        {% if profile_form.avatar_source %}{{ profile_form.avatar_source.as_field_group }}{% endif %}
+        {% if profile_form.avatar_license %}{{ profile_form.avatar_license.as_field_group }}{% endif %}
         {% if profile_form.availabilities %}
             {% include "common/availabilities.html" %}
             {{ profile_form.availabilities.as_field_group }}

--- a/src/pretalx/cfp/views/wizard.py
+++ b/src/pretalx/cfp/views/wizard.py
@@ -13,7 +13,6 @@ from pretalx.cfp.views.event import EventPageMixin
 from pretalx.common.exceptions import SendMailException
 from pretalx.common.text.phrases import phrases
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -60,7 +59,7 @@ class SubmitWizard(EventPageMixin, View):
         if getattr(step, "is_before", False):  # The current step URL is incorrect
             raise Http404()
         handler = getattr(step, request.method.lower(), self.http_method_not_allowed)
-        logger.info('Handler: %s', handler)
+        logger.debug("Handler: %s", handler)
         result = handler(request)
 
         if request.method == "POST" and request.POST.get("action", "submit") == "draft":

--- a/src/pretalx/cfp/views/wizard.py
+++ b/src/pretalx/cfp/views/wizard.py
@@ -14,6 +14,9 @@ from pretalx.common.exceptions import SendMailException
 from pretalx.common.text.phrases import phrases
 
 
+logger = logging.getLogger(__name__)
+
+
 class SubmitStartView(EventPageMixin, View):
     @staticmethod
     def get(request, *args, **kwargs):
@@ -57,6 +60,7 @@ class SubmitWizard(EventPageMixin, View):
         if getattr(step, "is_before", False):  # The current step URL is incorrect
             raise Http404()
         handler = getattr(step, request.method.lower(), self.http_method_not_allowed)
+        logger.info('Handler: %s', handler)
         result = handler(request)
 
         if request.method == "POST" and request.POST.get("action", "submit") == "draft":

--- a/src/pretalx/common/templates/common/avatar.html
+++ b/src/pretalx/common/templates/common/avatar.html
@@ -26,18 +26,6 @@
         </div>
     </div>
 </div>
-<div class="avatar-form form-group row">
-    <label class="col-md-3 col-form-label">{{ form.avatar_source.field.label }}</label>
-    <div class="col-md-9">
-        {{ form.avatar_source.as_widget }}
-    </div>
-</div>
-<div class="avatar-form form-group row">
-    <label class="col-md-3 col-form-label">{{ form.avatar_license.field.label }}</label>
-    <div class="col-md-9">
-        {{ form.avatar_license.as_widget }}
-    </div>
-</div>
 
 {% compress css %}
     <link rel="stylesheet" href="{% static "common/css/avatar.css" %}">

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -77,6 +77,8 @@
         {% if form.avatar %}
             {% include "common/avatar.html" with user=form.instance.user form=form %}
         {% endif %}
+        {% if form.avatar_source %}{{ form.avatar_source.as_field_group }}{% endif %}
+        {% if form.avatar_license %}{{ form.avatar_license.as_field_group }}{% endif %}
 
         {% if form.biography %}
             {{ form.biography.as_field_group }}


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #294 

I follow other templates to move two fields off the _common/avatar.html_ file.

## How has this been tested?

![image](https://github.com/user-attachments/assets/d3244174-0281-49bb-ac40-f78f5384e6e6)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where the avatar source field was duplicated in the user profile and speaker forms.