### PR TITLE
Remove redundant prefix in email subject

### DIFF
--- a/src/pretalx/submission/models/submission.py
+++ b/src/pretalx/submission/models/submission.py
@@ -995,12 +995,11 @@ class Submission(GenerateCode, PretalxModel):
         from pretalx.mail.models import QueuedMail
 
         if not _from and (not subject or not text):
-            raise Exception("Please enter a sender for this invitation.")
+            raise ValueError("Please enter a sender for this invitation.")
 
         subject = subject or phrases.cfp.invite_subject.format(
             speaker=_from.get_display_name()
         )
-        subject = f"[{self.event.slug}] {subject}"
         text = text or phrases.cfp.invite_text.format(
             event=self.event.name,
             title=self.title,
@@ -1053,7 +1052,7 @@ class SubmissionFavouriteDeprecatedSerializer(serializers.ModelSerializer):
     def save(self, user_id, talk_code):
         with scopes_disabled():
             user = get_object_or_404(User, id=user_id)
-            submission_fav, created = (
+            submission_fav, _created = (
                 SubmissionFavouriteDeprecated.objects.get_or_create(user=user)
             )
             submission_fav.talk_list = talk_code


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #302 

## How has this been tested?

![image](https://github.com/user-attachments/assets/0ade8c82-4e32-45a7-a4c0-c174433b22c4)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Bug Fixes:
- Fixes issue where email subjects for invitations included a redundant event slug prefix.