### PR TITLE
Add Persian Localization Support for pretalx

### DIFF
--- a/src/pretalx/locale/fa_IR/django.po
+++ b/src/pretalx/locale/fa_IR/django.po
@@ -1,0 +1,6767 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Goudarz Jafari <me@goudarzjafari.com>, 2025.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-03-05 10:10+0000\n"
+"PO-Revision-Date: 2025-03-15 10:47+0330\n"
+"Last-Translator: Goudarz Jafari <me@goudarzjafari.com>\n"
+"Language-Team: \n"
+"Language: fa_IR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n==0 || n==1);\n"
+"X-Generator: Poedit 3.5\n"
+
+#: tests/screenshots/conftest.py:42 pretalx/mail/context.py:247
+msgid "Jane Doe"
+msgstr "فلان شخص"
+
+#: tests/screenshots/conftest.py:95 pretalx/orga/templates/orga/base.html:458
+msgid "Organisers"
+msgstr "برگزارکنندگان"
+
+#: tests/screenshots/conftest.py:106
+msgid "John Doe"
+msgstr "فلان شخص"
+
+#: pretalx/agenda/phrases.py:8
+msgid "Thank you for your feedback!"
+msgstr "از بازخورد شما متشکریم!"
+
+#: pretalx/agenda/phrases.py:9
+msgid "Thanks, we (and our speakers) appreciate your feedback!"
+msgstr "متشکریم، ما (و سخنرانان) از بازخورد شما قدردانی می‌کنیم!"
+
+#: pretalx/agenda/phrases.py:11
+msgid "This session will not be recorded."
+msgstr "این جلسه ضبط نخواهد شد."
+
+#: pretalx/agenda/phrases.py:13
+msgid "View conference schedule"
+msgstr "مشاهده برنامه زمان‌بندی کنفرانس"
+
+#: pretalx/agenda/phrases.py:14
+msgid "View schedule preview"
+msgstr "مشاهده پیش‌نمایش برنامه زمان‌بندی"
+
+#: pretalx/agenda/phrases.py:15
+msgid "Edit or view your proposals"
+msgstr "طرح‌های پیشنهادی خود را ویرایش یا مشاهده کنید"
+
+#: pretalx/agenda/templates/agenda/base.html:43
+msgid "Tickets"
+msgstr "بلیط‌ها"
+
+#: pretalx/agenda/templates/agenda/base.html:48
+msgid "Videos"
+msgstr "ویدیوها"
+
+#: pretalx/agenda/templates/agenda/base.html:57
+msgid "This schedule-related page is non-public. Only organisers can see it."
+msgstr "این صفحه مرتبط با برنامه عمومی نیست. فقط برگزارکنندگان می‌توانند آن را ببینند."
+
+#: pretalx/agenda/templates/agenda/changelog_block.html:14
+msgid "We have new sessions!"
+msgstr "ما جلسات جدید داریم!"
+
+#: pretalx/agenda/templates/agenda/changelog_block.html:24
+msgid "We have a new session: "
+msgstr "ما یک جلسه جدید داریم: "
+
+#: pretalx/agenda/templates/agenda/changelog_block.html:34
+msgid "Sadly, we had to cancel sessions:"
+msgstr "متأسفانه، مجبور شدیم جلسه‌ها را لغو کنیم:"
+
+#: pretalx/agenda/templates/agenda/changelog_block.html:42
+msgid "We sadly had to cancel a session: "
+msgstr "متأسفانه، مجبور شدیم یک جلسه را لغو کنیم: "
+
+#: pretalx/agenda/templates/agenda/changelog_block.html:51
+msgid "We had to move some sessions, so if you were planning on seeing them, check their new dates or locations:"
+msgstr "ما مجبور شدیم برخی جلسه‌ها را جابجا کنیم، بنابراین اگر قصد دیدن آنها را داشتید، تاریخ یا مکان جدیدشان را بررسی کنید:"
+
+#: pretalx/agenda/templates/agenda/changelog_block.html:69
+msgid "We have moved a session around: "
+msgstr "ما یک جلسه را جابجا کرده‌ایم: "
+
+#: pretalx/agenda/templates/agenda/featured.html:14
+msgid "Welcome to our list of featured sessions!"
+msgstr "به فهرست جلسه‌های برجسته ما خوش آمدید!"
+
+#: pretalx/agenda/templates/agenda/featured.html:17
+msgid "We prepared a list of exciting sessions, so you can get a feel for our conference. Please keep in mind that this is not our full schedule. We will follow up with the full schedule in time, stay tuned!"
+msgstr "ما فهرستی از جلسه‌های هیجان‌انگیز آماده کرده‌ایم تا نگاهی به کنفرانس ما داشته باشید. لطفا توجه داشته باشید که این برنامه زمان‌بندی کامل ما نیست. به‌موقع برنامه زمان‌بندی کامل را ارائه خواهیم داد، منتظر بمانید!"
+
+#: pretalx/agenda/templates/agenda/featured.html:23
+msgid "In the near future you will see a curated list of sessions we’d like to show off here. Right now we are busy reviewing proposals.<br> Check back later!"
+msgstr "در آینده نزدیک، فهرتسی انتخابی از جلسه‌هایی که می‌خواهیم به نمایش بگذاریم را اینجا خواهید دید. در حال حاضر مشغول بررسی طرح‌های پیشنهادی هستیم.<br> دوباره سر بزنید!"
+
+#: pretalx/agenda/templates/agenda/feed/description.html:5
+#, python-format
+msgid "A new %(event_name)s schedule has been released!"
+msgstr "برنامه جدید %(event_name)s منتشر شده است!"
+
+#: pretalx/agenda/templates/agenda/feed/description.html:9
+#, python-format
+msgid "The first %(event_name)s schedule has been released!"
+msgstr "اولین برنامه %(event_name)s منتشر شده است!"
+
+#: pretalx/agenda/templates/agenda/feedback.html:9 pretalx/cfp/templates/cfp/event/user_submissions.html:137 pretalx/orga/templates/orga/base.html:299 pretalx/orga/templates/orga/submission/base.html:67 pretalx/orga/templates/orga/submission/feedbacks_list.html:16 pretalx/submission/models/feedback.py:36
+msgid "Feedback"
+msgstr "بازخورد"
+
+#: pretalx/agenda/templates/agenda/feedback.html:20
+msgid "This review is for you personally, not for all speakers in this session."
+msgstr "این بازخورد برای شما به طور شخصی است، نه برای تمام سخنرانان این جلسه."
+
+#: pretalx/agenda/templates/agenda/feedback_form.html:17
+msgid "Reviews are a valuable tool for speakers to improve their content and presentation. Even a short review can prove valuable to a speaker! Please take the time and communicate your feedback in a constructive way."
+msgstr "بازخوردها ابزار ارزشمندی برای سخنرانان هستند تا محتوای خود و ارائه‌شان را بهبود دهند. حتی یک بازخورد کوتاه می‌تواند برای یک سخنران مفید باشد! لطفا وقت بگذارید و بازخورد خود را به‌صورت سازنده بیان کنید."
+
+#: pretalx/agenda/templates/agenda/feedback_form.html:24
+msgid "You can’t give feedback for this session at this time."
+msgstr "در حال حاضر نمی‌توانید برای این جلسه بازخورد ارائه دهید."
+
+#: pretalx/agenda/templates/agenda/header_row.html:18
+msgid "This is a ticketed event. If you ordered a ticket as a guest user, you don't have an account but can still access the ticket using the secret link in your ticket confirmation email. On the tickets page there is also a link to join online sessions."
+msgstr "این یک رویداد بلیط‌دار است. اگر به عنوان کاربر مهمان بلیط تهیه کرده‌اید، حساب کاربری ندارید، اما هنوز می‌توانید با استفاده از پیوند مخفی در رایانامه تایید بلیط خود به بلیط دسترسی پیدا کنید. در صفحه بلیط‌ها همچنین پیوندی برای پیوستن به جلسه‌های آنلاین وجود دارد."
+
+#: pretalx/agenda/templates/agenda/header_row.html:21
+msgid "As a ticket holder please also check your email for the unique link to join online sessions."
+msgstr "به عنوان دارنده بلیط لطفا رایانامه خود را برای پیوند یکتای پیوستن به جلسه‌های آنلاین بررسی کنید."
+
+#: pretalx/agenda/templates/agenda/header_row.html:24
+msgid "Can't find your ticket?"
+msgstr "نمی‌توانید بلیط خود را پیدا کنید؟"
+
+#: pretalx/agenda/templates/agenda/header_row.html:26
+msgid "Resend the email"
+msgstr "رایانامه را دوباره ارسال کنید"
+
+#: pretalx/agenda/templates/agenda/header_row.html:28
+msgid "to receive it."
+msgstr "تا آن را دریافت کنید."
+
+#: pretalx/agenda/templates/agenda/header_row.html:31
+msgid "Want to order a ticket?"
+msgstr "می‌خواهید بلیط تهیه دهید؟"
+
+#: pretalx/agenda/templates/agenda/header_row.html:33
+msgid "Get a ticket here"
+msgstr "بلیط را از اینجا دریافت کنید"
+
+#: pretalx/agenda/templates/agenda/header_row.html:48
+msgid "Some configurations is missing for video setting, please contact organizer."
+msgstr "برخی تنظیمات برای ویدیو وجود ندارد، لطفا با برگزارکننده تماس بگیرید."
+
+#: pretalx/agenda/templates/agenda/schedule.html:22
+msgid "Changelog"
+msgstr "فهرست تغییرات"
+
+#: pretalx/agenda/templates/agenda/schedule.html:76
+#, python-format
+msgid "To see our schedule, please either enable JavaScript or go <a href=\"%(href)s\">here</a> for our NoJS schedule."
+msgstr "برای مشاهده برنامه زمان‌بندی ما لطفا جاوااسکریپت را فعال کنید یا <a href=\\\"%(href)s\\\">اینجا</a> را برای برنامه زمان‌بندی بدون جاوااسکریپت مشاهده کنید."
+
+#: pretalx/agenda/templates/agenda/schedule_nojs.html:21
+#, python-format
+msgid "To see our schedule with full functionality, like timezone conversion and personal scheduling, please enable JavaScript and go <a href=\"%(href)s\">here</a>."
+msgstr "برای دیدن برنامه زمان‌بندی ما با تمام قابلیت‌ها، مانند تبدیل منطقه زمان‌بندی و زمان‌بندی شخصی، لطفا جاوااسکریپت را فعال کنید و به <a href=\\\"%(href)s\\\">اینجا</a> بروید."
+
+#: pretalx/agenda/templates/agenda/schedule_nojs.html:77
+#, python-format
+msgid "No sessions on %(weekday)s, %(current_day)s."
+msgstr "هنوز هیچ جلسه‌ای در %(weekday)s، %(current_day)s وجود ندارد."
+
+#: pretalx/agenda/templates/agenda/session_block.html:12
+#, python-format
+msgid "%(minutes)smin"
+msgstr "%(minutes)s دقیقه"
+
+#: pretalx/agenda/templates/agenda/speaker.html:51 pretalx/agenda/templates/agenda/speakers.html:18 pretalx/agenda/templates/agenda/speakers.html:20 pretalx/agenda/templates/agenda/talk.html:166 pretalx/orga/templates/orga/submission/speakers.html:38
+msgid "The speaker’s profile picture"
+msgstr "تصویر نمایه سخنران"
+
+#: pretalx/agenda/templates/agenda/speaker.html:69
+msgid "Session"
+msgid_plural "Sessions"
+msgstr[0] "جلسه"
+msgstr[1] "جلسه‌ها"
+
+#: pretalx/agenda/templates/agenda/talk.html:48
+msgid "Favourite this session"
+msgstr "افزودن این جلسه به علاقه‌مندی‌ها"
+
+#: pretalx/agenda/templates/agenda/talk.html:49
+msgid "Remove this session from your favourites"
+msgstr "حذف این جلسه از علاقه‌مندی‌ها"
+
+#: pretalx/agenda/templates/agenda/talk.html:100
+msgid "This session’s header image"
+msgstr "تصویر سربرگ این جلسه"
+
+#: pretalx/agenda/templates/agenda/talk.html:137
+msgid "See also:"
+msgstr "همچنین ببینید:"
+
+#: pretalx/agenda/templates/agenda/talk.html:179
+msgid "This speaker also appears in:"
+msgstr "این سخنران همچنین در اینجا دیده می‌شود:"
+
+#: pretalx/agenda/views/schedule.py:192
+msgid "Our schedule is not live yet."
+msgstr "برنامه زمان‌بندی ما هنوز منتشر نشده است."
+
+#: pretalx/agenda/views/schedule.py:256
+msgid "You're currently not logged in, so your favourited talks will only be stored locally in your browser."
+msgstr "شما در حال حاضر در وبگاه وارد نشده‌اید، بنابراین سخنرانی‌های علاقه‌مند شما فقط در مرورگر شما ذخیره می‌شود."
+
+#: pretalx/agenda/views/schedule.py:259
+msgid "Your favourites could only be saved locally in your browser."
+msgstr "علاقه‌مندی‌های شما فقط می‌توانند به صورت محلی در مرورگر شما ذخیره شوند."
+
+#: pretalx/agenda/views/talk.py:138
+#, python-brace-format
+msgid "The session “{title}” at {event}"
+msgstr "جلسه «{title}» در {event}"
+
+#: pretalx/api/templates/rest_framework/api.html:18 pretalx/orga/templates/orga/auth/base.html:29
+msgid "The eventyay logo"
+msgstr "آرم eventyay"
+
+#: pretalx/cfp/flow.py:350
+msgid "Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr "پیش‌نویس شما ذخیره شد. شما می‌توانید تا زمان‌بندی که فراخوان برای طرح پیشنهادی باز است، به ویرایش آن ادامه دهید."
+
+#: pretalx/cfp/flow.py:358
+msgid "Congratulations, you’ve submitted your proposal! You can continue to make changes to it up to the submission deadline, and you will be notified of any changes or questions."
+msgstr "تبریک می‌گوییم، شما طرح پیشنهادی خود را ارسال کرده‌اید! شما می‌توانید تا زمان مهلت ارسال تغییراتی در آن ایجاد کنید و از هرگونه تغییر یا سوالی مطلع خواهید شد."
+
+#: pretalx/cfp/flow.py:388
+msgid "Hey, nice to meet you!"
+msgstr "سلام، خوشحالم که شما را ملاقات می‌کنم!"
+
+#: pretalx/cfp/flow.py:393
+msgid "We’re glad that you want to contribute to our event with your proposal. Let’s get started, this won’t take long."
+msgstr "خوشحالیم که می‌خواهید با طرح پیشنهادی خود در رویداد ما مشارکت داشته باشید. بیایید شروع کنیم، این کار زیاد طول نمی‌کشد."
+
+#: pretalx/cfp/flow.py:452
+msgid "Tell us more!"
+msgstr "بیشتر به ما بگویید!"
+
+#: pretalx/cfp/flow.py:457
+msgid "Before we can save your proposal, we have some more questions for you."
+msgstr "قبل از اینکه بتوانیم طرح پیشنهادی شما را ذخیره کنیم، چند سوال دیگر از شما داریم."
+
+#: pretalx/cfp/flow.py:481
+msgid "There was an error when logging in. Please contact the organiser for further help."
+msgstr "خطایی هنگام ورود رخ داد. لطفا برای کمک بیشتر با برگزارکننده تماس بگیرید."
+
+#: pretalx/cfp/flow.py:490
+msgid "Account"
+msgstr "حساب کاربری"
+
+#: pretalx/cfp/flow.py:495
+msgid "That’s it about your proposal! We now just need a way to contact you."
+msgstr "این همه چیز درباره طرح پیشنهادی شماست! اکنون فقط به راهی برای تماس با شما نیاز داریم."
+
+#: pretalx/cfp/flow.py:501
+msgid "To create your proposal, you need an account on this page. This not only gives us a way to contact you, it also gives you the possibility to edit your proposal or to view its current state."
+msgstr "برای ایجاد طرح پیشنهادی خود، به یک حساب کاربری در این صفحه نیاز دارید. این نه تنها راهی برای تماس با شما به ما می‌دهد، بلکه امکان ویرایش طرح پیشنهادی‌تان یا مشاهده وضعیت فعلی آن را نیز فراهم می‌کند."
+
+#: pretalx/cfp/flow.py:543
+msgid "Profile"
+msgstr "نمایه"
+
+#: pretalx/cfp/flow.py:547
+msgid "Tell us something about yourself!"
+msgstr "چیزی درباره خودتان به ما بگویید!"
+
+#: pretalx/cfp/flow.py:552
+msgid "This information will be publicly displayed next to your session - you can always edit for as long as proposals are still open."
+msgstr "این اطلاعات به صورت عمومی در کنار جلسه شما نمایش داده خواهد شد - تا زمان‌بندی که طرح‌های پیشنهادی باز هستند می‌توانید آن را ویرایش کنید."
+
+#: pretalx/cfp/phrases.py:7
+msgid "Go to CfP"
+msgstr "به قسمت فراخوان برای طرح پیشنهادی بروید"
+
+#: pretalx/cfp/phrases.py:10
+msgid "If we know a user by this email address (who has not requested a password reset in the last 24 hours), we will send you an email containing further instructions. If you don’t see the email within the next minutes, check your spam inbox!"
+msgstr "اگر کاربری با این نشانی رایانامه بشناسیم (که در ۲۴ ساعت گذشته درخواست بازنشانی گذرواژه نکرده است)، رایانامه‌ای حاوی دستورالعمل‌های بیشتر برای شما ارسال خواهیم کرد. اگر رایانامه را در دقایق آینده مشاهده نکردید، پوشه هرزنامه خود را بررسی کنید!"
+
+#: pretalx/cfp/phrases.py:14
+msgid "This link was not valid. Make sure you copied the complete URL from the email and that the email is no more than 24 hours old."
+msgstr "این پیوند معتبر نبود. اطمینان حاصل کنید که نشانی اینترنتی کامل را از رایانامه کپی کرده‌اید و رایانامه بیش از ۲۴ ساعت پیش ارسال نشده است."
+
+#: pretalx/cfp/phrases.py:17
+msgid "Awesome! You can now log in using your new password."
+msgstr "عالی! اکنون می‌توانید با استفاده از گذرواژه جدید خود وارد شوید."
+
+#: pretalx/cfp/phrases.py:19
+msgid "Your API token has been regenerated. The previous token will not be usable any longer."
+msgstr "توکن API شما دوباره تولید شده است. توکن قبلی دیگر قابل استفاده نیست."
+
+#: pretalx/cfp/phrases.py:23
+msgid "Your proposal has been withdrawn."
+msgstr "طرح پیشنهادی شما پس‌گرفته شده است."
+
+#: pretalx/cfp/phrases.py:25
+msgid "Your proposal can’t be withdrawn at this time – please contact us if you need to withdraw your proposal!"
+msgstr "در حال حاضر نمی‌توان طرح پیشنهادی شما را بازپس‌گیری کرد – اگر نیاز به بازپس‌گیری طرح پیشنهادی‌تان دارید، لطفا با ما تماس بگیرید!"
+
+#: pretalx/cfp/phrases.py:28
+msgid "Your session has been confirmed – we’re looking forward to seeing you!"
+msgstr "جلسه شما تایید شده است – منتظر دیدار شما هستیم!"
+
+#: pretalx/cfp/phrases.py:31
+msgid "This proposal has already been confirmed – we’re looking forward to seeing you!"
+msgstr "این طرح پیشنهادی قبلا تایید شده است – منتظر دیدار شما هستیم!"
+
+#: pretalx/cfp/phrases.py:34
+msgid "This proposal cannot be confirmed at this time – please contact us if you think this is an error."
+msgstr "این طرح پیشنهادی در حال حاضر نمی‌تواند تایید شود – اگر فکر می‌کنید اشتباهی رخ داده است، لطفا با ما تماس بگیرید."
+
+#: pretalx/cfp/phrases.py:36
+msgid "This proposal cannot be edited anymore."
+msgstr "این طرح پیشنهادی دیگر نمی‌تواند ویرایش شود."
+
+#: pretalx/cfp/phrases.py:38 pretalx/cfp/phrases.py:63
+msgid "Speaker email"
+msgstr "رایانامه سخنران"
+
+#: pretalx/cfp/phrases.py:39 pretalx/cfp/phrases.py:64
+#, python-brace-format
+msgid "{speaker} invites you to join their session!"
+msgstr "{speaker} شما را به پیوستن به جلسه‌شان دعوت می‌کند!"
+
+#: pretalx/cfp/phrases.py:41 pretalx/cfp/phrases.py:66
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"\n"
+"I’d like to invite you to be a speaker in the session\n"
+"\n"
+"  “{title}”\n"
+"\n"
+"at {event}. Please follow this link to join:\n"
+"\n"
+"  {url}\n"
+"\n"
+"I’m looking forward to it!\n"
+"{speaker}"
+msgstr ""
+"سلام!\n"
+"\n"
+"مایلم شما را به عنوان سخنران در جلسه‌ای دعوت کنم\n"
+"\n"
+"  «{title}»\n"
+"\n"
+"در {event}. لطفا برای پیوستن به این پیوند مراجعه کنید:\n"
+"\n"
+"  {url}\n"
+"\n"
+"منتظر شما هستم!\n"
+"{speaker}"
+
+#: pretalx/cfp/phrases.py:54
+msgid "Please provide a valid email address."
+msgstr "لطفا یک نشانی رایانامه معتبر ارائه دهید."
+
+#: pretalx/cfp/phrases.py:55
+msgid "The invitation was sent!"
+msgstr "دعوت‌نامه ارسال شد!"
+
+#: pretalx/cfp/phrases.py:57
+msgid "You are now part of this proposal! Please fill in your profile below."
+msgstr "شما اکنون بخشی از این طرح پیشنهادی هستید! لطفا نمایه خود را در زیر پر کنید."
+
+#: pretalx/cfp/phrases.py:61
+msgid "We are experiencing difficulties when sending mails, but your session was submitted successfully!"
+msgstr "هنگام ارسال رایانامه‌ها با مشکلاتی مواجه هستیم، اما جلسه شما با موفقیت ارسال شد!"
+
+#: pretalx/cfp/phrases.py:79 pretalx/orga/templates/orga/cfp/question_view.html:7 pretalx/orga/templates/orga/cfp/question_view.html:26 pretalx/orga/templates/orga/submission/content.html:88
+msgid "Questions"
+msgstr "سوالات"
+
+#: pretalx/cfp/templates/cfp/event/cfp.html:24
+#, python-format
+msgid "You can enter proposals until %(deadline)s (%(timezone)s), %(until_string)s from now."
+msgstr "می‌توانید تا %(until_string)s از اکنون، طرح‌های پیشنهادی را تا %(deadline)s (%(timezone)s) وارد کنید."
+
+#: pretalx/cfp/templates/cfp/event/cfp.html:28
+#, python-format
+msgid "This Call for Papers closed on %(deadline)s (%(timezone)s)."
+msgstr "این فراخوان برای طرح‌های پیشنهادی در %(deadline)s (%(timezone)s) بسته شده است."
+
+#: pretalx/cfp/templates/cfp/event/cfp.html:54
+msgid "View or edit speaker profile"
+msgstr "نمایه سخنران را مشاهده یا ویرایش کنید"
+
+#: pretalx/cfp/templates/cfp/event/cfp.html:62
+msgid "Submit a proposal"
+msgstr "یک طرح پیشنهادی ارسال کنید"
+
+#: pretalx/cfp/templates/cfp/event/cfp.html:64 pretalx/cfp/views/wizard.py:47
+msgid "Proposals are closed"
+msgstr "طرح‌های پیشنهادی بسته شده‌اند"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11 pretalx/submission/models/submission.py:55
+msgid "accepted"
+msgstr "پذیرفته‌شده"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13 pretalx/submission/models/submission.py:56
+msgid "confirmed"
+msgstr "تایید‌شده"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15 pretalx/submission/models/submission.py:58
+msgid "canceled"
+msgstr "لغوشده"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17 pretalx/submission/models/submission.py:59
+msgid "withdrawn"
+msgstr "بازپس‌گرفته‌شده"
+
+#: pretalx/cfp/templates/cfp/event/index.html:36
+msgid "Go To Organiser Area"
+msgstr "به بخش برگزارکننده بروید"
+
+#: pretalx/cfp/templates/cfp/event/invitation.html:6 pretalx/cfp/templates/cfp/event/invitation.html:9
+msgid "Accept invitation?"
+msgstr "آیا دعوت‌نامه را می‌پذیرید؟"
+
+#: pretalx/cfp/templates/cfp/event/invitation.html:13
+msgid "Unfortunately, you cannot accept this invitation at the moment. This may be because the invitation has expired, or because the proposal cannot be edited any more."
+msgstr "متاسفانه، در حال حاضر نمی‌توانید این دعوت‌نامه را بپذیرید. ممکن است دعوت‌نامه منقضی شده باشد یا طرح پیشنهادی دیگر قابل ویرایش نباشد."
+
+#: pretalx/cfp/templates/cfp/event/invitation.html:20
+msgid "Please contact the conference organizers for more information."
+msgstr "برای اطلاعات بیشتر لطفا با برگزارکنندگان کنفرانس تماس بگیرید."
+
+#: pretalx/cfp/templates/cfp/event/invitation.html:26
+#, python-format
+msgid "You, %(name)s, have been invited to be a speaker for the session “%(talk)s”. Do you accept the invitation?"
+msgstr "شما، %(name)s، برای سخنرانی در جلسه «%(talk)s» دعوت شده‌اید. آیا این دعوت را می‌پذیرید؟"
+
+#: pretalx/cfp/templates/cfp/event/invitation.html:34
+msgid "Abstract:"
+msgstr "چکیده:"
+
+#: pretalx/cfp/templates/cfp/event/invitation.html:43 pretalx/event/models/event.py:588 pretalx/submission/models/question.py:424 pretalx/submission/models/submission.py:949
+msgid "No"
+msgstr "خیر"
+
+#: pretalx/cfp/templates/cfp/event/invitation.html:44
+msgid "Accept invitation"
+msgstr "پذیرش دعوت"
+
+#: pretalx/cfp/templates/cfp/event/login.html:5 pretalx/common/text/phrases.py:111
+msgid "Login"
+msgstr "ورود"
+
+#: pretalx/cfp/templates/cfp/event/login.html:8
+msgid "Welcome back!"
+msgstr "خوش آمدید!"
+
+#: pretalx/cfp/templates/cfp/event/login.html:10
+msgid "If you already created a proposal for a different event on this server, you can re-use your account to log in for this event."
+msgstr "اگر پیش‌تر پیشنهادی برای رویدادی دیگر در این سرور ایجاد کرده‌اید، می‌توانید از حساب کاربری خود برای ورود به این رویداد استفاده کنید."
+
+#: pretalx/cfp/templates/cfp/event/login.html:15
+msgid "You do not need an account to view the event, submit feedback, or receive schedule updates. An account is only necessary if you want to create your own personalized schedule, or if you are participating in the event as a speaker or organizer."
+msgstr "برای مشاهده رویداد، ارسال بازخورد یا دریافت به‌روزرسانی‌های برنامه زمان‌بندی به حساب کاربری نیاز ندارید. حساب کاربری تنها در صورتی لازم است که بخواهید یک برنامه زمان‌بندی شخصی‌سازی‌شده ایجاد کنید یا در رویداد به عنوان سخنران یا برگزارکننده شرکت کنید."
+
+#: pretalx/cfp/templates/cfp/event/recover.html:25
+msgid "Set your password to access your profile and proposals"
+msgstr "گذرواژه خود را تنظیم کنید تا به نمایه و طرح‌های پیشنهادی خود دسترسی داشته باشید"
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:10 pretalx/orga/templates/orga/submission/content.html:27
+msgid "Create proposal"
+msgstr "ایجاد طرح پیشنهادی"
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:36
+msgid "Done!"
+msgstr "انجام شد!"
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
+msgid "Save as draft"
+msgstr "ذخیره به عنوان پیش‌نویس"
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:63
+msgid "Continue"
+msgstr "ادامه"
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:65
+msgid "Submit proposal!"
+msgstr "ارسال طرح پیشنهادی!"
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:69
+msgid "or save as draft for now"
+msgstr "یا فعلا به عنوان پیش‌نویس ذخیره کنید"
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:70
+msgid "You can save your proposal as a draft and submit it later. Organisers will not be able to see your proposal, though they will be able to send you reminder emails about the upcoming deadline."
+msgstr "می‌توانید طرح پیشنهادی خود را به عنوان پیش‌نویس ذخیره کرده و بعدا ارسال کنید. برگزارکنندگان نمی‌توانند طرح پیشنهادی شما را ببینند، اما می‌توانند رایانامه‌های یادآوری درباره مهلت نزدیک ارسال کنند."
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:85
+msgid "You need to be logged in to submit a proposal"
+msgstr "برای ارسال طرح پیشنهادی باید وارد حساب کاربری شوید"
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:86
+msgid "Please log in or create an account to submit a proposal. This enables us to contact you and allows you to edit your proposal or check its status at any time."
+msgstr "لطفا وارد شوید یا یک حساب کاربری ایجاد کنید تا بتوانید طرح پیشنهادی خود را ارسال کنید. این به ما امکان تماس با شما را می‌دهد و به شما اجازه می‌دهد طرح پیشنهادی خود را ویرایش کنید یا وضعیت آن را در هر زمان بررسی کنید."
+
+#: pretalx/cfp/templates/cfp/event/submission_questions.html:13
+msgid "… about your proposal:"
+msgstr "... درباره طرح پیشنهادی شما:"
+
+#: pretalx/cfp/templates/cfp/event/submission_questions.html:21
+msgid "… about yourself:"
+msgstr "... درباره خودتان:"
+
+#: pretalx/cfp/templates/cfp/event/submission_user.html:8
+msgid "Sign in or register to save your draft"
+msgstr "وارد شوید یا نام‌نویسی کنید تا پیش‌نویس خود را ذخیره کنید"
+
+#: pretalx/cfp/templates/cfp/event/submission_user.html:17
+msgid "Organisers will not be able to see your draft or your email address. They will be able to send you reminders about your pending proposal draft closer to the deadline."
+msgstr "برگزارکنندگان نمی‌توانند پیش‌نویس شما یا نشانی رایانامه شما را ببینند. آن‌ها می‌توانند نزدیک به مهلت، یادآورهایی درباره پیش‌نویس طرح پیشنهادی در انتظار شما ارسال کنند."
+
+#: pretalx/cfp/templates/cfp/event/user_mails.html:4 pretalx/cfp/templates/cfp/event/user_mails.html:7
+msgid "Your Emails"
+msgstr "رایانامه‌های شما"
+
+#: pretalx/cfp/templates/cfp/event/user_mails.html:9
+msgid "These are emails the organisers sent you, so you should be able to find them in your email inbox, but this page serves as a helper in case your email address was unavailable or the emails got lost in some way."
+msgstr "این‌ها رایانامه‌هایی هستند که برگزارکنندگان برای شما ارسال کرده‌اند، بنابراین باید بتوانید آن‌ها را در صندوق ورودی رایانامه خود پیدا کنید، اما این صفحه به عنوان یک ابزار کمکی عمل می‌کند در صورتی که نشانی رایانامه شما در دسترس نبوده یا رایانامه‌ها به نحوی گم شده باشند."
+
+#: pretalx/cfp/templates/cfp/event/user_profile.html:7 pretalx/cfp/templates/cfp/event/user_profile.html:21
+msgid "Your Profile"
+msgstr "نمایه شما"
+
+#: pretalx/cfp/templates/cfp/event/user_profile.html:23
+msgid "This data will be displayed publicly if your proposal is accepted. It is also visible to reviewers."
+msgstr "این داده‌ها در صورت پذیرش پیشنهاد شما به صورت عمومی نمایش داده خواهند شد. همچنین برای بررسی‌کنندگان قابل مشاهده هستند."
+
+#: pretalx/cfp/templates/cfp/event/user_profile.html:53
+msgid "We have some questions"
+msgstr "ما چند سوال داریم"
+
+#: pretalx/cfp/templates/cfp/event/user_profile.html:68
+msgid "Your Account"
+msgstr "حساب کاربری شما"
+
+#: pretalx/cfp/templates/cfp/event/user_profile.html:69
+msgid "You can change your log in data here."
+msgstr "می‌توانید اطلاعات ورود خود را اینجا تغییر دهید."
+
+#: pretalx/cfp/templates/cfp/event/user_profile.html:90
+msgid "Account deletion"
+msgstr "حذف حساب کاربری"
+
+#: pretalx/cfp/templates/cfp/event/user_profile.html:95
+msgid "You can delete your account here – all names, emails, and other personal information will be overwritten. <strong>This action is irreversible.</strong>"
+msgstr "می‌توانید حساب خود را اینجا حذف کنید – تمام نام‌ها، رایانامه‌ها و سایر اطلاعات شخصی بازنویسی خواهند شد. <strong>این عمل غیرقابل برگشت است.</strong>"
+
+#: pretalx/cfp/templates/cfp/event/user_profile.html:101
+msgid "I really do want to delete my account, losing access to my proposals and sessions, and overriding my public and private data."
+msgstr "من واقعا می‌خواهم حساب کاربری خود را حذف کنم، دسترسی به طرح‌های پیشنهادی و جلساتم را از دست بدهم و داده‌های عمومی و خصوصی من بازنویسی شوند."
+
+#: pretalx/cfp/templates/cfp/event/user_profile.html:108
+msgid "Delete my account"
+msgstr "حذف حساب کاربری من"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:19
+msgid "Congratulations on your acceptance!"
+msgstr "تبریک بابت پذیرش شما!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:23
+msgid "Please provide us with your available hours during the event, so that we can schedule your event accordingly:"
+msgstr "لطفا ساعت‌های در دسترس خود در طول رویداد را به ما اطلاع دهید تا بتوانیم برنامه رویداد شما را به درستی تنظیم کنیم:"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:39
+msgid "By confirming your proposal, you agree that you are able and willing to participate in this event and present the content of this proposal. The proposal data, such as title, abstract, description, and any uploads you provided, can be made publicly available once the proposal is confirmed."
+msgstr "با تایید طرح پیشنهادی خود، می‌پذیرید که توانایی و تمایل به شرکت در این رویداد و ارائه محتوای این طرح پیشنهادی را دارید. داده‌های پیشنهادی، مانند عنوان، چکیده، توضیحات و هرگونه پرونده بارگذاری شده، پس از تایید طرح پیشنهادی می‌توانند عمومی شوند."
+
+#: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:49 pretalx/cfp/templates/cfp/event/user_submission_edit.html:120 pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:22
+msgid "Withdraw"
+msgstr "بازپس‌گیری"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:52 pretalx/cfp/templates/cfp/event/user_submissions.html:132
+msgid "Confirm"
+msgstr "تایید"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_confirm_error.html:7 pretalx/cfp/templates/cfp/event/user_submission_confirm_error.html:11
+msgid "Proposal not found"
+msgstr "طرح پیشنهادی یافت نشد"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_confirm_error.html:13
+msgid "The proposal you’re trying to confirm either does not exist or does not belong to the account you’re currently logged in with. Try logging in with a different account, or contact the event organisers for further information."
+msgstr "طرح پیشنهادی که می‌خواهید تایید کنید یا وجود ندارد یا متعلق به حسابی نیست که اکنون وارد آن شده‌اید. با یک حساب دیگر وارد شوید یا برای اطلاعات بیشتر با برگزارکنندگان رویداد تماس بگیرید."
+
+#: pretalx/cfp/templates/cfp/event/user_submission_discard.html:15
+msgid "Do you really want to discard your draft proposal? All data will be lost."
+msgstr "آیا واقعا می‌خواهید پیش‌نویس طرح پیشنهادی خود را کنار بگذارید؟ تمام داده‌ها از دست خواهند رفت."
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:30
+msgid "Confirm your attendance"
+msgstr "حضور خود را تایید کنید"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+msgid "Audience feedback"
+msgstr "بازخورد مخاطبان"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:37
+msgid "Attendees can leave feedback here after your session has taken place."
+msgstr "حاضران می‌توانند پس از برگزاری جلسه شما، بازخورد خود را در اینجا درج کنند."
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:47 pretalx/orga/templates/orga/submission/content.html:46
+msgid "Speaker"
+msgid_plural "Speakers"
+msgstr[0] "سخنران"
+msgstr[1] "سخنرانان"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:49
+msgid "Submitter"
+msgid_plural "Submitters"
+msgstr[0] "فرستنده"
+msgstr[1] "فرستندگان"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:80
+msgid "Save draft"
+msgstr "ذخیره پیش‌نویس"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:83
+msgid "Submit proposal"
+msgstr "ارسال پیشنهاد"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:99
+msgid "Share proposal"
+msgstr "هم‌رسانی طرح پیشنهادی"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:101
+msgid "If you need a review from a colleague or a friend here’s a link that you can send out for viewing your proposal:"
+msgstr "اگر نیاز به بررسی از سوی یک همکار یا دوست دارید، این پیوند را می‌توانید برای مشاهده طرح پیشنهادی خود ارسال کنید:"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:109 pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:13
+msgid "Withdraw proposal"
+msgstr "بازپس‌گیری طرح پیشنهادی"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:111
+msgid "You can withdraw your proposal from the selection process here. You cannot undo this - if you are just uncertain if you can or should hold your session, please contact the organiser instead."
+msgstr "می‌توانید طرح پیشنهادی خود را از فرآیند انتخاب بازپس‌گیری کنید. این عمل قابل بازگشت نیست - اگر مطمئن نیستید که می‌توانید یا باید جلسه خود را برگزار کنید، لطفا با برگزارکننده تماس بگیرید."
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:125
+msgid "Discard draft proposal"
+msgstr "کنار گذاشتن پیش‌نویس طرح پیشنهادی"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:127
+msgid "You can discard your draft proposal here. You cannot undo this - if you are just uncertain if you can or should submit your proposal, please contact the organiser instead."
+msgstr "می‌توانید پیش‌نویس طرح پیشنهادی خود را اینجا کنار بگذارید. این عمل قابل بازگشت نیست - اگر مطمئن نیستید که می‌توانید یا باید طرح پیشنهادی خود را ارسال کنید، لطفا با برگزارکننده تماس بگیرید."
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:136 pretalx/orga/templates/orga/mails/outbox_form.html:86
+msgid "Discard"
+msgstr "کنار گذاشتن"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:141
+msgid "Cancel proposal"
+msgstr "لغو طرح پیشنهادی"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:143
+msgid "As your proposal has been accepted already, please contact the event’s organising team to cancel it. The best way to reach out would be an answer to your acceptance mail."
+msgstr "از آنجایی که طرح پیشنهادی شما قبلا تایید شده است، لطفا برای لغو آن با تیم برگزارکننده رویداد تماس بگیرید. بهترین راه تماس پاسخ به رایانامه پذیرش شما است."
+
+#: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:22
+msgid "Invite another speaker to your proposal here. Instead of letting us send an email, (which might get caught by spam filters) you can also give them this link:"
+msgstr "در اینجا یک سخنران دیگر را به طرح پیشنهادی خود دعوت کنید. به جای اینکه ما رایانامه‌ای ارسال کنیم (که ممکن است در فیلترهای هرزنامه گرفتار شود)، می‌توانید این پیوند را به آن‌ها بدهید:"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:15
+msgid "Do you really want to withdraw your proposal?"
+msgstr "آیا واقعا می‌خواهید طرح پیشنهادی خود را بازپس‌گیری کنید؟"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:27
+msgid "You will not be able to revert this action."
+msgstr "نمی‌توانید این عمل را بازگردانید."
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:12 pretalx/cfp/templates/cfp/event/user_submissions.html:78
+msgid "Your proposals"
+msgstr "طرح‌های پیشنهادی شما"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+msgid "Important Information"
+msgstr "اطلاعات مهم"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:37
+msgid "Your drafts"
+msgstr "پیش‌نویس‌های شما"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:42 pretalx/cfp/templates/cfp/event/user_submissions.html:84 pretalx/orga/templates/orga/admin/user_detail.html:128 pretalx/orga/templates/orga/cfp/text.html:108 pretalx/orga/templates/orga/review/bulk.html:47 pretalx/orga/templates/orga/review/dashboard.html:190 pretalx/orga/templates/orga/speaker/information_list.html:52
+#: pretalx/orga/templates/orga/submission/list.html:73 pretalx/orga/templates/orga/submission/review.html:52
+msgid "Title"
+msgstr "عنوان"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:58 pretalx/cfp/templates/cfp/event/user_submissions.html:117
+msgid "Copy code for review"
+msgstr "کد را برای بررسی کپی کنید"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:66
+msgid "Edit draft"
+msgstr "ویرایش پیش‌نویس"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:68
+msgid "Open draft"
+msgstr "باز کردن پیش‌نویس"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:85 pretalx/orga/templates/orga/admin/user_detail.html:130 pretalx/orga/templates/orga/review/dashboard.html:107 pretalx/orga/templates/orga/review/dashboard.html:199 pretalx/orga/templates/orga/submission/list.html:86
+msgid "State"
+msgstr "وضعیت"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:125
+msgid "Edit proposal"
+msgstr "ویرایش طرح پیشنهادی"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:127
+msgid "Open proposal"
+msgstr "باز کردن طرح پیشنهادی"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
+msgid "Create a new proposal"
+msgstr "ایجاد یک طرح پیشنهادی جدید"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:153
+msgid "It seems like you haven’t submitted anything to this event yet."
+msgstr "به نظر می‌رسد که هنوز چیزی برای این رویداد ارسال نکرده‌اید."
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:154
+msgid "If you did, maybe you used a different account? Check your emails!"
+msgstr "اگر ارسال کرده‌اید، شاید از یک حساب دیگر استفاده کرده باشید؟ رایانامه‌های خود را بررسی کنید!"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:157
+msgid "If you did not, why not go ahead and create a proposal now? We’d love to hear from you!"
+msgstr "اگر نه، چرا همین حالا یک طرح پیشنهادی ایجاد نمی‌کنید؟ دوست داریم از شما بشنویم!"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:162
+msgid "Submit something now!"
+msgstr "همین حالا چیزی ارسال کنید!"
+
+#: pretalx/cfp/templates/cfp/includes/submission_resources_form.html:9 pretalx/orga/forms/schedule.py:159 pretalx/orga/templates/orga/submission/review.html:120
+msgid "Resources"
+msgstr "منابع"
+
+#: pretalx/cfp/templates/cfp/includes/submission_resources_form.html:13
+msgid "Resources will be publicly visible."
+msgstr "منابع به صورت عمومی قابل مشاهده خواهند بود."
+
+#: pretalx/cfp/templates/cfp/includes/submission_resources_form.html:62
+msgid "This proposal has no resources yet."
+msgstr "این طرح پیشنهادی هنوز منابعی ندارد."
+
+#: pretalx/cfp/templates/cfp/includes/submission_resources_form.html:94
+msgid "You can either provide a URL or upload a file."
+msgstr "می‌توانید یا یک نشانی اینترنتی ارائه دهید یا یک پرونده بارگذاری کنید."
+
+#: pretalx/cfp/templates/cfp/includes/submission_resources_form.html:104
+msgid "Add another resource"
+msgstr "منبع دیگری اضافه کنید"
+
+#: pretalx/cfp/templates/cfp/includes/user_submission_header.html:15
+msgid "Draft"
+msgstr "پیش‌نویس"
+
+#: pretalx/cfp/templates/cfp/includes/user_submission_header.html:20
+msgid "Current state of your proposal:"
+msgstr "وضعیت فعلی طرح پیشنهادی شما:"
+
+#: pretalx/cfp/templates/cfp/includes/user_submission_header.html:27
+msgid "This is a draft proposal. It will never be visible to anybody else, unless you submit it or explicitly share it."
+msgstr "این یک پیش‌نویس طرح پیشنهادی است. این پیش‌نویس هرگز برای کسی دیگر قابل مشاهده نخواهد بود، مگر اینکه آن را ارسال یا به صراحت هم‌رسانی کنید."
+
+#: pretalx/cfp/templates/cfp/includes/user_submission_header.html:46 pretalx/orga/templates/orga/cfp/access_code_view.html:56 pretalx/orga/templates/orga/cfp/submission_type_form.html:12 pretalx/orga/templates/orga/cfp/submission_type_view.html:48 pretalx/orga/templates/orga/review/dashboard.html:97 pretalx/orga/templates/orga/submission/review.html:62 pretalx/orga/views/cfp.py:540
+#: pretalx/submission/models/submission.py:150
+msgid "Session type"
+msgstr "نوع جلسه"
+
+#: pretalx/cfp/templates/cfp/includes/user_submission_header.html:52 pretalx/orga/templates/orga/cfp/access_code_view.html:54 pretalx/orga/templates/orga/cfp/text.html:126 pretalx/orga/templates/orga/cfp/track_form.html:22 pretalx/orga/templates/orga/cfp/track_view.html:49 pretalx/orga/templates/orga/review/dashboard.html:89 pretalx/orga/templates/orga/review/dashboard.html:195
+#: pretalx/orga/templates/orga/submission/review.html:67 pretalx/orga/views/cfp.py:639 pretalx/submission/models/access_code.py:28 pretalx/submission/models/submission.py:156
+msgid "Track"
+msgstr "مسیر"
+
+#: pretalx/cfp/templates/cfp/includes/user_submission_header.html:63 pretalx/orga/templates/orga/cfp/text.html:164 pretalx/orga/templates/orga/review/dashboard.html:93 pretalx/orga/templates/orga/review/dashboard.html:196 pretalx/submission/models/submission.py:210
+msgid "Duration"
+msgstr "مدت زمان"
+
+#: pretalx/cfp/templates/cfp/index.html:4 pretalx/cfp/templates/cfp/index.html:8 pretalx/orga/templates/orga/admin/user_detail.html:87 pretalx/orga/templates/orga/admin/user_list.html:33 pretalx/orga/templates/orga/base.html:451
+msgid "Events"
+msgstr "رویدادها"
+
+#: pretalx/cfp/templates/cfp/index.html:22
+msgid "No events are currently ongoing."
+msgstr "هیچ رویداد فعالی در حال حاضر وجود ندارد."
+
+#: pretalx/cfp/templates/cfp/index.html:25
+msgid "Upcoming events"
+msgstr "رویدادهای آینده"
+
+#: pretalx/cfp/templates/cfp/index.html:38
+msgid "Past events"
+msgstr "رویدادهای گذشته"
+
+#: pretalx/cfp/views/locale.py:47
+msgid "Your locale preferences have been saved."
+msgstr "تنظیمات منطقه‌ای شما ذخیره شد."
+
+#: pretalx/cfp/views/user.py:279
+msgid "Your draft was discarded."
+msgstr "پیش‌نویس شما کنار گذاشته شد."
+
+#: pretalx/cfp/views/user.py:439
+msgid "Your proposal has been submitted."
+msgstr "طرح پیشنهادی شما ارسال شد."
+
+#: pretalx/cfp/views/user.py:454
+msgid "Your account has now been deleted."
+msgstr "حساب کاربری شما اکنون حذف شده است."
+
+#: pretalx/cfp/views/user.py:456
+msgid "Are you really sure? Please tick the box"
+msgstr "آیا مطمئن هستید؟ لطفا این کادر را علامت بزنید"
+
+#: pretalx/cfp/views/user.py:513
+msgid "You cannot accept this invitation."
+msgstr "نمی‌توانید این دعوت را بپذیرید."
+
+#: pretalx/common/forms/fields.py:72
+#, python-brace-format
+msgid "Please do not upload files larger than {size}!"
+msgstr "لطفا پرونده‌هایی بزرگ‌تر از {size} بارگذاری نکنید!"
+
+#: pretalx/common/forms/fields.py:107
+#, python-brace-format
+msgid "This filetype ({extension}) is not allowed, it has to be one of the following: "
+msgstr "این نوع پرونده ({extension}) مجاز نیست، باید یکی از موارد زیر باشد: "
+
+#: pretalx/common/forms/forms.py:12 pretalx/common/forms/widgets.py:208 pretalx/common/templates/common/includes/search_form.html:7 pretalx/orga/templates/orga/base.html:182 pretalx/orga/templates/orga/event_list.html:21 pretalx/orga/templates/orga/includes/submission_filter_form.html:21 pretalx/orga/templates/orga/organiser/list.html:18 pretalx/submission/forms/submission.py:277
+msgid "Search"
+msgstr "جستجو"
+
+#: pretalx/common/forms/mixins.py:39
+msgid "You are trying to change read-only data."
+msgstr "شما در حال تلاش برای تغییر داده‌های فقط خواندنی هستید."
+
+#: pretalx/common/forms/mixins.py:109
+#, python-brace-format
+msgid "Please write between {min_length} and {max_length} words."
+msgstr "لطفا بین {min_length} تا {max_length} کلمه بنویسید."
+
+#: pretalx/common/forms/mixins.py:112
+#, python-brace-format
+msgid "Please write between {min_length} and {max_length} characters."
+msgstr "لطفا بین {min_length} تا {max_length} نویسه بنویسید."
+
+#: pretalx/common/forms/mixins.py:114
+#, python-brace-format
+msgid "Please write at least {min_length} words."
+msgstr "لطفا حداقل {min_length} کلمه بنویسید."
+
+#: pretalx/common/forms/mixins.py:115
+#, python-brace-format
+msgid "Please write at least {min_length} characters."
+msgstr "لطفا حداقل {min_length} نویسه بنویسید."
+
+#: pretalx/common/forms/mixins.py:116
+#, python-brace-format
+msgid "Please write at most {max_length} words."
+msgstr "لطفا حداکثر {max_length} کلمه بنویسید."
+
+#: pretalx/common/forms/mixins.py:117
+#, python-brace-format
+msgid "Please write at most {max_length} characters."
+msgstr "لطفا حداکثر {max_length} نویسه بنویسید."
+
+#: pretalx/common/forms/mixins.py:137
+#, python-brace-format
+msgid "You wrote {count} characters."
+msgstr "شما {count} نویسه نوشته‌اید."
+
+#: pretalx/common/forms/mixins.py:138
+#, python-brace-format
+msgid "You wrote {count} words."
+msgstr "شما {count} کلمه نوشته‌اید."
+
+#: pretalx/common/forms/widgets.py:48
+msgid "This password would take <em class=\"password_strength_time\"></em> to crack."
+msgstr "شکستن این گذرواژه <em class=\"password_strength_time\"></em> طول می‌کشد."
+
+#: pretalx/common/forms/widgets.py:73
+msgid "Warning"
+msgstr "هشدار"
+
+#: pretalx/common/forms/widgets.py:73
+msgid "Your passwords don’t match."
+msgstr "گذرواژه‌های شما با یکدیگر مطابقت ندارند."
+
+#: pretalx/common/log_display.py:28
+#, python-brace-format
+msgid "The event {name} ({slug}) by {organiser} was deleted."
+msgstr "رویداد {name} ({slug}) توسط {organiser} حذف شد."
+
+#: pretalx/common/log_display.py:29
+#, python-brace-format
+msgid "The organiser {name} was deleted."
+msgstr "برگزارکننده {name} حذف شد."
+
+#: pretalx/common/log_display.py:49
+msgid "The CfP has been modified."
+msgstr "فراخوان برای طرح پیشنهادی تغییر یافته است."
+
+#: pretalx/common/log_display.py:50
+msgid "The event has been added."
+msgstr "رویداد افزوده شد."
+
+#: pretalx/common/log_display.py:51
+msgid "The event was modified."
+msgstr "رویداد تغییر داده شد."
+
+#: pretalx/common/log_display.py:52
+msgid "The event was made public."
+msgstr "رویداد عمومی شد."
+
+#: pretalx/common/log_display.py:53
+msgid "The event was deactivated."
+msgstr "رویداد غیرفعال شد."
+
+#: pretalx/common/log_display.py:54
+msgid "A plugin was enabled."
+msgstr "یک افزونه فعال شد."
+
+#: pretalx/common/log_display.py:55
+msgid "A plugin was disabled."
+msgstr "یک افزونه غیرفعال شد."
+
+#: pretalx/common/log_display.py:56
+msgid "The invitation to the event orga was accepted."
+msgstr "دعوت به تیم برگزارکننده رویداد پذیرفته شد."
+
+#: pretalx/common/log_display.py:57
+msgid "An invitation to the event orga was retracted."
+msgstr "یک دعوت به تیم برگزارکننده رویداد پس گرفته شد."
+
+#: pretalx/common/log_display.py:58
+msgid "An invitation to the event orga was sent."
+msgstr "یک دعوت به تیم برگزارکننده رویداد ارسال شد."
+
+#: pretalx/common/log_display.py:60
+msgid "The invitation to the review team was retracted."
+msgstr "دعوت به تیم بازبینی پس گرفته شد."
+
+#: pretalx/common/log_display.py:62
+msgid "The invitation to the review team was sent."
+msgstr "دعوت به تیم بازبینی ارسال شد."
+
+#: pretalx/common/log_display.py:63
+msgid "An email was created."
+msgstr "یک رایانامه ایجاد شد."
+
+#: pretalx/common/log_display.py:64
+msgid "A pending email was deleted."
+msgstr "یک رایانامه در انتظار حذف شد."
+
+#: pretalx/common/log_display.py:65
+msgid "All pending emails were deleted."
+msgstr "تمام رایانامه‌های در انتظار حذف شدند."
+
+#: pretalx/common/log_display.py:66
+msgid "An email was sent."
+msgstr "یک رایانامه ارسال شد."
+
+#: pretalx/common/log_display.py:67
+msgid "An email was modified."
+msgstr "یک رایانامه تغییر داده شد."
+
+#: pretalx/common/log_display.py:68
+msgid "A mail template was added."
+msgstr "یک قالب رایانامه افزوده شد."
+
+#: pretalx/common/log_display.py:69
+msgid "A mail template was deleted."
+msgstr "یک قالب رایانامه حذف شد."
+
+#: pretalx/common/log_display.py:70
+msgid "A mail template was modified."
+msgstr "یک قالب رایانامه تغییر یافت."
+
+#: pretalx/common/log_display.py:71
+msgid "A question was added."
+msgstr "یک سوال اضافه شد."
+
+#: pretalx/common/log_display.py:72
+msgid "A question was deleted."
+msgstr "یک سوال حذف شد."
+
+#: pretalx/common/log_display.py:73
+msgid "A question was modified."
+msgstr "یک سوال تغییر یافت."
+
+#: pretalx/common/log_display.py:74
+msgid "A question option was added."
+msgstr "یک گزینه به سوال اضافه شد."
+
+#: pretalx/common/log_display.py:75
+msgid "A question option was deleted."
+msgstr "یک گزینه از سوال حذف شد."
+
+#: pretalx/common/log_display.py:76
+msgid "A question option was modified."
+msgstr "یک گزینه از سوال تغییر یافت."
+
+#: pretalx/common/log_display.py:77
+msgid "A tag was added."
+msgstr "یک برچسب اضافه شد."
+
+#: pretalx/common/log_display.py:78
+msgid "A tag was deleted."
+msgstr "یک برچسب حذف شد."
+
+#: pretalx/common/log_display.py:79
+msgid "A tag was modified."
+msgstr "یک برچسب تغییر یافت."
+
+#: pretalx/common/log_display.py:80
+msgid "A new room was added."
+msgstr "یک اتاق جدید اضافه شد."
+
+#: pretalx/common/log_display.py:81
+msgid "A new schedule version was released."
+msgstr "یک نسخه جدید از برنامه زمان‌بندی منتشر شد."
+
+#: pretalx/common/log_display.py:82
+msgid "The proposal was accepted."
+msgstr "طرح پیشنهادی پذیرفته شد."
+
+#: pretalx/common/log_display.py:83
+msgid "The proposal was cancelled."
+msgstr "طرح پیشنهادی لغو شد."
+
+#: pretalx/common/log_display.py:84
+msgid "The proposal was confirmed."
+msgstr "طرح پیشنهادی تأیید شد."
+
+#: pretalx/common/log_display.py:85
+msgid "The proposal was added."
+msgstr "طرح پیشنهادی اضافه شد."
+
+#: pretalx/common/log_display.py:86
+msgid "The proposal was deleted."
+msgstr "طرح پیشنهادی حذف شد."
+
+#: pretalx/common/log_display.py:87
+msgid "The proposal was rejected."
+msgstr "طرح پیشنهادی رد شد."
+
+#: pretalx/common/log_display.py:88
+msgid "A proposal resource was added."
+msgstr "یک منبع به طرح پیشنهادی اضافه شد."
+
+#: pretalx/common/log_display.py:89
+msgid "A proposal resource was deleted."
+msgstr "یک منبع از طرح پیشنهادی حذف شد."
+
+#: pretalx/common/log_display.py:90
+msgid "A proposal resource was modified."
+msgstr "یک منبع از طرح پیشنهادی تغییر یافت."
+
+#: pretalx/common/log_display.py:91
+msgid "A speaker was added to the proposal."
+msgstr "یک سخنران به طرح پیشنهادی اضافه شد."
+
+#: pretalx/common/log_display.py:92
+msgid "A speaker was invited to the proposal."
+msgstr "یک سخنران به طرح پیشنهادی دعوت شد."
+
+#: pretalx/common/log_display.py:93
+msgid "A speaker was removed from the proposal."
+msgstr "یک سخنران از طرح پیشنهادی حذف شد."
+
+#: pretalx/common/log_display.py:94
+msgid "The proposal was unconfirmed."
+msgstr "طرح پیشنهادی تأیید نشده بود."
+
+#: pretalx/common/log_display.py:95
+msgid "The proposal was modified."
+msgstr "طرح پیشنهادی تغییر یافت."
+
+#: pretalx/common/log_display.py:96
+msgid "The proposal was withdrawn."
+msgstr "طرح پیشنهادی بازپس‌گرفته شد."
+
+#: pretalx/common/log_display.py:97
+msgid "A proposal answer was modified."
+msgstr "یک پاسخ طرح پیشنهادی تغییر یافت."
+
+#: pretalx/common/log_display.py:98
+msgid "A proposal answer was added."
+msgstr "یک پاسخ به طرح پیشنهادی اضافه شد."
+
+#: pretalx/common/log_display.py:99
+msgid "A session type was added."
+msgstr "یک نوع جلسه اضافه شد."
+
+#: pretalx/common/log_display.py:100
+msgid "A session type was deleted."
+msgstr "یک نوع جلسه حذف شد."
+
+#: pretalx/common/log_display.py:101
+msgid "The session type was made default."
+msgstr "نوع جلسه به پیش‌فرض تغییر یافت."
+
+#: pretalx/common/log_display.py:102
+msgid "A session type was modified."
+msgstr "یک نوع جلسه تغییر یافت."
+
+#: pretalx/common/log_display.py:103
+msgid "An access code was added."
+msgstr "یک کد دسترسی اضافه شد."
+
+#: pretalx/common/log_display.py:104
+msgid "An access code was sent."
+msgstr "یک کد دسترسی ارسال شد."
+
+#: pretalx/common/log_display.py:105
+msgid "An access code was modified."
+msgstr "یک کد دسترسی تغییر یافت."
+
+#: pretalx/common/log_display.py:106
+msgid "An access code was deleted."
+msgstr "یک کد دسترسی حذف شد."
+
+#: pretalx/common/log_display.py:107
+msgid "A track was added."
+msgstr "یک مسیر اضافه شد."
+
+#: pretalx/common/log_display.py:108
+msgid "A track was deleted."
+msgstr "یک مسیر حذف شد."
+
+#: pretalx/common/log_display.py:109
+msgid "A track was modified."
+msgstr "یک مسیر تغییر یافت."
+
+#: pretalx/common/log_display.py:110
+msgid "A speaker has been marked as arrived."
+msgstr "یک سخنران به‌عنوان حاضر علامت‌گذاری شد."
+
+#: pretalx/common/log_display.py:111
+msgid "A speaker has been marked as not arrived."
+msgstr "یک سخنران به‌عنوان غایب علامت‌گذاری شد."
+
+#: pretalx/common/log_display.py:112
+msgid "The API token was reset."
+msgstr "توکن API بازنشانی شد."
+
+#: pretalx/common/log_display.py:114
+msgid "The password was modified."
+msgstr "گذرواژه تغییر یافت."
+
+#: pretalx/common/log_display.py:115
+msgid "The profile was modified."
+msgstr "نمایه تغییر یافت."
+
+#: pretalx/common/log_display.py:151 pretalx/common/log_display.py:155 pretalx/orga/templates/orga/cfp/question_form.html:29 pretalx/orga/templates/orga/cfp/question_view.html:58 pretalx/orga/templates/orga/review/dashboard.html:84 pretalx/orga/views/cfp.py:357
+msgid "Question"
+msgstr "سوال"
+
+#: pretalx/common/log_display.py:162
+msgid "Answer to question"
+msgstr "پاسخ به سوال"
+
+#: pretalx/common/log_display.py:165 pretalx/orga/templates/orga/cfp/text.html:20 pretalx/orga/templates/orga/cfp/text.html:24
+msgid "Call for Proposals"
+msgstr "فراخوان برای طرح پیشنهادی"
+
+#: pretalx/common/log_display.py:168
+msgid "Mail template"
+msgstr "قالب رایانامه"
+
+#: pretalx/common/log_display.py:172 pretalx/event/models/organiser.py:244 pretalx/orga/templates/orga/admin/user_detail.html:49 pretalx/orga/templates/orga/admin/user_list.html:30 pretalx/orga/templates/orga/base.html:226 pretalx/orga/templates/orga/organiser/speaker_list.html:41 pretalx/orga/templates/orga/settings/team_detail.html:34 pretalx/person/models/user.py:91
+msgid "Email"
+msgstr "رایانامه"
+
+#: pretalx/common/models/settings.py:59
+msgid "Please give a fair review on why you’d like to see this proposal at the conference, or why you think it would not be a good fit."
+msgstr "لطفا توضیح دهید چرا می‌خواهید این طرح پیشنهادی در کنفرانس ارائه شود، یا چرا فکر می‌کنید که مناسب نیست."
+
+#: pretalx/common/models/settings.py:72
+#, python-brace-format
+msgid ""
+"Hi,\n"
+"\n"
+"we hope you’re happy with eventyay as your event’s CfP system.\n"
+"These links may be helpful in the coming days and weeks:\n"
+"\n"
+"- Your event’s dashboard: {event_dashboard}\n"
+"- A list of proposals: {event_submissions}\n"
+"- Your schedule editor: {event_schedule}\n"
+"\n"
+"If there is anything you’re missing, come tell us about it\n"
+"at https://github.com/fossasia/eventyay-talk/issues/new or via an\n"
+"email to support@eventyay.com!\n"
+msgstr ""
+"سلام،\n"
+"\n"
+"امیدواریم از eventyay به‌عنوان سیستم فراخوان برای طرح پیشنهادی رویداد خود راضی باشید.\n"
+"این پیوند‌ها ممکن است در روزها و هفته‌های آتی مفید باشند:\n"
+"\n"
+"- پیشخوان رویداد شما: {event_dashboard}\n"
+"- فهرست طرح‌های پیشنهادی: {event_submissions}\n"
+"- ویرایشگر برنامه زمان‌بندی شما: {event_schedule}\n"
+"\n"
+"اگر چیزی کم است، با ما در میان بگذارید\n"
+"از طریق https://github.com/fossasia/eventyay-talk/issues/new یا\n"
+"رایانامه به support@eventyay.com!\n"
+"\n"
+"ترجمه شده به فارسی توسط گودرز جعفری\n"
+
+#: pretalx/common/models/settings.py:93
+#, python-brace-format
+msgid ""
+"Hi,\n"
+"\n"
+"just writing you to let you know that your Call for Participation is now\n"
+"closed. Here is a list of links that should be useful in the next days:\n"
+"\n"
+"- You’ll find a list of all your {submission_count} proposals here:\n"
+"  {event_submissions}\n"
+"- You can add reviewers here:\n"
+"  {event_team}\n"
+"- You can review proposals here:\n"
+"  {event_review}\n"
+"- And create your schedule here, once you have accepted proposals:\n"
+"  {event_schedule}\n"
+msgstr ""
+"سلام،\n"
+"\n"
+"این پیام را می‌نویسیم تا اطلاع دهیم فراخوان مشارکت شما اکنون بسته شده است.\n"
+"در اینجا فهرستی از پیوندهایی آورده شده که در روزهای آینده مفید خواهند بود:\n"
+"\n"
+"- فهرست تمامی {submission_count} طرح‌های پیشنهادی شما را اینجا پیدا می‌کنید:\n"
+"  {event_submissions}\n"
+"- می‌توانید بازبین‌ها را اینجا اضافه کنید:\n"
+"  {event_team}\n"
+"- می‌توانید طرح‌های پیشنهادی را اینجا مرور کنید:\n"
+"  {event_review}\n"
+"- و برنامه زمان‌بندی خود را اینجا ایجاد کنید، زمانی که طرح‌های پیشنهادی را پذیرفتید:\n"
+"  {event_schedule}\n"
+
+#: pretalx/common/models/settings.py:115
+#, python-brace-format
+msgid ""
+"Hi,\n"
+"\n"
+"congratulations, your event is over! Hopefully it went well. Here are some\n"
+"statistics you might find interesting:\n"
+"\n"
+"- You had {submission_count} proposals,\n"
+"- Of which you selected {talk_count} sessions.\n"
+"- The reviewers wrote {review_count} reviews.\n"
+"- You released {schedule_count} schedules in total.\n"
+"- Over the course of the event, you sent {mail_count} mails.\n"
+"\n"
+"If there is anything you’re missing, come tell us about it\n"
+"at https://github.com/fossasia/eventyay-talk/issues/new or via an\n"
+"email to support@eventyay.com!\n"
+msgstr ""
+"سلام،\n"
+"\n"
+"تبریک می‌گوییم، رویداد شما به پایان رسیده است! امیدواریم خوب پیش رفته باشد. در اینجا برخی\n"
+"آمارهایی که ممکن است برای شما جالب باشند آورده شده است:\n"
+"\n"
+"- {submission_count} پیشنهاد داشتید،\n"
+"- که از آن‌ها {talk_count} جلسه انتخاب کردید.\n"
+"- بازبین‌ها {review_count} بازبینی نوشتند.\n"
+"- در مجموع {schedule_count} برنامه زمان‌بندی منتشر کردید.\n"
+"- در طول رویداد، {mail_count} رایانامه ارسال کردید.\n"
+"\n"
+"اگر چیزی کم است، به ما اطلاع دهید\n"
+"از طریق https://github.com/fossasia/eventyay-talk/issues/new یا\n"
+"رایانامه به support@eventyay.com!\n"
+
+#: pretalx/common/phrases.py:42 pretalx/common/text/phrases.py:43
+msgid "Send"
+msgstr "ارسال"
+
+#: pretalx/common/phrases.py:43 pretalx/common/text/phrases.py:44
+msgid "Save"
+msgstr "ذخیره"
+
+#: pretalx/common/phrases.py:44 pretalx/common/text/phrases.py:45
+msgid "Cancel"
+msgstr "لغو"
+
+#. Translators: This is the label on edit buttons.
+#: pretalx/common/phrases.py:46 pretalx/common/text/phrases.py:47
+msgid "Edit"
+msgstr "ویرایش"
+
+#: pretalx/common/phrases.py:47 pretalx/common/text/phrases.py:48
+msgid "all"
+msgstr "همه"
+
+#: pretalx/common/phrases.py:48 pretalx/common/text/phrases.py:49
+msgid "Back"
+msgstr "بازگشت"
+
+#: pretalx/common/phrases.py:49 pretalx/common/text/phrases.py:50
+msgid "Delete"
+msgstr "حذف"
+
+#: pretalx/common/phrases.py:51 pretalx/common/text/phrases.py:52
+msgid "Confirm deletion"
+msgstr "حذف را تایید کنید"
+
+#: pretalx/common/phrases.py:53 pretalx/common/text/phrases.py:54
+msgid "Please make sure that this is the item you want to delete. This action cannot be undone!"
+msgstr "لطفا مطمئن شوید که این همان موردی است که می‌خواهید حذف کنید. این عمل قابل بازگشت نیست!"
+
+#: pretalx/common/phrases.py:56 pretalx/common/text/phrases.py:57
+msgid "Your changes have been saved."
+msgstr "تغییرات شما ذخیره شد."
+
+#: pretalx/common/phrases.py:57 pretalx/common/text/phrases.py:58
+msgid "Please go back and try again."
+msgstr "لطفا بازگردید و دوباره امتحان کنید."
+
+#: pretalx/common/phrases.py:58 pretalx/common/text/phrases.py:59
+msgid "Bad request."
+msgstr "درخواست نامعتبر."
+
+#: pretalx/common/phrases.py:60 pretalx/common/text/phrases.py:61
+msgid "There was an error sending the mail. Please try again later."
+msgstr "هنگام ارسال رایانامه خطایی رخ داد. لطفا بعداً دوباره امتحان کنید."
+
+#: pretalx/common/phrases.py:63 pretalx/common/text/phrases.py:64
+msgid "We had trouble saving your input – Please see below for details."
+msgstr "ما در صرفه‌جویی در ورودی شما مشکل داشتیم - لطفا برای جزئیات بیشتر به زیر مراجعه کنید."
+
+#: pretalx/common/phrases.py:65 pretalx/common/text/phrases.py:66
+msgid "You do not have permission to perform this action."
+msgstr "شما اجازه انجام این عمل را ندارید."
+
+#: pretalx/common/phrases.py:67 pretalx/common/text/phrases.py:68
+msgid "Permission denied."
+msgstr "دسترسی رد شد."
+
+#: pretalx/common/phrases.py:69 pretalx/common/text/phrases.py:70
+msgid "Sorry, you do not have the required permissions to access this page."
+msgstr "متأسفیم، شما دسترسی لازم برای مشاهده این صفحه را ندارید."
+
+#: pretalx/common/phrases.py:71 pretalx/common/text/phrases.py:72
+msgid "Page not found."
+msgstr "صفحه یافت نشد."
+
+#: pretalx/common/phrases.py:73 pretalx/common/text/phrases.py:74
+msgid "This page does not exist."
+msgstr "این صفحه وجود ندارد."
+
+#: pretalx/common/phrases.py:74 pretalx/common/text/phrases.py:75
+msgid "Huh, I could have sworn there was something here."
+msgstr "اوه، مطمئن بودم اینجا چیزی بود."
+
+#: pretalx/common/phrases.py:76 pretalx/common/text/phrases.py:77
+msgid "This page is no more."
+msgstr "این صفحه دیگر وجود ندارد."
+
+#: pretalx/common/phrases.py:77 pretalx/common/text/phrases.py:78
+msgid "This page has ceased to be."
+msgstr "این صفحه از بین رفته است."
+
+#: pretalx/common/phrases.py:78 pretalx/common/text/phrases.py:79
+msgid "Huh."
+msgstr "اوه."
+
+#: pretalx/common/phrases.py:81 pretalx/common/text/phrases.py:82
+msgid "Email address"
+msgstr "نشانی رایانامه"
+
+#: pretalx/common/phrases.py:82 pretalx/common/text/phrases.py:83
+msgid "New password"
+msgstr "گذرواژه جدید"
+
+#: pretalx/common/phrases.py:83 pretalx/common/text/phrases.py:84
+msgid "New password (again)"
+msgstr "گذرواژه جدید (دوباره)"
+
+#: pretalx/common/phrases.py:85 pretalx/common/text/phrases.py:86
+msgid "You entered two different passwords. Please enter the same one twice!"
+msgstr "شما دو گذرواژه متفاوت وارد کرده‌اید. لطفا یک گذرواژه یکسان را دوبار وارد کنید!"
+
+#: pretalx/common/phrases.py:87 pretalx/common/text/phrases.py:88
+msgctxt "noun / heading"
+msgid "Reset password"
+msgstr "بازنشانی گذرواژه"
+
+#: pretalx/common/phrases.py:88 pretalx/common/text/phrases.py:89
+msgid "Forgot your password?"
+msgstr "گذرواژه خود را فراموش کرده‌اید؟"
+
+#: pretalx/common/phrases.py:89 pretalx/common/text/phrases.py:90
+msgid "Let me set a new one!"
+msgstr "اجازه دهید یک گذرواژه جدید تنظیم کنم!"
+
+#: pretalx/common/phrases.py:91 pretalx/common/text/phrases.py:92
+msgid "Now you just need to choose your new password and you are ready to go."
+msgstr "حالا فقط باید گذرواژه جدید خود را انتخاب کنید و آماده باشید."
+
+#: pretalx/common/phrases.py:93 pretalx/common/text/phrases.py:94
+msgid "The password was reset."
+msgstr "گذرواژه بازنشانی شد."
+
+#: pretalx/common/phrases.py:95 pretalx/common/text/phrases.py:96
+#, python-brace-format
+msgid "You can use {link_start}Markdown{link_end} here."
+msgstr "می‌توانید از {link_start}Markdown{link_end} در اینجا استفاده کنید."
+
+#: pretalx/common/phrases.py:99 pretalx/common/text/phrases.py:100
+msgid "This content will be shown publicly."
+msgstr "این محتوا به‌صورت عمومی نمایش داده خواهد شد."
+
+#: pretalx/common/phrases.py:100 pretalx/common/text/phrases.py:101
+msgctxt "opening quotation mark"
+msgid "“"
+msgstr "«"
+
+#: pretalx/common/phrases.py:101 pretalx/common/text/phrases.py:102
+msgctxt "closing quotation mark"
+msgid "”"
+msgstr "»"
+
+#: pretalx/common/phrases.py:102 pretalx/common/text/phrases.py:103 pretalx/submission/models/submission.py:222
+msgid "Language"
+msgstr "زبان"
+
+#: pretalx/common/phrases.py:103 pretalx/common/text/phrases.py:104
+msgid "General"
+msgstr "عمومی"
+
+#: pretalx/common/phrases.py:104 pretalx/common/text/phrases.py:105 pretalx/mail/models.py:66 pretalx/mail/models.py:262 pretalx/person/models/information.py:47
+msgctxt "email subject"
+msgid "Subject"
+msgstr "موضوع"
+
+#: pretalx/common/phrases.py:105 pretalx/common/templates/common/widgets/markdown.html:4 pretalx/common/text/phrases.py:106 pretalx/mail/models.py:69 pretalx/mail/models.py:264 pretalx/person/models/information.py:49
+msgid "Text"
+msgstr "متن"
+
+#: pretalx/common/plugins.py:9
+msgctxt "Type of plugin"
+msgid "Features"
+msgstr "ویژگی‌ها"
+
+#: pretalx/common/plugins.py:10
+msgctxt "Type of plugin"
+msgid "Integrations"
+msgstr "ادغام‌ها"
+
+#: pretalx/common/plugins.py:11
+msgctxt "Type of plugin"
+msgid "Customizations"
+msgstr "سفارشی‌سازی‌ها"
+
+#: pretalx/common/plugins.py:12
+msgid "Exporters"
+msgstr "صادرکننده‌ها"
+
+#: pretalx/common/plugins.py:13
+msgid "Recording integrations"
+msgstr "ادغام‌های ضبط"
+
+#: pretalx/common/plugins.py:14
+msgid "Languages"
+msgstr "زبان‌ها"
+
+#: pretalx/common/plugins.py:15 pretalx/orga/templates/orga/mails/_placeholder_group.html:20
+msgctxt "category of items"
+msgid "Other"
+msgstr "دیگر"
+
+#: pretalx/common/templates/400.html:18
+msgid "It looks as if the communication between you and eventyay went wrong in some way. <br> Please return to the last page and try again!"
+msgstr "به نظر می‌رسد ارتباط بین شما و eventyay به طریقی اشتباه پیش رفته است. <br> لطفا به صفحه قبلی بازگردید و دوباره امتحان کنید!"
+
+#: pretalx/common/templates/403_csrf.html:7 pretalx/common/templates/403_csrf.html:11
+msgid "Verification failed."
+msgstr "تأیید شکست خورد."
+
+#: pretalx/common/templates/403_csrf.html:17
+msgid "We could not verify that this request really was sent by you. For security reasons, we cannot process it. <br> Please go back to the last page, refresh, and then try again."
+msgstr "ما نتوانستیم تأیید کنیم که این درخواست واقعا توسط شما ارسال شده است. به دلایل امنیتی، نمی‌توانیم آن را پردازش کنیم. <br> لطفا به صفحه قبلی بازگردید، آن را تازه کنید و دوباره امتحان کنید."
+
+#: pretalx/common/templates/500.html:7
+msgid "Internal server error."
+msgstr "خطای داخلی سرور."
+
+#: pretalx/common/templates/500.html:11
+msgid "We have encountered an error."
+msgstr "ما با یک خطا روبرو شده‌ایم."
+
+#: pretalx/common/templates/common/auth.html:41
+msgid "Register account"
+msgstr "نام‌نویسی حساب کاربری"
+
+#: pretalx/common/templates/common/avatar.html:7 pretalx/orga/templates/orga/admin/user_detail.html:73 pretalx/orga/templates/orga/cfp/text.html:198 pretalx/person/models/user.py:124
+msgid "Profile picture"
+msgstr "تصویر نمایه"
+
+#: pretalx/common/templates/common/avatar.html:22
+msgid "Your avatar"
+msgstr "آواتار شما"
+
+#: pretalx/common/templates/common/base.html:75
+msgid "This event is currently non-public. Only organisers can see it."
+msgstr "این رویداد در حال حاضر عمومی نیست. فقط برگزارکننده‌ها می‌توانند آن را ببینند."
+
+#: pretalx/common/templates/common/base.html:85 pretalx/orga/templates/orga/auth/base.html:31
+msgid "The event’s logo"
+msgstr "آرم رویداد"
+
+#: pretalx/common/templates/common/base.html:115
+msgid "My proposals"
+msgstr "طرح‌های پیشنهادی من"
+
+#: pretalx/common/templates/common/base.html:119
+msgid "My Emails"
+msgstr "رایانامه‌های من"
+
+#: pretalx/common/templates/common/base.html:123
+msgid "My profile"
+msgstr "نمایه من"
+
+#: pretalx/common/templates/common/base.html:129
+msgid "Organiser area"
+msgstr "منطقه برگزارکننده‌ها"
+
+#: pretalx/common/templates/common/base.html:137
+msgid "Logout"
+msgstr "خروج"
+
+#: pretalx/common/templates/common/base.html:165
+#, python-format
+msgid "This is a static export generated at %(timestamp)s"
+msgstr "این یک خروجی ایستا است که در %(timestamp)s تولید شده است"
+
+#: pretalx/common/templates/common/base.html:173
+msgid "Contact us"
+msgstr "تماس با ما"
+
+#: pretalx/common/templates/common/base.html:177
+msgid "Imprint"
+msgstr "اطلاعات تماس"
+
+#: pretalx/common/templates/common/forms/field.html:7 pretalx/orga/templates/orga/settings/form.html:92 pretalx/orga/templates/orga/settings/form.html:110
+msgid "Optional"
+msgstr "اختیاری"
+
+#: pretalx/common/templates/common/logs.html:17
+msgid "This change was performed by a member of the event orga."
+msgstr "این تغییر توسط یکی از اعضای برگزارکننده رویداد انجام شد."
+
+#: pretalx/common/templates/common/logs.html:23
+msgid "An organiser"
+msgstr "یک برگزارکننده"
+
+#: pretalx/common/templates/common/powered_by.html:36
+#, python-format
+msgid "powered by <a %(a_attr)s>eventyay</a>"
+msgstr "قدرت گرفته از <a %(a_attr)s>eventyay</a>"
+
+#: pretalx/common/templates/common/question_answer.html:9
+msgid "No file provided"
+msgstr "هنوز هیچ پرونده‌ای ارائه نشده است"
+
+#: pretalx/common/templates/common/question_answer.html:16
+msgid "Not answered"
+msgstr "پاسخ داده نشده"
+
+#: pretalx/common/templates/common/redirect.html:7 pretalx/common/templates/common/redirect.html:13
+msgid "Redirect"
+msgstr "انتقال"
+
+#: pretalx/common/templates/common/redirect.html:15
+#, python-format
+msgid "The link you clicked on wants to redirect you to a destination on the website %(host)s."
+msgstr "پیوندی که روی آن کلیک کردید می‌خواهد شما را به مقصدی در وبگاه %(host)s هدایت کند."
+
+#: pretalx/common/templates/common/redirect.html:18
+msgid "Please only proceed if you trust this website to be safe."
+msgstr "لطفا فقط در صورتی ادامه دهید که به ایمنی این وبگاه اعتماد دارید."
+
+#: pretalx/common/templates/common/redirect.html:24
+#, python-format
+msgid "Proceed to %(host)s"
+msgstr "ادامه به %(host)s"
+
+#: pretalx/common/templates/common/user_api_token.html:8
+msgid "API Access"
+msgstr "دسترسی API"
+
+#: pretalx/common/templates/common/user_api_token.html:11
+#, python-format
+msgid "This token can be used to access the <a %(apiurl)s>eventyay API</a>. You can generate a new token, which will invalidate the old one. To find out more, please have a look at the <a %(docurl)s> API documentation</a>."
+msgstr "این توکن می‌تواند برای دسترسی به <a %(apiurl)s>API eventyay</a> استفاده شود. می‌توانید یک توکن جدید تولید کنید که توکن قبلی را نامعتبر خواهد کرد. برای اطلاعات بیشتر، به <a %(docurl)s> مستندات API</a> نگاهی بیاندازید."
+
+#: pretalx/common/templates/common/user_api_token.html:20
+msgid "API Token"
+msgstr "توکن API"
+
+#: pretalx/common/templates/common/user_api_token.html:25
+msgid "Use for authentication when accessing the API."
+msgstr "برای احراز هویت هنگام دسترسی به API استفاده کنید."
+
+#: pretalx/common/templates/common/user_api_token.html:32
+msgid "Generate a new token. The current token will not be usable any longer."
+msgstr "یک توکن جدید تولید کنید. توکن فعلی دیگر قابل استفاده نخواهد بود."
+
+#: pretalx/common/templates/common/user_api_token.html:33
+msgid "Invalidate and regenerate"
+msgstr "نامعتبرسازی و بازتولید"
+
+#: pretalx/common/templates/common/widgets/markdown.html:6
+msgid "Preview"
+msgstr "پیش‌نمایش"
+
+#: pretalx/common/templatetags/copyable.py:13
+msgid "Copy"
+msgstr "کپی"
+
+#: pretalx/common/templatetags/times.py:14
+msgid "once"
+msgstr "یک بار"
+
+#: pretalx/common/templatetags/times.py:16
+msgid "twice"
+msgstr "دو بار"
+
+#: pretalx/common/templatetags/times.py:17
+#, python-brace-format
+msgid "{number} times"
+msgstr "{number} بار"
+
+#: pretalx/common/text/css.py:116
+#, python-brace-format
+msgid "“{value}” is not allowed as attribute of “{key}”"
+msgstr "«{value}» به‌عنوان ویژگی «{key}» مجاز نیست."
+
+#: pretalx/common/text/css.py:122
+#, python-brace-format
+msgid "You are not allowed to include “{key}” keys in your CSS."
+msgstr "شما مجاز به افزودن کلیدهای «{key}» در CSS خود نیستید."
+
+#: pretalx/common/text/daterange.py:68
+#, python-brace-format
+msgid "{date_from} – {date_to}"
+msgstr "{date_from} – {date_to}"
+
+#: pretalx/common/text/phrases.py:112
+msgid "Login with MediaWiki SSO or Email"
+msgstr "ورود با SSO مدیاویکی یا رایانامه"
+
+#: pretalx/common/update_check.py:100
+msgid "pretalx update available"
+msgstr "به‌روزرسانی pretalx در دسترس است"
+
+#: pretalx/common/update_check.py:104
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"\n"
+"An update is available for pretalx or for one of the plugins you installed in your pretalx installation at {base_url}.\n"
+"Please follow this link for more information:\n"
+"\n"
+" {url} \n"
+"\n"
+"You can always find information on the latest updates in the changelog:\n"
+"\n"
+"  https://docs.pretalx.org/changelog.html\n"
+"\n"
+"Larger updates are also announced with upgrade notes on the pretalx.com blog:\n"
+"\n"
+"  https://pretalx.com/p/news\n"
+"\n"
+"Best regards,\n"
+"your pretalx developers"
+msgstr ""
+"سلام!\n"
+"\n"
+"یک به‌روزرسانی برای pretalx یا یکی از افزونه‌هایی که در نصب pretalx خود در {base_url} نصب کرده‌اید موجود است.\n"
+"لطفا برای اطلاعات بیشتر این پیوند را دنبال کنید:\n"
+"\n"
+" {url} \n"
+"\n"
+"شما همیشه می‌توانید اطلاعات مربوط به آخرین به‌روزرسانی‌ها را در تغییرات مشاهده کنید:\n"
+"\n"
+"  https://docs.pretalx.org/changelog.html\n"
+"\n"
+"به‌روزرسانی‌های بزرگ‌تر نیز با یادداشت‌های ارتقاء در وبلاگ pretalx.com اعلام می‌شوند:\n"
+"\n"
+"  https://pretalx.com/p/news\n"
+"\n"
+"با احترام،\n"
+"توسعه‌دهندگان pretalx شما"
+
+#: pretalx/common/update_check.py:145 pretalx/common/update_check.py:152
+msgid "Plugin"
+msgstr "افزونه"
+
+#: pretalx/common/views/mixins.py:274
+msgid "ManagementForm data is missing or has been tampered with."
+msgstr "داده‌های ManagementForm وجود ندارد یا دستکاری شده است."
+
+#: pretalx/event/forms.py:57
+msgid "Please either pick some events for this team, or grant access to all your events!"
+msgstr "لطفا یا چند رویداد برای این تیم انتخاب کنید، یا دسترسی به تمام رویدادهای خود را اعطا کنید!"
+
+#: pretalx/event/forms.py:71
+msgid "Please pick at least one permission for this team!"
+msgstr "لطفا حداقل یک مجوز برای این تیم انتخاب کنید!"
+
+#: pretalx/event/forms.py:104
+msgid "Email addresses"
+msgstr "نشانی‌های رایانامه"
+
+#: pretalx/event/forms.py:105
+msgid "Enter one email address per line."
+msgstr "در هر خط یک نشانی رایانامه وارد کنید."
+
+#: pretalx/event/forms.py:124
+#, python-format
+msgid "“%(email)s” is not a valid email address."
+msgstr "«%(email)s» یک نشانی رایانامه معتبر نیست."
+
+#: pretalx/event/forms.py:134
+msgid "Please enter at least one email address!"
+msgstr "لطفا حداقل یک نشانی رایانامه وارد کنید!"
+
+#: pretalx/event/forms.py:170
+msgid "Use languages"
+msgstr "استفاده از زبان‌ها"
+
+#: pretalx/event/forms.py:171
+msgid "Choose all languages that your event should be available in."
+msgstr "تمام زبان‌هایی که رویداد شما باید در آن‌ها در دسترس باشد را انتخاب کنید."
+
+#: pretalx/event/forms.py:178 pretalx/orga/templates/orga/admin/user_detail.html:86 pretalx/orga/templates/orga/organiser/detail.html:4 pretalx/orga/views/organiser.py:336
+msgid "Organiser"
+msgstr "برگزارکننده"
+
+#: pretalx/event/forms.py:192
+msgid "The organiser running the event can copy settings from previous events and share team permissions across all or multiple events."
+msgstr "برگزارکننده‌ای که رویداد را مدیریت می‌کند می‌تواند تنظیمات را از رویدادهای قبلی کپی کرده و مجوزهای تیم را در تمام یا چند رویداد هم‌رسانی کند."
+
+#: pretalx/event/forms.py:208
+msgid "This is the address your event will be available at. Should be short, only contain lowercase letters and numbers, and must be unique. We recommend some kind of abbreviation with less than 30 characters that can be easily remembered."
+msgstr "این نشانی جایی است که رویداد شما در آن در دسترس خواهد بود. باید کوتاه باشد، فقط حروف کوچک و اعداد را شامل شود و باید منحصر‌به‌فرد باشد. ما یک نوع اختصار با کمتر از ۳۰ نویسه که به راحتی قابل یادآوری باشد را توصیه می‌کنیم."
+
+#: pretalx/event/forms.py:214
+msgid "You cannot change the slug later on!"
+msgstr "شما نمی‌توانید بعدا نامک را تغییر دهید!"
+
+#: pretalx/event/forms.py:224
+msgid "This short name is already taken, please choose another one (or ask the owner of that event to add you to their team)."
+msgstr "این نام کوتاه قبلا انتخاب شده است، لطفا یکی دیگر را انتخاب کنید (یا از مالک آن رویداد بخواهید شما را به تیم‌شان اضافه کند)."
+
+#: pretalx/event/forms.py:244
+msgid "The default deadline for your Call for Papers. You can assign additional deadlines to individual session types, which will take precedence over this deadline."
+msgstr "مهلت پیش‌فرض برای فراخوان برای طرح‌های پیشنهادی شما. شما می‌توانید مهلت‌های اضافی را برای انواع جلسه‌های خاص اختصاص دهید که بر این مهلت اولویت دارند."
+
+#: pretalx/event/forms.py:311
+msgid "Copy configuration from"
+msgstr "کپی تنظیمات از"
+
+#: pretalx/event/forms.py:315 pretalx/orga/templates/orga/event/wizard/copy.html:7
+msgid "You can copy settings from previous events here, such as mail settings, session types, and email templates. Please check those settings once the event has been created!"
+msgstr "می‌توانید تنظیمات را از رویدادهای قبلی اینجا کپی کنید، مانند تنظیمات رایانامه، انواع جلسات و قالب‌های رایانامه. لطفا پس از ایجاد رویداد، آن تنظیمات را بررسی کنید!"
+
+#: pretalx/event/forms.py:318
+msgid "Do not copy"
+msgstr "کپی نکنید"
+
+#: pretalx/event/models/event.py:61
+#, python-brace-format
+msgid "Invalid event slug – this slug is reserved: {value}."
+msgstr "نامک رویداد نامعتبر است – این نامک رزرو شده است: {value}."
+
+#: pretalx/event/models/event.py:156 pretalx/event/models/organiser.py:89 pretalx/orga/templates/orga/admin/admin.html:59 pretalx/orga/templates/orga/admin/user_list.html:29 pretalx/orga/templates/orga/organiser/speaker_list.html:36 pretalx/orga/templates/orga/schedule/room_list.html:36 pretalx/orga/templates/orga/settings/team_detail.html:33
+#: pretalx/orga/templates/orga/speaker/list.html:39 pretalx/person/forms.py:56 pretalx/person/models/user.py:84 pretalx/schedule/models/room.py:24 pretalx/submission/models/review.py:264 pretalx/submission/models/track.py:24
+msgid "Name"
+msgstr "نام"
+
+#: pretalx/event/models/event.py:165 pretalx/event/models/event.py:171 pretalx/event/models/organiser.py:98
+msgid "The slug may only contain letters, numbers, dots and dashes."
+msgstr "نامک تنها می‌تواند شامل حروف، اعداد، نقطه و خط تیره باشد."
+
+#: pretalx/event/models/event.py:170 pretalx/event/models/organiser.py:102
+msgid "Short form"
+msgstr "فرم کوتاه"
+
+#: pretalx/event/models/event.py:179
+msgid "Event is public"
+msgstr "رویداد عمومی است"
+
+#: pretalx/event/models/event.py:180
+msgid "Event start date"
+msgstr "تاریخ شروع رویداد"
+
+#: pretalx/event/models/event.py:181
+msgid "Event end date"
+msgstr "تاریخ پایان رویداد"
+
+#: pretalx/event/models/event.py:187
+msgid "All event dates will be localised and interpreted to be in this timezone."
+msgstr "تمام تاریخ‌های رویداد محلی‌سازی شده و در این منطقه زمانی تفسیر خواهند شد."
+
+#: pretalx/event/models/event.py:191
+msgid "Organiser email address"
+msgstr "نشانی رایانامه برگزارکننده"
+
+#: pretalx/event/models/event.py:192
+msgid "Will be used as Reply-To in emails."
+msgstr "به‌عنوان Reply-To در ایمیل‌ها استفاده خواهد شد."
+
+#: pretalx/event/models/event.py:195
+msgid "Custom domain"
+msgstr "دامنه سفارشی"
+
+#: pretalx/event/models/event.py:196
+msgid "Enter a custom domain, such as https://my.event.example.org"
+msgstr "یک دامنه سفارشی وارد کنید، مانند https://my.event.example.org"
+
+#: pretalx/event/models/event.py:211
+msgid "Main event colour"
+msgstr "رنگ اصلی رویداد"
+
+#: pretalx/event/models/event.py:213
+msgid "Provide a hex value like #00ff00 if you want to style eventyay in your event’s colour scheme."
+msgstr "یک مقدار هگز مانند #00ff00 ارائه دهید اگر می‌خواهید eventyay را در طرح رنگ رویداد خود طراحی کنید."
+
+#: pretalx/event/models/event.py:220
+msgid "Custom Event CSS"
+msgstr "CSS سفارشی رویداد"
+
+#: pretalx/event/models/event.py:222
+msgid "Upload a custom CSS file if changing the primary colour is not sufficient for you."
+msgstr "یک پرونده CSS سفارشی بارگذاری کنید اگر تغییر رنگ اصلی کافی نیست."
+
+#: pretalx/event/models/event.py:229
+msgid "Logo"
+msgstr "آرم"
+
+#: pretalx/event/models/event.py:231
+msgid "If you provide a logo image, your event’s name will not be shown in the event header. The logo will be scaled down to a height of 150px."
+msgstr "اگر یک تصویر آرم ارائه دهید، نام رویداد شما در هدر رویداد نشان داده نخواهد شد. آرم به ارتفاع ۱۵۰ پیکسل مقیاس داده خواهد شد."
+
+#: pretalx/event/models/event.py:239
+msgid "Header image"
+msgstr "تصویر سربرگ"
+
+#: pretalx/event/models/event.py:241
+msgid "If you provide a header image, it will be displayed instead of your event’s color and/or header pattern at the top of all event pages. It will be center-aligned, so when the window shrinks, the center parts will continue to be displayed, and not stretched."
+msgstr "اگر یک تصویر سربرگ ارائه دهید، به جای رنگ و یا الگوی سربرگ رویداد شما در بالای تمام صفحات رویداد نمایش داده خواهد شد. این تصویر مرکزگرا خواهد بود، بنابراین وقتی پنجره کوچک می‌شود، بخش‌های مرکزی همچنان نمایش داده می‌شوند و کشیده نخواهند شد."
+
+#: pretalx/event/models/event.py:252
+msgid "Default language"
+msgstr "زبان پیش‌فرض"
+
+#: pretalx/event/models/event.py:255
+msgid "Landing page text"
+msgstr "متن صفحه ورودی"
+
+#: pretalx/event/models/event.py:257
+msgid "This text will be shown on the landing page, alongside with links to the CfP and schedule, if appropriate."
+msgstr "این متن در صفحه ورودی نمایش داده خواهد شد، همراه با پیوندهای به فراخوان برای طرح پیشنهادی و برنامه، در صورت لزوم."
+
+#: pretalx/event/models/event.py:265
+msgid "Featured sessions text"
+msgstr "متن جلسات برجسته"
+
+#: pretalx/event/models/event.py:267
+msgid "This text will be shown at the top of the featured sessions page instead of the default text."
+msgstr "این متن در بالای صفحه جلسات برجسته به جای متن پیش‌فرض نمایش داده خواهد شد."
+
+#: pretalx/event/models/event.py:274 pretalx/orga/templates/orga/admin/admin.html:106 pretalx/orga/templates/orga/base.html:232 pretalx/orga/templates/orga/plugins.html:5 pretalx/orga/templates/orga/plugins.html:7
+msgid "Plugins"
+msgstr "افزونه‌ها"
+
+#: pretalx/event/models/event.py:277
+msgid "Plain"
+msgstr "ساده"
+
+#: pretalx/event/models/event.py:278
+msgid "Circuits"
+msgstr "مدارها"
+
+#: pretalx/event/models/event.py:279
+msgid "Circles"
+msgstr "دایره‌ها"
+
+#: pretalx/event/models/event.py:280
+msgid "Signal"
+msgstr "سیگنال"
+
+#: pretalx/event/models/event.py:281
+msgid "Topography"
+msgstr "توپوگرافی"
+
+#: pretalx/event/models/event.py:282
+msgid "Graph Paper"
+msgstr "کاغذ شطرنجی"
+
+#: pretalx/event/models/event.py:562 pretalx/event/models/event.py:873 pretalx/event/stages.py:70 pretalx/orga/templates/orga/base.html:223 pretalx/orga/templates/orga/base.html:312 pretalx/orga/templates/orga/base.html:320 pretalx/orga/templates/orga/base.html:333 pretalx/orga/templates/orga/submission/review.html:174
+msgid "Review"
+msgstr "بازبینی"
+
+#: pretalx/event/models/event.py:570
+msgid "Selection"
+msgstr "انتخاب"
+
+#: pretalx/event/models/event.py:583 pretalx/orga/templates/orga/review/dashboard.html:60 pretalx/orga/templates/orga/submission/review.html:169 pretalx/submission/models/review.py:133
+msgid "Score"
+msgstr "امتیاز"
+
+#: pretalx/event/models/event.py:593
+msgid "Maybe"
+msgstr "شاید"
+
+#: pretalx/event/models/event.py:598 pretalx/submission/models/question.py:422 pretalx/submission/models/submission.py:949
+msgid "Yes"
+msgstr "بله"
+
+#: pretalx/event/models/event.py:1023
+msgid "News from your content system"
+msgstr "اخبار از سیستم محتوای شما"
+
+#: pretalx/event/models/event.py:1100
+msgid "Link text"
+msgstr "متن پیوند"
+
+#: pretalx/event/models/event.py:1101
+msgid "Link URL"
+msgstr "نشانی پیوند"
+
+#: pretalx/event/models/organiser.py:35
+msgid "There must be at least one team with the permission to change teams, as otherwise nobody can create new teams or grant permissions to existing teams."
+msgstr "باید حداقل یک تیم با اجازه تغییر تیم‌ها وجود داشته باشد، در غیر این صورت هیچ‌کس نمی‌تواند تیم‌های جدید ایجاد کند یا مجوزهایی به تیم‌های موجود اختصاص دهد."
+
+#: pretalx/event/models/organiser.py:42
+msgid "Nobody on your teams has the permission to create new events."
+msgstr "هیچ‌کسی در تیم‌های شما مجوز ایجاد رویدادهای جدید را ندارد."
+
+#: pretalx/event/models/organiser.py:50
+msgid "Nobody on your teams has the permission to change organiser-level settings."
+msgstr "هیچ‌کسی در تیم‌های شما مجوز تغییر تنظیمات سطح برگزارکننده را ندارد."
+
+#: pretalx/event/models/organiser.py:65
+#, python-brace-format
+msgid "There must be at least one team with access to every event. Currently, nobody has access to {event_name}."
+msgstr "باید حداقل یک تیم با دسترسی به هر رویدادی وجود داشته باشد. در حال حاضر، هیچ‌کس به {event_name} دسترسی ندارد."
+
+#: pretalx/event/models/organiser.py:75
+#, python-brace-format
+msgid "Nobody on your teams has the permissions to change settings for the event {event_name}"
+msgstr "هیچ‌کسی در تیم‌های شما مجوز تغییر تنظیمات برای رویداد {event_name} را ندارد."
+
+#: pretalx/event/models/organiser.py:104
+msgid "Should be short, only contain lowercase letters and numbers, and must be unique, as it is used in URLs."
+msgstr "باید کوتاه باشد، فقط شامل حروف کوچک و اعداد باشد و باید منحصر‌به‌فرد باشد، زیرا در نشانی اینترنتی‌ها استفاده می‌شود."
+
+#: pretalx/event/models/organiser.py:162
+msgid "Team name"
+msgstr "نام تیم"
+
+#: pretalx/event/models/organiser.py:164
+msgid "Team members"
+msgstr "اعضای تیم"
+
+#: pretalx/event/models/organiser.py:169
+msgid "Apply permissions to all events by this organiser (including newly created ones)"
+msgstr "مجوزها را برای تمام رویدادهای این برگزارکننده اعمال کنید (از جمله رویدادهای تازه ایجادشده)."
+
+#: pretalx/event/models/organiser.py:173
+msgid "Limit permissions to these events"
+msgstr "مجوزها را به این رویدادها محدود کنید"
+
+#: pretalx/event/models/organiser.py:176 pretalx/person/models/information.py:36 pretalx/submission/models/review.py:22
+msgid "Limit to tracks"
+msgstr "محدود به مسیرها"
+
+#: pretalx/event/models/organiser.py:179
+msgid "Can create events"
+msgstr "می‌تواند رویداد ایجاد کند"
+
+#: pretalx/event/models/organiser.py:182
+msgid "Can change teams and permissions"
+msgstr "می‌تواند تیم‌ها و مجوزها را تغییر دهد"
+
+#: pretalx/event/models/organiser.py:185
+msgid "Can change organiser settings"
+msgstr "می‌تواند تنظیمات برگزارکننده را تغییر دهد"
+
+#: pretalx/event/models/organiser.py:188
+msgid "Can change event settings"
+msgstr "می‌تواند تنظیمات رویداد را تغییر دهد"
+
+#: pretalx/event/models/organiser.py:191
+msgid "Can work with and change proposals"
+msgstr "می‌تواند با طرح‌های پیشنهادی کار کرده و آن‌ها را تغییر دهد"
+
+#: pretalx/event/models/organiser.py:193
+msgid "Is a reviewer"
+msgstr "یک بازبین است"
+
+#: pretalx/event/models/organiser.py:195
+msgid "Always hide speaker names"
+msgstr "همیشه نام سخنرانان را مخفی کند"
+
+#: pretalx/event/models/organiser.py:197
+msgid "Normally, anonymisation is configured in the event review settings. This setting will <b>override the event settings</b> and always hide speaker names for this team."
+msgstr "به طور معمول، ناشناس‌سازی در تنظیمات بازبینی رویداد پیکربندی می‌شود. این تنظیم <b>تنظیمات رویداد را بازنویسی می‌کند</b> و همیشه نام سخنرانان را برای این تیم مخفی می‌کند."
+
+#: pretalx/event/models/organiser.py:207
+#, python-brace-format
+msgid "{name} on {orga}"
+msgstr "{name} در {orga}"
+
+#: pretalx/event/models/organiser.py:253
+#, python-brace-format
+msgid "Invite to team {team} for {email}"
+msgstr "دعوت به تیم {team} برای {email}"
+
+#: pretalx/event/models/organiser.py:267
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"You have been invited to the {name} event organiser team - Please click here to accept:\n"
+"\n"
+"{invitation_link}\n"
+"\n"
+"See you there,\n"
+"The {organiser} team"
+msgstr ""
+"سلام!\n"
+"شما به تیم برگزارکننده رویداد {name} دعوت شده‌اید - لطفا برای پذیرش اینجا کلیک کنید:\n"
+"\n"
+"{invitation_link}\n"
+"\n"
+"به امید دیدار،\n"
+"تیم {organiser}"
+
+#: pretalx/event/models/organiser.py:279
+msgid "You have been invited to an organiser team"
+msgstr "شما به یک تیم برگزارکننده دعوت شده‌اید"
+
+#: pretalx/event/stages.py:43
+msgid "Preparation"
+msgstr "آمادگی"
+
+#: pretalx/event/stages.py:47
+msgid "Configure the event"
+msgstr "پیکربندی رویداد"
+
+#: pretalx/event/stages.py:48
+msgid "Gather your team"
+msgstr "تیم خود را جمع کنید"
+
+#: pretalx/event/stages.py:49
+msgid "Write a CfP"
+msgstr "نوشتن یک فراخوان برای طرح پیشنهادی"
+
+#: pretalx/event/stages.py:51
+msgid "Customize mail templates"
+msgstr "سفارشی‌سازی قالب‌های رایانامه"
+
+#: pretalx/event/stages.py:57
+msgid "CfP is open"
+msgstr "فراخوان برای طرح پیشنهادی باز است"
+
+#: pretalx/event/stages.py:61
+msgid "Monitor proposals"
+msgstr "پایش طرح‌های پیشنهادی"
+
+#: pretalx/event/stages.py:63
+msgid "Submit sessions for your speakers"
+msgstr "جلسات را برای سخنرانان خود ارسال کنید"
+
+#: pretalx/event/stages.py:66
+msgid "Invite reviewers"
+msgstr "بازبین‌ها را دعوت کنید"
+
+#: pretalx/event/stages.py:74
+msgid "Let reviewers do their work"
+msgstr "اجازه دهید بازبین‌ها کار خود را انجام دهند"
+
+#: pretalx/event/stages.py:76
+msgid "Accept or reject proposals"
+msgstr "طرح‌های پیشنهادی را بپذیرید یا رد کنید"
+
+#: pretalx/event/stages.py:79
+msgid "Build your first schedule"
+msgstr "اولین برنامه زمان‌بندی خود را بسازید"
+
+#: pretalx/event/stages.py:88
+msgid "Release schedules as needed"
+msgstr "برنامه‌های زمان‌بندی را بر اساس نیاز منتشر کنید"
+
+#: pretalx/event/stages.py:92
+msgid "Inform your speakers about the infrastructure"
+msgstr "سخنرانان خود را درباره زیرساخت‌ها مطلع کنید"
+
+#: pretalx/event/stages.py:98 pretalx/orga/templates/orga/admin/user_detail.html:129 pretalx/orga/templates/orga/mails/_placeholder_group.html:14 pretalx/orga/templates/orga/organiser/list.html:33 pretalx/orga/views/event.py:746
+msgid "Event"
+msgid_plural "Events"
+msgstr[0] "رویداد"
+msgstr[1] "رویدادها"
+
+#: pretalx/event/stages.py:102
+msgid "Provide a point of contact for the speakers"
+msgstr "یک نقطه تماس برای سخنرانان فراهم کنید"
+
+#: pretalx/event/stages.py:103
+msgid "Enjoy the event!"
+msgstr "از رویداد لذت ببرید!"
+
+#: pretalx/event/stages.py:107
+msgid "Wrapup"
+msgstr "جمع‌بندی"
+
+#: pretalx/event/stages.py:111
+msgid "Monitor incoming feedback"
+msgstr "بازخوردهای دریافتی را پایش کنید"
+
+#: pretalx/event/stages.py:112
+msgid "Embed session recordings if available"
+msgstr "اگر ضبط جلسات موجود است، آن‌ها را جاسازی کنید"
+
+#: pretalx/event/stages.py:113
+msgid "Release next event date?"
+msgstr "تاریخ رویداد بعدی را اعلام کنید؟"
+
+#: pretalx/eventyay_common/templates/eventyay_common/sso/detail.html:4 pretalx/orga/templates/orga/base.html:482
+msgid "SSO settings"
+msgstr "تنظیمات SSO"
+
+#: pretalx/eventyay_common/templates/eventyay_common/sso/detail.html:6
+msgid "SSO client settings"
+msgstr "تنظیمات کلاینت SSO"
+
+#: pretalx/eventyay_common/templates/eventyay_common/sso/detail.html:14
+msgid "Delete key"
+msgstr "حذف کلید"
+
+#: pretalx/eventyay_common/views/sso.py:73
+msgid "You will not able to login with eventyay-tickets account."
+msgstr "شما قادر به ورود با حساب eventyay-tickets نخواهید بود."
+
+#: pretalx/eventyay_common/views/sso.py:82
+msgid "SSO Provider"
+msgstr "ارائه‌دهنده SSO"
+
+#: pretalx/mail/context.py:84
+msgid "The event’s full name"
+msgstr "نام کامل رویداد"
+
+#: pretalx/mail/context.py:91
+msgid "The event’s short form, used in URLs"
+msgstr "فرم کوتاه رویداد که در نشانی‌‌های اینترنتی استفاده می‌شود"
+
+#: pretalx/mail/context.py:98
+msgid "The event’s public base URL"
+msgstr "نشانی پایه عمومی رویداد"
+
+#: pretalx/mail/context.py:105
+msgid "The event’s public schedule URL"
+msgstr "نشانی برنامه زمان‌بندی عمومی رویداد"
+
+#: pretalx/mail/context.py:112
+msgid "The event’s public CfP URL"
+msgstr "نشانی عمومی فراخوان برای طرح پیشنهادی رویداد"
+
+#: pretalx/mail/context.py:119
+msgid "URL to a user’s list of proposals"
+msgstr "نشانی فهرست طرح‌های پیشنهادی کاربر"
+
+#: pretalx/mail/context.py:134
+msgid "The general CfP deadline"
+msgstr "مهلت کلی فراخوان برای طرح پیشنهادی"
+
+#: pretalx/mail/context.py:141
+msgid "The proposal’s unique ID"
+msgstr "شناسه یکتای طرح‌های پیشنهادی"
+
+#: pretalx/mail/context.py:148
+msgid "The proposal’s public URL"
+msgstr "نشانی عمومی طرح‌های پیشنهادی"
+
+#: pretalx/mail/context.py:155
+msgid "The speaker’s edit page for the proposal"
+msgstr "صفحه ویرایش سخنران برای طرح پیشنهادی"
+
+#: pretalx/mail/context.py:162
+msgid "Link to confirm a proposal after it has been accepted."
+msgstr "پیوند برای تایید طرح پیشنهادی پس از پذیرش آن."
+
+#: pretalx/mail/context.py:169
+msgid "Link to withdraw the proposal"
+msgstr "پیوند برای بازپس‌گیری طرح پیشنهادی"
+
+#: pretalx/mail/context.py:175
+msgid "This Is a Proposal Title"
+msgstr "این یک عنوان طرح پیشنهادی است"
+
+#: pretalx/mail/context.py:176
+msgid "The proposal’s title"
+msgstr "عنوان طرح پیشنهادی"
+
+#: pretalx/mail/context.py:183
+msgid "The name(s) of all speakers in this proposal."
+msgstr "نام (نام‌های) تمام سخنرانان در این طرح پیشنهادی."
+
+#: pretalx/mail/context.py:189
+msgid "Session Type A"
+msgstr "نوع جلسه الف"
+
+#: pretalx/mail/context.py:190
+msgid "The proposal’s session type"
+msgstr "نوع جلسه طرح پیشنهادی"
+
+#: pretalx/mail/context.py:196
+msgid "Track A"
+msgstr "مسیر الف"
+
+#: pretalx/mail/context.py:197
+msgid "The track the proposal belongs to"
+msgstr "مسیر مرتبط با طرح پیشنهادی"
+
+#: pretalx/mail/context.py:204
+msgid ""
+"First review, agreeing with the proposal.\n"
+"\n"
+"--------- \n"
+"\n"
+"Second review, containing heavy criticism!"
+msgstr ""
+"بازبینی اول، موافق با طرح پیشنهادی.\n"
+"\n"
+"--------- \n"
+"\n"
+"بازبینی دوم، حاوی نقدهای شدید!"
+
+#: pretalx/mail/context.py:206
+msgid "All review texts for this proposal"
+msgstr "تمام متون بازبینی برای این طرح پیشنهادی"
+
+#: pretalx/mail/context.py:213
+msgid "The session’s start date"
+msgstr "تاریخ شروع جلسه"
+
+#: pretalx/mail/context.py:220
+msgid "The session’s start time"
+msgstr "زمان شروع جلسه"
+
+#: pretalx/mail/context.py:227
+msgid "The session’s end date"
+msgstr "تاریخ پایان جلسه"
+
+#: pretalx/mail/context.py:234
+msgid "The session’s end time"
+msgstr "زمان پایان جلسه"
+
+#: pretalx/mail/context.py:240
+msgid "Room 101"
+msgstr "اتاق ۱۰۱"
+
+#: pretalx/mail/context.py:241
+msgid "The session’s room"
+msgstr "اتاق جلسه"
+
+#: pretalx/mail/context.py:248
+msgid "The addressed user’s full name"
+msgstr "نام کامل کاربر مورد خطاب"
+
+#: pretalx/mail/context.py:255
+msgid "The addressed user’s email address"
+msgstr "نشانی رایانامه کاربر مورد خطاب"
+
+#: pretalx/mail/context.py:266
+#, python-brace-format
+msgid ""
+"- Your session “Title” will take place at {time} in Room 101.\n"
+"- Your session “Other Title” has been moved to {time2} in Room 102."
+msgstr ""
+"- جلسه شما «عنوان» در {time} در اتاق ۱۰۱ برگزار خواهد شد.\n"
+"- جلسه شما «عنوان دیگری» به {time2} در اتاق ۱۰۲ منتقل شده است."
+
+#: pretalx/mail/context.py:270
+msgid "A list of all changes to the user’s schedule in the current schedule version."
+msgstr "فهرستی از تمام تغییرات در برنامه زمان‌بندی کاربر در نسخه فعلی برنامه زمان‌بندی."
+
+#: pretalx/mail/context.py:281
+#, python-brace-format
+msgid ""
+"- Your session “Title” will take place at {time} in Room 101.\n"
+"- Your session “Other Title” will take place at {time2} in Room 102."
+msgstr ""
+"- جلسه شما «عنوان» در {time} در اتاق ۱۰۱ برگزار خواهد شد.\n"
+"- جلسه شما «عنوان دیگری» در {time2} در اتاق ۱۰۲ برگزار خواهد شد."
+
+#: pretalx/mail/context.py:284
+msgid "A list of time and place for this user’s publicly visible sessions."
+msgstr "فهرستی از زمان و مکان برای جلسات عمومی کاربر."
+
+#: pretalx/mail/default_templates.py:4
+#, python-brace-format
+msgid "Your proposal: {submission_title}"
+msgstr "طرح پیشنهادی شما: {submission_title}"
+
+#: pretalx/mail/default_templates.py:8
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"\n"
+"We have received your proposal “{submission_title}” to\n"
+"{event_name}. We will notify you once we have had time to consider all\n"
+"proposals, but until then you can see and edit your proposal at\n"
+"{submission_url}.\n"
+"\n"
+"Please do not hesitate to contact us if you have any questions!\n"
+"\n"
+"The {event_name} organisers"
+msgstr ""
+"سلام!\n"
+"\n"
+"ما طرح پیشنهادی شما «{submission_title}» را برای\n"
+"{event_name} دریافت کرده‌ایم. ما به شما اطلاع خواهیم داد زمانی که فرصت بررسی تمام\n"
+"طرح‌های پیشنهادی را پیدا کنیم، اما تا آن زمان می‌توانید پیشنهاد خود را مشاهده و ویرایش کنید در\n"
+"{submission_url}.\n"
+"\n"
+"لطفا اگر سوالی دارید دریغ نکنید که با ما تماس بگیرید!\n"
+"\n"
+"تیم برگزارکننده‌گان {event_name}"
+
+#: pretalx/mail/default_templates.py:23
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"\n"
+"We are happy to tell you that we accept your proposal “{submission_title}”\n"
+"to {event_name}. Please click this link to confirm your attendance:\n"
+"\n"
+"    {confirmation_link}\n"
+"\n"
+"We look forward to seeing you at {event_name} - Please contact us if you have any\n"
+"questions! We will reach out again before the conference to tell you details\n"
+"about your slot in the schedule and technical details concerning the room\n"
+"and presentation tech.\n"
+"\n"
+"See you there!\n"
+"The {event_name} organisers"
+msgstr ""
+"سلام!\n"
+"\n"
+"ما خوشحالیم که به شما بگوییم طرح پیشنهادی شما «{submission_title}» را\n"
+"برای {event_name} پذیرفته‌ایم. لطفا برای تایید حضور خود روی این پیوند کلیک کنید:\n"
+"\n"
+"    {confirmation_link}\n"
+"\n"
+"منتظر دیدار شما در {event_name} هستیم - لطفا اگر سوالی دارید با ما تماس بگیرید!\n"
+"ما دوباره قبل از کنفرانس با شما تماس خواهیم گرفت تا جزئیات مربوط به فاصله شما در برنامه زمان‌بندی و جزئیات فنی مربوط به اتاق و فناوری ارائه را به شما اطلاع دهیم.\n"
+"\n"
+"به امید دیدار!\n"
+"تیم برگزارکننده‌گان {event_name}"
+
+#: pretalx/mail/default_templates.py:42
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"\n"
+"We are sorry to tell you that we cannot accept your proposal\n"
+"“{submission_title}” to {event_name}. There were just too many great\n"
+"proposals - we hope to see you at {event_name} as an attendee instead\n"
+"of a speaker!\n"
+"\n"
+"The {event_name} organisers"
+msgstr ""
+"سلام!\n"
+"\n"
+"متأسفیم که به شما اطلاع دهیم نمی‌توانیم طرح پیشنهادی شما\n"
+"«{submission_title}» را برای {event_name} بپذیریم. طرح‌های پیشنهادی زیادی عالی وجود داشتند - امیدواریم شما را در {event_name} به‌عنوان شرکت‌کننده ببینیم، نه به‌عنوان سخنران!\n"
+"\n"
+"تیم برگزارکننده‌گان {event_name}"
+
+#: pretalx/mail/default_templates.py:53
+msgid "New schedule!"
+msgstr "برنامه زمان‌بندی جدید!"
+
+#: pretalx/mail/default_templates.py:56
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"\n"
+"We have released a new schedule version, and wanted to tell you:\n"
+"\n"
+"{speaker_schedule_new}\n"
+"\n"
+"We look forward to seeing you, and please contact us if there is any problem with your session or assigned slot.\n"
+"\n"
+"The {event_name} organisers"
+msgstr ""
+"سلام!\n"
+"\n"
+"ما یک نسخه جدید از برنامه زمان‌بندی منتشر کرده‌ایم و می‌خواهیم به شما اطلاع دهیم:\n"
+"\n"
+"{speaker_schedule_new}\n"
+"\n"
+"منتظر دیدن شما هستیم، و لطفا اگر مشکلی با جلسه شما یا فاصله اختصاص‌یافته دارید، با ما تماس بگیرید.\n"
+"\n"
+"تیم برگزارکننده‌گان {event_name}"
+
+#: pretalx/mail/default_templates.py:69
+msgid "We have some questions about your proposal"
+msgstr "ما چند سؤال درباره طرح پیشنهادی شما داریم"
+
+#: pretalx/mail/default_templates.py:73
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"\n"
+"We have some open questions about yourself and your proposal that we’d\n"
+"like to ask you to answer:\n"
+"\n"
+"{questions}\n"
+"\n"
+"You can answer them at {url}.\n"
+"\n"
+"Please do not hesitate to contact us if you have any questions in turn!\n"
+"\n"
+"The {event_name} organisers"
+msgstr ""
+"سلام!\n"
+"\n"
+"ما چند سوال باز درباره خودتان و طرح پیشنهادی شما داریم که می‌خواهیم از شما بپرسیم:\n"
+"\n"
+"{questions}\n"
+"\n"
+"می‌توانید آن‌ها را در {url} پاسخ دهید.\n"
+"\n"
+"لطفا اگر خودتان سوالی دارید، دریغ نکنید که با ما تماس بگیرید!\n"
+"\n"
+"تیم برگزارکننده‌گان {event_name}"
+
+#: pretalx/mail/default_templates.py:89
+#, python-brace-format
+msgid "New proposal: {proposal_title}"
+msgstr "طرح پیشنهادی جدید: {proposal_title}"
+
+#: pretalx/mail/default_templates.py:93
+#, python-brace-format
+msgid ""
+"Hi,\n"
+"\n"
+"you have received a new proposal for your event {event_name}:\n"
+"“{submission_title}” by {speakers}.\n"
+"You can see details at\n"
+"\n"
+"  {orga_url}\n"
+"\n"
+"All the best,\n"
+"your {event_name} CfP system.\n"
+msgstr ""
+"سلام،\n"
+"\n"
+"شما یک طرح پیشنهادی جدید برای رویداد خود {event_name} دریافت کرده‌اید:\n"
+"«{submission_title}» توسط {speakers}.\n"
+"می‌توانید جزئیات را در\n"
+"\n"
+"  {orga_url}\n"
+"\n"
+"مشاهده کنید.\n"
+"با آرزوی بهترین‌ها،\n"
+"سیستم فراخوان برای طرح پیشنهادی {event_name} شما.\n"
+
+#: pretalx/mail/default_templates.py:108
+#, python-brace-format
+msgid "You have been added to a proposal for {event_name}"
+msgstr "شما به یک طرح پیشنهادی برای {event_name} اضافه شده‌اید"
+
+#: pretalx/mail/default_templates.py:113
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"\n"
+"You have been added to a proposal of {event_name}, titled “{proposal_title}”.\n"
+"An account has been created for you – please follow this link to set your account password.\n"
+"\n"
+"{invitation_link}\n"
+"\n"
+"Afterwards, you can edit your user profile and see the state of your proposal.\n"
+"\n"
+"The {event} orga crew"
+msgstr ""
+"سلام!\n"
+"\n"
+"شما به یک طرح پیشنهادی از {event_name} اضافه شده‌اید، با عنوان «{proposal_title}».\n"
+"یک حساب برای شما ایجاد شده است – لطفا این پیوند را برای تنظیم گذرواژه حساب خود دنبال کنید.\n"
+"\n"
+"{invitation_link}\n"
+"\n"
+"سپس می‌توانید نمایه کاربری خود را ویرایش کرده و وضعیت طرح پیشنهادی خود را مشاهده کنید.\n"
+"\n"
+"تیم برگزارکننده‌گان {event}"
+
+#: pretalx/mail/default_templates.py:127
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"\n"
+"You have been added to a proposal of {event_name}, titled “{proposal_title}”.\n"
+"Please follow this link to edit your user profile and see the state of your proposal:\n"
+"\n"
+"{proposal_url}\n"
+"\n"
+"The {event_name} organisers"
+msgstr ""
+"سلام!\n"
+"\n"
+"شما به یک طرح پیشنهادی از {event_name} اضافه شده‌اید، با عنوان «{proposal_title}».\n"
+"لطفا این پیوند را برای ویرایش نمایه کاربری خود و مشاهده وضعیت طرح پیشنهادی دنبال کنید:\n"
+"\n"
+"{proposal_url}\n"
+"\n"
+"تیم برگزارکننده‌گان {event_name}"
+
+#: pretalx/mail/models.py:28
+msgid "Acknowledge proposal submission"
+msgstr "پذیرش ارسال طرح پیشنهادی را تایید کنید"
+
+#: pretalx/mail/models.py:30
+msgid "New proposal (organiser notification)"
+msgstr "طرح پیشنهادی جدید (اطلاع‌رسانی به برگزارکننده)"
+
+#: pretalx/mail/models.py:32
+msgid "Proposal accepted"
+msgstr "طرح پیشنهادی پذیرفته شد"
+
+#: pretalx/mail/models.py:33
+msgid "Proposal rejected"
+msgstr "طرح پیشنهادی رد شد"
+
+#: pretalx/mail/models.py:35
+msgid "Add a speaker to a proposal (new account)"
+msgstr "اضافه کردن یک سخنران به یک طرح پیشنهادی (حساب کاربری جدید)"
+
+#: pretalx/mail/models.py:38
+msgid "Add a speaker to a proposal (existing account)"
+msgstr "اضافه کردن یک سخنران به یک طرح پیشنهادی (حساب کاربری موجود)"
+
+#: pretalx/mail/models.py:40 pretalx/orga/templates/orga/cfp/question_remind.html:18 pretalx/orga/templates/orga/includes/mail_template_role.html:9
+msgid "Unanswered questions reminder"
+msgstr "یادآوری سوالات بی‌پاسخ"
+
+#: pretalx/mail/models.py:41
+msgid "New schedule published"
+msgstr "برنامه زمان‌بندی جدید منتشر شد"
+
+#: pretalx/mail/models.py:75 pretalx/mail/models.py:244
+msgid "Reply-To"
+msgstr "پاسخ به"
+
+#: pretalx/mail/models.py:77
+msgid "Change the Reply-To address if you do not want to use the default organiser address"
+msgstr "نشانی پاسخ به را تغییر دهید اگر نمی‌خواهید از نشانی پیش‌فرض برگزارکننده استفاده کنید"
+
+#: pretalx/mail/models.py:84 pretalx/mail/models.py:258
+msgid "BCC"
+msgstr "کپی مخفی (BCC)"
+
+#: pretalx/mail/models.py:86
+msgid "Enter comma separated addresses. Will receive a blind copy of every mail sent from this template. This may be a LOT!"
+msgstr "نشانی‌ها را با کاما جدا وارد کنید. یک کپی مخفی از هر رایانامه‌ای که از این قالب ارسال شود، دریافت خواهند کرد. این ممکن است زیاد باشد!"
+
+#: pretalx/mail/models.py:231 pretalx/orga/forms/cfp.py:455 pretalx/orga/templates/orga/mails/outbox_list.html:54 pretalx/orga/templates/orga/mails/sent_list.html:21
+msgid "To"
+msgstr "به"
+
+#: pretalx/mail/models.py:232 pretalx/mail/models.py:252 pretalx/mail/models.py:259
+msgid "One email address or several addresses separated by commas."
+msgstr "یک نشانی رایانامه یا چندین نشانی جدا شده با کاما."
+
+#: pretalx/mail/models.py:245
+msgid "By default, the organiser address is used as Reply-To."
+msgstr "به‌طور پیش‌فرض، نشانی برگزارکننده به‌عنوان پاسخ به استفاده می‌شود."
+
+#: pretalx/mail/models.py:251
+msgid "CC"
+msgstr "کپی (CC)"
+
+#: pretalx/mail/models.py:265
+msgid "Sent at"
+msgstr "ارسال شده در"
+
+#: pretalx/mail/models.py:332
+msgid "This mail has been sent already. It cannot be sent again."
+msgstr "این رایانامه قبلا ارسال شده است. نمی‌توان آن را دوباره ارسال کرد."
+
+#: pretalx/orga/forms/admin.py:17
+msgid "Perform update checks"
+msgstr "انجام بررسی‌های به‌روزرسانی"
+
+#: pretalx/orga/forms/admin.py:19
+msgid ""
+"During the update check, pretalx will report an anonymous, unique installation ID, the current version of pretalx and your installed plugins and the number of active and inactive events in your installation to servers operated by the pretalx developers. We will only store anonymous data, never any IP addresses and we will not know who you are or where to find your instance. You can "
+"disable this behavior here at any time."
+msgstr "در طول بررسی به‌روزرسانی، pretalx یک شناسه نصب یکتا و ناشناس، نسخه فعلی pretalx و افزونه‌های نصب‌شده و تعداد رویدادهای فعال و غیرفعال در نصب شما را به سرورهای توسعه‌دهندگان pretalx گزارش می‌دهد. ما فقط داده‌های ناشناس ذخیره می‌کنیم، هرگز نشانی‌های IP ذخیره نمی‌شود و نمی‌دانیم شما کیستید یا چگونه نمونه شما را پیدا کنیم. می‌توانید این رفتار را در اینجا در هر زمانی غیرفعال کنید."
+
+#: pretalx/orga/forms/admin.py:28
+msgid "Email notifications"
+msgstr "اطلاع‌رسانی‌های رایانامه"
+
+#: pretalx/orga/forms/admin.py:30
+msgid "We will notify you at this address if we detect that a new update is available. This address will not be transmitted to pretalx.com, the emails will be sent by your server locally."
+msgstr "ما اگر تشخیص دهیم که یک به‌روزرسانی جدید موجود است، شما را در این نشانی مطلع خواهیم کرد. این نشانی به pretalx.com منتقل نخواهد شد، رایانامه‌ها توسط سرور شما به صورت محلی ارسال می‌شوند."
+
+#: pretalx/orga/forms/cfp.py:39
+msgid "Use tracks"
+msgstr "استفاده از مسیرها"
+
+#: pretalx/orga/forms/cfp.py:41
+msgid "Do you organise your sessions by tracks?"
+msgstr "آیا جلسات خود را بر اساس مسیرها سازمان‌دهی می‌کنید؟"
+
+#: pretalx/orga/forms/cfp.py:44 pretalx/submission/models/submission.py:215
+msgid "Slot Count"
+msgstr "تعداد فاصله"
+
+#: pretalx/orga/forms/cfp.py:46
+msgid "Can sessions be held multiple times?"
+msgstr "آیا جلسات می‌توانند چندین بار برگزار شوند؟"
+
+#: pretalx/orga/forms/cfp.py:49
+msgid "Send mail on new proposal"
+msgstr "ارسال رایانامه برای طرح پیشنهادی جدید"
+
+#: pretalx/orga/forms/cfp.py:51
+msgid "If this setting is checked, you will receive an email to the organiser address for every received proposal."
+msgstr "اگر این تنظیم فعال شود، شما برای هر طرح پیشنهادی دریافت شده یک رایانامه به نشانی برگزارکننده دریافت خواهید کرد."
+
+#: pretalx/orga/forms/cfp.py:56
+msgid "Allow submitters to share their proposal publicly"
+msgstr "اجازه دهید ارسال‌کنندگان پیشنهاد خود را به‌صورت عمومی هم‌رسانی کنند"
+
+#: pretalx/orga/forms/cfp.py:58
+msgid "Allow submitters to share a secret link to their proposal with others."
+msgstr "اجازه دهید ارسال‌کنندگان یک پیوند مخفی از پیشنهاد خود را با دیگران هم‌رسانی کنند."
+
+#: pretalx/orga/forms/cfp.py:124
+msgid "Do not ask"
+msgstr "نپرسید"
+
+#: pretalx/orga/forms/cfp.py:125
+msgid "Ask, but do not require input"
+msgstr "بپرسید، اما ورودی لازم نیست"
+
+#: pretalx/orga/forms/cfp.py:126
+msgid "Ask and require input"
+msgstr "بپرسید و ورودی را لازم کنید"
+
+#: pretalx/orga/forms/cfp.py:161
+msgid "Display deadline publicly"
+msgstr "مهلت را به‌صورت عمومی نمایش دهید"
+
+#: pretalx/orga/forms/cfp.py:163
+msgid "Show the time and date the CfP ends to potential speakers."
+msgstr "زمان و تاریخ پایان فراخوان برای طرح پیشنهادی را به سخنرانان احتمالی نمایش دهید."
+
+#: pretalx/orga/forms/cfp.py:166
+msgid "Count text length in"
+msgstr "طول متن را بشمارید در"
+
+#: pretalx/orga/forms/cfp.py:167
+msgid "Characters"
+msgstr "نویسه‌ها"
+
+#: pretalx/orga/forms/cfp.py:167
+msgid "Words"
+msgstr "کلمات"
+
+#: pretalx/orga/forms/cfp.py:184
+msgid "Upload options"
+msgstr "گزینه‌ها را بارگذاری کنید"
+
+#: pretalx/orga/forms/cfp.py:186
+msgid "You can upload question options here, one option per line. To use multiple languages, please upload a JSON file with a list of options:"
+msgstr "می‌توانید گزینه‌های سوال را اینجا بارگذاری کنید، هر گزینه در یک خط. برای استفاده از چندین زبان، لطفا یک فایل JSON با فهرستی از گزینه‌ها بارگذاری کنید:"
+
+#: pretalx/orga/forms/cfp.py:194
+msgid "Replace existing options"
+msgstr "جایگزینی گزینه‌های موجود"
+
+#: pretalx/orga/forms/cfp.py:196
+msgid "If you upload new options, do you want to replace the existing ones? Please note that this will DELETE all existing answers to this question! If you do not check this, the uploaded options will be added to the existing ones, without adding duplicates."
+msgstr "اگر گزینه‌های جدید بارگذاری کنید، آیا می‌خواهید گزینه‌های موجود را جایگزین کنید؟ لطفا توجه داشته باشید که این کار تمامی پاسخ‌های موجود به این سوال را حذف خواهد کرد! اگر این را تیک نزنید، گزینه‌های بارگذاری شده به گزینه‌های موجود اضافه خواهند شد، بدون افزودن تکراری‌ها."
+
+#: pretalx/orga/forms/cfp.py:235
+msgid "Could not read file."
+msgstr "نمی‌توان پرونده را خواند."
+
+#: pretalx/orga/forms/cfp.py:240
+msgid "JSON file does not contain a list."
+msgstr "پرونده JSON حاوی فهرست نیست."
+
+#: pretalx/orga/forms/cfp.py:242
+msgid "JSON file does not contain a list of objects."
+msgstr "پرونده JSON حاوی فهرستی از اشیاء نیست."
+
+#: pretalx/orga/forms/cfp.py:256
+msgid "Please select a deadline after which the question should become mandatory."
+msgstr "لطفا مهلتی را انتخاب کنید که پس از آن سوال اجباری شود."
+
+#: pretalx/orga/forms/cfp.py:268
+msgid "You cannot replace answer options without uploading new ones."
+msgstr "نمی‌توانید گزینه‌های پاسخ را جایگزین کنید بدون اینکه گزینه‌های جدید بارگذاری کنید."
+
+#: pretalx/orga/forms/cfp.py:373
+msgid "You already have a session type by this name!"
+msgstr "شما از قبل یک نوع جلسه با این نام دارید!"
+
+#: pretalx/orga/forms/cfp.py:387 pretalx/orga/forms/submission.py:209
+msgid "minutes"
+msgstr "دقیقه"
+
+#: pretalx/orga/forms/cfp.py:398
+#, python-brace-format
+msgid "You can create an access code <a href=\"{url}\">here</a>."
+msgstr "می‌توانید یک کد دسترسی را <a href=\"{url}\">اینجا</a> ایجاد کنید."
+
+#: pretalx/orga/forms/cfp.py:407
+msgid "You already have a track by this name!"
+msgstr "شما از قبل یک مسیر با این نام دارید!"
+
+#: pretalx/orga/forms/cfp.py:461
+#, python-brace-format
+msgid "Access code for the {event} CfP"
+msgstr "کد دسترسی برای فراخوان برای طرح پیشنهادی {event}"
+
+#: pretalx/orga/forms/cfp.py:465
+#, python-brace-format
+msgid ""
+"Hi!\n"
+"\n"
+"This is an access code for the {event} CfP."
+msgstr ""
+"سلام!\n"
+"\n"
+"این یک کد دسترسی برای فراخوان برای طرح پیشنهادی {event} است."
+
+#: pretalx/orga/forms/cfp.py:476
+#, python-brace-format
+msgid "It will allow you to submit a proposal to the “{track}” track."
+msgstr "این به شما امکان می‌دهد یک طرح پیشنهادی به مسیر «{track}» ارسال کنید."
+
+#: pretalx/orga/forms/cfp.py:482
+msgid "It will allow you to submit a proposal to our CfP."
+msgstr "این به شما امکان می‌دهد یک طرح پیشنهادی به فراخوان برای طرح پیشنهادی ما ارسال کنید."
+
+#: pretalx/orga/forms/cfp.py:486
+#, python-brace-format
+msgid "This access code is valid until {date}."
+msgstr "این کد دسترسی تا تاریخ {date} معتبر است."
+
+#: pretalx/orga/forms/cfp.py:498
+#, python-brace-format
+msgid "The code can be redeemed multiple times ({num})."
+msgstr "این کد می‌تواند چندین بار استفاده شود ({num})."
+
+#: pretalx/orga/forms/cfp.py:503
+#, python-brace-format
+msgid ""
+"\n"
+"Please follow this URL to use the code:\n"
+"\n"
+"  {url}\n"
+"\n"
+"I’m looking forward to your proposal!\n"
+"{name}"
+msgstr ""
+"\n"
+"لطفا این نشانی اینترنتی را برای استفاده از کد دنبال کنید:\n"
+"\n"
+"  {url}\n"
+"\n"
+"منتظر پیشنهاد شما هستم!\n"
+"{name}"
+
+#: pretalx/orga/forms/cfp.py:534
+msgid "Accepted or confirmed speakers"
+msgstr "سخنرانان پذیرفته‌شده یا تأییدشده"
+
+#: pretalx/orga/forms/cfp.py:535
+msgid "Confirmed speakers"
+msgstr "سخنرانان تأییدشده"
+
+#: pretalx/orga/forms/cfp.py:538 pretalx/orga/templates/orga/mails/_mail_editor.html:28
+msgid "Recipients"
+msgstr "گیرندگان"
+
+#: pretalx/orga/forms/cfp.py:609
+msgid "If you select no question, all questions will be used."
+msgstr "اگر هیچ سوالی انتخاب نکنید، تمامی سوالات استفاده خواهند شد."
+
+#: pretalx/orga/forms/event.py:42
+msgid "Grid"
+msgstr "شبکه‌ای"
+
+#: pretalx/orga/forms/event.py:43
+msgid "List"
+msgstr "فهرستی"
+
+#: pretalx/orga/forms/event.py:59
+msgid "Active languages"
+msgstr "زبان‌های فعال"
+
+#: pretalx/orga/forms/event.py:63
+msgid "Users will be able to use eventyay in these languages, and you will be able to provide all texts in these languages. If you don’t provide a text in the language a user selects, it will be shown in your event’s default language instead."
+msgstr "کاربران می‌توانند eventyay را در این زبان‌ها استفاده کنند و شما قادر خواهید بود تمام متن‌ها را به این زبان‌ها ارائه دهید. اگر متنی به زبانی که کاربر انتخاب می‌کند ارائه ندهید، به‌جای آن به زبان پیش‌فرض رویداد شما نمایش داده خواهد شد."
+
+#: pretalx/orga/forms/event.py:69
+msgid "Content languages"
+msgstr "زبان‌های محتوا"
+
+#: pretalx/orga/forms/event.py:72
+msgid "Users will be able to submit proposals in these languages."
+msgstr "کاربران می‌توانند طرح‌های پیشنهادی خود را به این زبان‌ها ارسال کنند."
+
+#: pretalx/orga/forms/event.py:78
+msgid "You can type in your CSS instead of uploading it, too."
+msgstr "می‌توانید CSS خود را تایپ کنید به‌جای بارگذاری آن."
+
+#: pretalx/orga/forms/event.py:81
+msgid "Imprint URL"
+msgstr "نشانی اینترنتی اطلاعات تماس"
+
+#: pretalx/orga/forms/event.py:83
+msgid "This should point e.g. to a part of your website that has your contact details and legal information."
+msgstr "این باید به‌عنوان مثال به بخشی از وبگاه شما اشاره کند که اطلاعات تماس و اطلاعات قانونی شما را دارد."
+
+#: pretalx/orga/forms/event.py:88
+msgid "Show schedule publicly"
+msgstr "نمایش عمومی برنامه"
+
+#: pretalx/orga/forms/event.py:90
+msgid "Unset to hide your schedule, e.g. if you want to use the HTML export exclusively."
+msgstr "غیرفعال کنید تا برنامه شما مخفی شود، به‌عنوان مثال اگر فقط می‌خواهید از خروجی HTML استفاده کنید."
+
+#: pretalx/orga/forms/event.py:100
+msgid "Show featured sessions"
+msgstr "نمایش جلسات برجسته"
+
+#: pretalx/orga/forms/event.py:102 pretalx/submission/models/review.py:292 pretalx/submission/models/review.py:313
+msgid "Never"
+msgstr "هرگز"
+
+#: pretalx/orga/forms/event.py:103
+msgid "Until the first schedule is released"
+msgstr "تا زمان انتشار اولین برنامه زمان‌بندی"
+
+#: pretalx/orga/forms/event.py:104 pretalx/submission/models/review.py:291
+msgid "Always"
+msgstr "همیشه"
+
+#: pretalx/orga/forms/event.py:107
+msgid "Marking sessions as “featured” is a good way to show them before the first schedule release, or to highlight them once the schedule is visible."
+msgstr "علامت‌گذاری جلسات به‌عنوان «برجسته» روشی مناسب برای نمایش آن‌ها قبل از انتشار اولین برنامه زمان‌بندی یا برجسته‌کردن آن‌ها پس از مشاهده برنامه زمان‌بندی است."
+
+#: pretalx/orga/forms/event.py:112
+msgid "Enable anonymous feedback"
+msgstr "فعال‌سازی بازخورد ناشناس"
+
+#: pretalx/orga/forms/event.py:114
+msgid "Attendees will be able to send in feedback after a session is over."
+msgstr "شرکت‌کنندگان می‌توانند پس از پایان جلسه بازخورد ارسال کنند."
+
+#: pretalx/orga/forms/event.py:119
+msgid "Generate HTML export on schedule release"
+msgstr "تولید خروجی HTML در زمان انتشار برنامه زمان‌بندی"
+
+#: pretalx/orga/forms/event.py:121
+msgid "The static HTML export will be provided as a .zip archive on the schedule export page."
+msgstr "خروجی HTML استاتیک به‌صورت یک بایگانی .zip در صفحه خروجی برنامه زمان‌بندی ارائه خواهد شد."
+
+#: pretalx/orga/forms/event.py:126
+msgid "HTML Export URL"
+msgstr "نشانی اینترنتی خروجی HTML"
+
+#: pretalx/orga/forms/event.py:128
+msgid "If you publish your schedule via the HTML export, you will want the correct absolute URL to be set in various places. Please only set this value once you have published your schedule. Should end with a slash."
+msgstr "اگر برنامه زمان‌بندی خود را از طریق خروجی HTML منتشر کنید، باید نشانی اینترنتی مطلق صحیح را در مکان‌های مختلف تنظیم کنید. لطفا این مقدار را فقط پس از انتشار برنامه زمان‌بندی تنظیم کنید. باید با یک اسلش خاتمه یابد."
+
+#: pretalx/orga/forms/event.py:134
+msgid "Event ticket shop URL"
+msgstr "نشانی فروشگاه بلیط رویداد"
+
+#: pretalx/orga/forms/event.py:135
+msgid "Ticket shop link will be shown on event menu."
+msgstr "پیوند فروشگاه بلیط در منوی رویداد نمایش داده خواهد شد."
+
+#: pretalx/orga/forms/event.py:144
+msgid "Video Live URL"
+msgstr "نشانی ویدیوی زنده"
+
+#: pretalx/orga/forms/event.py:159
+msgid "Ask search engines not to index the event pages"
+msgstr "از موتورهای جستجو بخواهید صفحات رویداد را ایندکس نکنند"
+
+#: pretalx/orga/forms/event.py:168
+#, python-brace-format
+msgid "Make sure to point a CNAME record from your domain to {site_url}."
+msgstr "اطمینان حاصل کنید که یک رکورد CNAME از دامنه خود به {site_url} اشاره می‌کند."
+
+#: pretalx/orga/forms/event.py:175
+#, python-brace-format
+msgid "You can find the page <a {href}>here</a>."
+msgstr "می‌توانید صفحه را <a {href}>اینجا</a> پیدا کنید."
+
+#: pretalx/orga/forms/event.py:184
+msgid "Please contact your administrator if you need to change the short name of your event."
+msgstr "لطفاً اگر نیاز دارید نام کوتاه رویداد خود را تغییر دهید با مدیریت تماس بگیرید."
+
+#: pretalx/orga/forms/event.py:187
+msgid "Any sessions you have scheduled already will be moved if you change the event dates. You will have to release a new schedule version to notify all speakers."
+msgstr "هر جلسه‌ای که قبلا برنامه‌ریزی کرده‌اید جابجا خواهد شد اگر تاریخ‌های رویداد را تغییر دهید. شما باید یک نسخه جدید برنامه زمان‌بندی منتشر کنید تا همه سخنرانان را مطلع کنید."
+
+#: pretalx/orga/forms/event.py:204
+msgid "Please do not choose the default domain as custom event domain."
+msgstr "لطفا دامنه پیش‌فرض را به‌عنوان دامنه سفارشی رویداد انتخاب نکنید."
+
+#: pretalx/orga/forms/event.py:215
+#, python-brace-format
+msgid "The domain “{domain}” does not have a name server entry at this time. Please make sure the domain is working before configuring it here."
+msgstr "دامنه «{domain}» در حال حاضر ورودی نام سرور ندارد. لطفا مطمئن شوید که دامنه کار می‌کند قبل از اینکه آن را اینجا تنظیم کنید."
+
+#: pretalx/orga/forms/event.py:252
+msgid "Your default language needs to be one of your active languages."
+msgstr "زبان پیش‌فرض شما باید یکی از زبان‌های فعال شما باشد."
+
+#: pretalx/orga/forms/event.py:390
+msgid "Contact address"
+msgstr "نشانی تماس"
+
+#: pretalx/orga/forms/event.py:392
+msgid "Reply-To address. If this setting is empty and you have no custom sender, your event email address will be used as Reply-To address."
+msgstr "نشانی پاسخ به. اگر این تنظیم خالی باشد و شما هیچ فرستنده سفارشی ندارید، نشانی رایانامه رویداد شما به‌عنوان نشانی پاسخ به استفاده خواهد شد."
+
+#: pretalx/orga/forms/event.py:397
+msgid "Mail subject prefix"
+msgstr "پیشوند موضوع رایانامه"
+
+#: pretalx/orga/forms/event.py:399
+msgid "The prefix will be prepended to outgoing mail subjects in [brackets]."
+msgstr "پیشوند به موضوع رایانامه‌های خروجی در [براکت‌ها] اضافه خواهد شد."
+
+#: pretalx/orga/forms/event.py:404
+msgid "Mail signature"
+msgstr "امضای رایانامه"
+
+#: pretalx/orga/forms/event.py:406
+msgid "The signature will be added to outgoing mails, preceded by “-- ”."
+msgstr "امضا به رایانامه‌های خروجی اضافه خواهد شد، پیش از آن «-- » قرار خواهد گرفت."
+
+#: pretalx/orga/forms/event.py:414
+msgid "Use custom SMTP server"
+msgstr "استفاده از سرور SMTP سفارشی"
+
+#: pretalx/orga/forms/event.py:416
+msgid "All mail related to your event will be sent over the SMTP server specified by you."
+msgstr "تمام رایانامه‌های مرتبط با رویداد شما از طریق سرور SMTP مشخص شده توسط شما ارسال خواهد شد."
+
+#: pretalx/orga/forms/event.py:421
+msgid "Sender address"
+msgstr "نشانی فرستنده"
+
+#: pretalx/orga/forms/event.py:422
+msgid "Sender address for outgoing emails."
+msgstr "نشانی فرستنده برای رایانامه‌های خروجی."
+
+#: pretalx/orga/forms/event.py:425
+msgid "Hostname"
+msgstr "نام میزبان"
+
+#: pretalx/orga/forms/event.py:426 pretalx/orga/templates/orga/admin/admin.html:84
+msgid "Port"
+msgstr "پورت"
+
+#: pretalx/orga/forms/event.py:427
+msgid "Username"
+msgstr "نام کاربری"
+
+#: pretalx/orga/forms/event.py:429 pretalx/orga/templates/orga/admin/admin.html:90 pretalx/person/forms.py:51 pretalx/person/forms.py:66
+msgid "Password"
+msgstr "گذرواژه"
+
+#: pretalx/orga/forms/event.py:437
+msgid "Use STARTTLS"
+msgstr "استفاده از STARTTLS"
+
+#: pretalx/orga/forms/event.py:438
+msgid "Commonly enabled on port 587."
+msgstr "معمولا روی پورت 587 فعال می‌شود."
+
+#: pretalx/orga/forms/event.py:442
+msgid "Use SSL"
+msgstr "استفاده از SSL"
+
+#: pretalx/orga/forms/event.py:442
+msgid "Commonly enabled on port 465."
+msgstr "معمولا روی پورت 465 فعال می‌شود."
+
+#: pretalx/orga/forms/event.py:470
+msgid "You have to provide a sender address if you use a custom SMTP server."
+msgstr "اگر از سرور SMTP سفارشی استفاده می‌کنید، باید یک نشانی فرستنده ارائه دهید."
+
+#: pretalx/orga/forms/event.py:479
+msgid "You can activate either SSL or STARTTLS security, but not both at the same time."
+msgstr "می‌توانید امنیت SSL یا STARTTLS را فعال کنید، اما نمی‌توانید هر دو را هم‌زمان فعال کنید."
+
+#: pretalx/orga/forms/event.py:496
+msgid "You have to activate either SSL or STARTTLS security if you use a non-local mailserver due to data protection reasons. Your administrator can add an instance-wide bypass. If you use this bypass, please also adjust your Privacy Policy."
+msgstr "اگر از سرور رایانامه غیرمحلی استفاده می‌کنید، به دلیل ملاحظات حفاظت داده باید امنیت SSL یا STARTTLS را فعال کنید. مدیر شما می‌تواند یک بی‌پاس سراسری اضافه کند. اگر از این بی‌پاس استفاده می‌کنید، لطفا سیاست حریم خصوصی خود را نیز تنظیم کنید."
+
+#: pretalx/orga/forms/event.py:527
+msgid "Require a review score"
+msgstr "نیاز به امتیاز بازبینی"
+
+#: pretalx/orga/forms/event.py:530
+msgid "Require a review text"
+msgstr "نیاز به متن بازبینی"
+
+#: pretalx/orga/forms/event.py:533
+msgid "Score display"
+msgstr "نمایش امتیاز"
+
+#: pretalx/orga/forms/event.py:536
+msgid "Text and score, e.g “Good (3)”"
+msgstr "متن و امتیاز، مانند «خوب (۳)»"
+
+#: pretalx/orga/forms/event.py:537
+msgid "Score and text, e.g “3 (good)”"
+msgstr "امتیاز و متن، مانند «۳ (خوب)»"
+
+#: pretalx/orga/forms/event.py:538
+msgid "Just scores"
+msgstr "فقط امتیازات"
+
+#: pretalx/orga/forms/event.py:539
+msgid "Just text"
+msgstr "فقط متن"
+
+#: pretalx/orga/forms/event.py:543
+msgid "This is how the score will look like on the review interface. The dashboard will always show numerical scores."
+msgstr "این‌گونه امتیاز در رابط بازبینی نمایش داده خواهد شد. پیشخوان همیشه امتیازات عددی را نمایش می‌دهد."
+
+#: pretalx/orga/forms/event.py:548
+msgid "Score aggregation method"
+msgstr "روش تجمیع امتیاز"
+
+#: pretalx/orga/forms/event.py:550 pretalx/orga/templates/orga/review/dashboard.html:160
+msgid "Median"
+msgstr "میانه"
+
+#: pretalx/orga/forms/event.py:550
+msgid "Average (mean)"
+msgstr "میانگین"
+
+#: pretalx/orga/forms/event.py:554
+msgid "Help text for reviewers"
+msgstr "متن راهنما برای بازبین‌ها"
+
+#: pretalx/orga/forms/event.py:556
+msgid "This text will be shown at the top of every review, as long as reviews can be created or edited."
+msgstr "این متن در بالای هر بازبینی نمایش داده خواهد شد، مادامی که بازبینی‌ها قابل ایجاد یا ویرایش باشند."
+
+#: pretalx/orga/forms/event.py:576
+msgid "Show the widget even if the schedule is not public"
+msgstr "ابزارک را حتی اگر برنامه زمان‌بندی عمومی نباشد نمایش دهید"
+
+#: pretalx/orga/forms/event.py:578
+msgid "Set to allow external pages to show the schedule widget, even if the schedule is not shown here using eventyay."
+msgstr "برای اجازه به صفحات خارجی برای نمایش ابزارک برنامه زمان‌بندی، حتی اگر برنامه زمان‌بندی اینجا با استفاده از eventyay نمایش داده نشود تنظیم کنید."
+
+#: pretalx/orga/forms/event.py:594
+msgid "Limit days"
+msgstr "محدود کردن روزها"
+
+#: pretalx/orga/forms/event.py:599
+msgid "You can limit the days shown in the widget. Leave empty to show all days."
+msgstr "می‌توانید روزهای نمایش داده شده در ابزارک را محدود کنید. برای نمایش همه روزها خالی بگذارید."
+
+#: pretalx/orga/forms/event.py:605
+msgid "Widget language"
+msgstr "زبان ابزارک"
+
+#: pretalx/orga/forms/event.py:631
+msgid "The end of a phase has to be after its start."
+msgstr "پایان یک فاز باید بعد از شروع آن باشد."
+
+#: pretalx/orga/forms/export.py:15
+msgid "Export format"
+msgstr "فرمت خروجی"
+
+#: pretalx/orga/forms/export.py:17
+msgid "A CSV export can be opened directly in Excel and similar applications."
+msgstr "یک خروجی CSV می‌تواند مستقیما در Excel و برنامه‌های مشابه باز شود."
+
+#: pretalx/orga/forms/export.py:20
+msgid "CSV export"
+msgstr "خروجی CSV"
+
+#: pretalx/orga/forms/export.py:21
+msgid "JSON export"
+msgstr "خروجی JSON"
+
+#: pretalx/orga/forms/export.py:27
+msgid "Data delimiter"
+msgstr "جداکننده داده"
+
+#: pretalx/orga/forms/export.py:29
+msgid "How do you want to separate data within a single cell (for example, multiple speakers in one session)?"
+msgstr "چگونه می‌خواهید داده‌ها را در یک سلول واحد جدا کنید (به عنوان مثال، چندین سخنران در یک جلسه)؟"
+
+#: pretalx/orga/forms/export.py:32
+msgid "Newline"
+msgstr "خط جدید"
+
+#: pretalx/orga/forms/export.py:33
+msgid "Comma"
+msgstr "کاما"
+
+#: pretalx/orga/forms/export.py:74
+#, python-brace-format
+msgid "Answer to the question “{q}”"
+msgstr "پاسخ به سوال «{q}»"
+
+#: pretalx/orga/forms/export.py:89
+msgid "Please select a delimiter for your CSV export."
+msgstr "لطفا یک جداکننده برای خروجی CSV خود انتخاب کنید."
+
+#: pretalx/orga/forms/mails.py:85
+msgid ""
+"- First missing question\n"
+"- Second missing question"
+msgstr ""
+"- سوال اول مفقود\n"
+"- سوال دوم مفقود"
+
+#: pretalx/orga/forms/mails.py:87
+msgid "The list of questions that the user has not answered, as bullet points"
+msgstr "فهرست سوالاتی که کاربر به آن‌ها پاسخ نداده است، به صورت نکات برجسته"
+
+#: pretalx/orga/forms/mails.py:145
+msgid "Invalid email template! Please check that you don’t have stray { or } somewhere, and that there are no spaces inside the {} blocks."
+msgstr "قالب رایانامه نامعتبر! لطفا بررسی کنید که در جایی { یا } اشتباه نداشته باشید و داخل بلوک‌های {} فاصله‌ای وجود نداشته باشد."
+
+#: pretalx/orga/forms/mails.py:152
+msgid "Unknown placeholder!"
+msgstr "جای‌نگهدار ناشناخته!"
+
+#: pretalx/orga/forms/mails.py:172
+#, python-brace-format
+msgid "You have an empty link in your email, labeled “{text}”!"
+msgstr "شما یک پیوند خالی در رایانامه خود دارید، با برچسب «{text}»!"
+
+#: pretalx/orga/forms/mails.py:227
+msgid "An email needs to have at least one recipient."
+msgstr "یک رایانامه باید حداقل یک گیرنده داشته باشد."
+
+#: pretalx/orga/forms/mails.py:262
+msgid "Send immediately"
+msgstr "بلافاصله ارسال کنید"
+
+#: pretalx/orga/forms/mails.py:265
+msgid "If you check this, the emails will be sent immediately, instead of being put in the outbox."
+msgstr "اگر این گزینه را انتخاب کنید، رایانامه‌ها بلافاصله ارسال می‌شوند، به‌جای اینکه در صندوق خروجی قرار گیرند."
+
+#: pretalx/orga/forms/mails.py:282
+msgid "Recipient groups"
+msgstr "گروه‌های گیرندگان"
+
+#: pretalx/orga/forms/mails.py:299
+msgid "Reviewers"
+msgstr "بازبین‌ها"
+
+#: pretalx/orga/forms/mails.py:303
+msgid "Other teams"
+msgstr "تیم‌های دیگر"
+
+#: pretalx/orga/forms/mails.py:348 pretalx/orga/forms/mails.py:352 pretalx/orga/templates/orga/admin/user_detail.html:122 pretalx/orga/templates/orga/cfp/submission_type_view.html:49 pretalx/orga/templates/orga/cfp/track_view.html:51 pretalx/orga/templates/orga/organiser/speaker_list.html:51 pretalx/orga/templates/orga/speaker/list.html:41
+#: pretalx/orga/templates/orga/submission/stats.html:25 pretalx/orga/templates/orga/submission/stats.html:37 pretalx/orga/templates/orga/submission/tag_list.html:25
+msgid "Proposals"
+msgstr "طرح‌های پیشنهادی"
+
+#: pretalx/orga/forms/mails.py:350
+msgid "Select proposals that should receive the email regardless of the other filters."
+msgstr "طرح‌های پیشنهادی را انتخاب کنید که باید رایانامه دریافت کنند، بدون توجه به فیلترهای دیگر."
+
+#: pretalx/orga/forms/mails.py:359
+msgid "Select speakers that should receive the email regardless of the other filters."
+msgstr "سخنرانانی را انتخاب کنید که باید رایانامه دریافت کنند، بدون توجه به فیلترهای دیگر."
+
+#: pretalx/orga/forms/mails.py:386
+msgid "If you provide only one language, that language will be used for all emails. If you provide multiple languages, the best fit for each speaker will be used."
+msgstr "اگر فقط یک زبان ارائه دهید، همان زبان برای تمام رایانامه‌ها استفاده خواهد شد. اگر چندین زبان ارائه دهید، بهترین زبان برای هر سخنران استفاده می‌شود."
+
+#: pretalx/orga/forms/mails.py:525 pretalx/orga/templates/orga/base.html:263 pretalx/orga/templates/orga/cfp/track_view.html:7 pretalx/orga/templates/orga/cfp/track_view.html:25 pretalx/submission/forms/submission.py:265 pretalx/submission/models/question.py:156
+msgid "Tracks"
+msgstr "مسیرها"
+
+#: pretalx/orga/forms/review.py:92
+msgid "No score"
+msgstr "بدون امتیاز"
+
+#: pretalx/orga/forms/review.py:146
+msgid "Please provide a review text!"
+msgstr "لطفا یک متن بازبینی ارائه دهید!"
+
+#: pretalx/orga/forms/review.py:153
+msgid "Please provide a review score!"
+msgstr "لطفا یک امتیاز بازبینی ارائه دهید!"
+
+#: pretalx/orga/forms/review.py:183
+msgid "Assign proposals to reviewers"
+msgstr "طرح‌های پیشنهادی را به بازبین‌ها اختصاص دهید"
+
+#: pretalx/orga/forms/review.py:184
+msgid "Assign reviewers to proposals"
+msgstr "بازبین‌ها را به طرح‌های پیشنهادی اختصاص دهید"
+
+#: pretalx/orga/forms/review.py:257
+msgid "Proposal ID"
+msgstr "شناسه طرح پیشنهادی"
+
+#: pretalx/orga/forms/review.py:266
+msgid "Reviewer name"
+msgstr "نام بازبین"
+
+#: pretalx/orga/forms/review.py:270
+msgid "Reviewer email"
+msgstr "رایانامه بازبین"
+
+#: pretalx/orga/forms/review.py:328
+#, python-brace-format
+msgid "Score in “{score_category}”"
+msgstr "امتیاز در «{score_category}»"
+
+#: pretalx/orga/forms/review.py:371 pretalx/person/models/information.py:51 pretalx/submission/models/resource.py:26
+msgid "File"
+msgstr "پرونده"
+
+#: pretalx/orga/forms/review.py:373 pretalx/orga/forms/review.py:376
+msgid "Replace current assignments"
+msgstr "جایگزینی تخصیص‌های فعلی"
+
+#: pretalx/orga/forms/review.py:375
+msgid "Keep current assignments"
+msgstr "حفظ تخصیص‌های فعلی"
+
+#: pretalx/orga/forms/review.py:379
+msgid "Select to remove all current assignments and replace them with the import. Otherwise, the import will be an addition to the current assignments."
+msgstr "برای حذف تمام تخصیص‌های فعلی و جایگزینی آن‌ها با واردات، این گزینه را انتخاب کنید. در غیر این صورت، واردات به تخصیص‌های فعلی اضافه خواهد شد."
+
+#: pretalx/orga/forms/review.py:385
+msgid "Cannot parse JSON file."
+msgstr "نمی‌توان پرونده JSON را تحلیل کرد."
+
+#: pretalx/orga/forms/review.py:402
+msgid "Unknown user: {}"
+msgstr "کاربر ناشناخته: {}"
+
+#: pretalx/orga/forms/review.py:412
+msgid "Unknown proposal: {}"
+msgstr "طرح پیشنهادی ناشناخته: {}"
+
+#: pretalx/orga/forms/schedule.py:21
+msgid "Notify speakers of changes"
+msgstr "سخنرانان را از تغییرات مطلع کنید"
+
+#: pretalx/orga/forms/schedule.py:36
+msgid "We released a new schedule version!"
+msgstr "ما نسخه جدیدی از برنامه زمان‌بندی منتشر کردیم!"
+
+#: pretalx/orga/forms/schedule.py:45
+msgid "This schedule version was used already, please choose a different one."
+msgstr "این نسخه برنامه زمان‌بندی قبلا استفاده شده است، لطفا نسخه دیگری انتخاب کنید."
+
+#: pretalx/orga/forms/schedule.py:61 pretalx/orga/forms/speaker.py:13 pretalx/orga/templates/orga/speaker/information_list.html:53
+msgid "Target group"
+msgstr "گروه هدف"
+
+#: pretalx/orga/forms/schedule.py:97
+msgid "Speaker IDs"
+msgstr "شناسه‌های سخنران"
+
+#: pretalx/orga/forms/schedule.py:99
+msgid "The unique ID of a speaker is used in the speaker URL and in exports"
+msgstr "شناسه یکتای سخنران در نشانی اینترنتی سخنران و در خروجی‌ها استفاده می‌شود"
+
+#: pretalx/orga/forms/schedule.py:104
+msgid "Speaker names"
+msgstr "نام‌های سخنرانان"
+
+#: pretalx/orga/forms/schedule.py:120 pretalx/orga/forms/schedule.py:139
+msgid "date"
+msgstr "تاریخ"
+
+#: pretalx/orga/forms/schedule.py:128 pretalx/orga/forms/schedule.py:144
+msgid "time"
+msgstr "زمان"
+
+#: pretalx/orga/forms/schedule.py:149
+msgid "Median score"
+msgstr "امتیاز میانه"
+
+#: pretalx/orga/forms/schedule.py:150
+msgid "Median review score, if there have been reviews yet"
+msgstr "امتیاز میانه بازبینی، اگر بازبینی‌هایی انجام شده باشد"
+
+#: pretalx/orga/forms/schedule.py:154
+msgid "Average (mean) score"
+msgstr "میانگین امتیاز"
+
+#: pretalx/orga/forms/schedule.py:155
+msgid "Average review score, if there have been reviews yet"
+msgstr "میانگین امتیاز بازبینی، اگر بازبینی‌هایی انجام شده باشد"
+
+#: pretalx/orga/forms/schedule.py:161
+msgid "Resources provided by the speaker, either as links or as uploaded files"
+msgstr "منابع ارائه‌شده توسط سخنران، به‌صورت پیوندها یا پرونده‌های بارگذاری شده"
+
+#: pretalx/orga/forms/speaker.py:16
+msgid "With accepted proposals"
+msgstr "با طرح‌های پیشنهادی پذیرفته‌شده"
+
+#: pretalx/orga/forms/speaker.py:17
+msgid "With confirmed proposals"
+msgstr "با طرح‌های پیشنهادی تأیید شده"
+
+#: pretalx/orga/forms/speaker.py:18
+msgid "With rejected proposals"
+msgstr "با طرح‌های پیشنهادی رد شده"
+
+#: pretalx/orga/forms/speaker.py:31
+msgid "Proposal IDs"
+msgstr "شناسه‌های طرح پیشنهادی"
+
+#: pretalx/orga/forms/speaker.py:36
+msgid "Proposal titles"
+msgstr "عناوین طرح پیشنهادی"
+
+#: pretalx/orga/forms/speaker.py:40 pretalx/orga/templates/orga/cfp/text.html:192 pretalx/orga/templates/orga/submission/review.html:136 pretalx/orga/templates/orga/submission/speakers.html:45 pretalx/person/models/profile.py:31
+msgid "Biography"
+msgstr "زندگی‌نامه"
+
+#: pretalx/orga/forms/speaker.py:44
+msgid "Picture"
+msgstr "تصویر"
+
+#: pretalx/orga/forms/speaker.py:45
+msgid "The link to the speaker’s profile picture"
+msgstr "پیوند به تصویر نمایه سخنران"
+
+#: pretalx/orga/forms/speaker.py:49
+msgid "Picture Source"
+msgstr "منبع تصویر"
+
+#: pretalx/orga/forms/speaker.py:50
+msgid "The source of the speaker's profile picture"
+msgstr "منبع تصویر نمایه سخنران"
+
+#: pretalx/orga/forms/speaker.py:54
+msgid "Picture License"
+msgstr "مجوز تصویر"
+
+#: pretalx/orga/forms/speaker.py:55
+msgid "The license of the speaker's profile picture"
+msgstr "مجوز تصویر نمایه سخنران"
+
+#: pretalx/orga/forms/submission.py:81 pretalx/submission/models/submission.py:169
+msgid "Proposal state"
+msgstr "وضعیت طرح پیشنهادی"
+
+#: pretalx/orga/forms/submission.py:138 pretalx/submission/forms/submission.py:151
+msgid "Leave empty to use the default duration for the session type."
+msgstr "برای استفاده از مدت زمان پیش‌فرض برای نوع جلسه خالی بگذارید."
+
+#: pretalx/orga/forms/submission.py:149
+msgid "The end time has to be after the start time."
+msgstr "زمان پایان باید پس از زمان شروع باشد."
+
+#: pretalx/orga/forms/submission.py:270 pretalx/orga/templates/orga/review/dashboard.html:310
+msgid "Mark the new state as “pending”"
+msgstr "وضعیت جدید را به عنوان «در انتظار» علامت‌گذاری کنید"
+
+#: pretalx/orga/forms/submission.py:272 pretalx/orga/templates/orga/review/dashboard.html:312
+msgid "If you mark state changes as pending, they won’t be visible to speakers right away. You can always apply pending changes for some or all proposals in one go once you’re ready to make your decisions public."
+msgstr "اگر تغییرات وضعیت را به عنوان در انتظار علامت‌گذاری کنید، فوراً برای سخنرانان قابل مشاهده نخواهند بود. می‌توانید تغییرات در انتظار را برای برخی یا همه طرح‌های پیشنهادی به یک‌باره اعمال کنید زمانی که آماده انتشار تصمیمات خود هستید."
+
+#: pretalx/orga/forms/submission.py:283
+msgid "The email address of the speaker holding the session. They will be invited to create an account."
+msgstr "نشانی رایانامه سخنرانی که جلسه را برگزار می‌کند. آن‌ها برای ایجاد حساب کاربری دعوت خواهند شد."
+
+#: pretalx/orga/forms/submission.py:289
+msgid "Speaker name"
+msgstr "نام سخنران"
+
+#: pretalx/orga/forms/submission.py:290
+msgid "The name of the speaker that should be displayed publicly."
+msgstr "نام سخنرانی که باید به صورت عمومی نمایش داده شود."
+
+#: pretalx/orga/forms/submission.py:294
+msgid "Invite language"
+msgstr "زبان دعوت‌نامه"
+
+#: pretalx/orga/forms/submission.py:298
+msgid "The language in which the speaker will receive their invitation email."
+msgstr "زبانی که سخنران رایانامه دعوت‌نامه خود را دریافت خواهد کرد."
+
+#: pretalx/orga/forms/submission.py:311
+msgid "Please provide an email address."
+msgstr "لطفا یک نشانی رایانامه ارائه دهید."
+
+#: pretalx/orga/forms/widgets.py:39
+msgid "Community translations"
+msgstr "ترجمه‌های اجتماع"
+
+#: pretalx/orga/forms/widgets.py:41
+#, python-brace-format
+msgid "These translations are not maintained by the eventyay team. We cannot vouch for their correctness, and new or recently changed features might not be translated and will show in English instead. You can <a href=\"{url}\" target=\"_blank\">contribute to the translations</a>."
+msgstr "این ترجمه‌ها توسط تیم eventyay نگهداری نمی‌شوند. ما نمی‌توانیم صحت آن‌ها را تضمین کنیم و ویژگی‌های جدید یا تازه تغییر یافته ممکن است ترجمه نشده و به جای آن به انگلیسی نمایش داده شوند. شما می‌توانید <a href=\"{url}\" target=\"_blank\">به ترجمه‌ها کمک کنید</a>."
+
+#: pretalx/orga/phrases.py:7
+msgid "The event end cannot be before the start."
+msgstr "پایان رویداد نمی‌تواند قبل از شروع باشد."
+
+#: pretalx/orga/phrases.py:9
+msgid "Frontpage header pattern"
+msgstr "الگوی سربرگ صفحه اصلی"
+
+#: pretalx/orga/phrases.py:11
+msgid "Choose how the frontpage header banner will be styled. Pattern source: <a href=\"http://www.heropatterns.com/\">heropatterns.com</a>, CC BY 4.0."
+msgstr "نحوه استایل‌دهی به بنر سربرگ صفحه اصلی را انتخاب کنید. منبع الگو: <a href=\"http://www.heropatterns.com/\">heropatterns.com</a>، CC BY 4.0."
+
+#: pretalx/orga/phrases.py:13
+msgid "Schedule display format"
+msgstr "فرمت نمایش برنامه زمان‌بندی"
+
+#: pretalx/orga/phrases.py:15
+msgid "The unique ID of a proposal is used in the proposal URL and in exports"
+msgstr "شناسه یکتای طرح پیشنهادی در نشانی اینترنتی طرح پیشنهادی و در خروجی‌ها استفاده می‌شود"
+
+#: pretalx/orga/phrases.py:17
+msgid "The password was reset and the user was notified."
+msgstr "گذرواژه بازنشانی شد و به کاربر اطلاع داده شد."
+
+#: pretalx/orga/phrases.py:19
+msgid "The password reset email could not be sent, so the password was not reset."
+msgstr "رایانامه بازنشانی گذرواژه ارسال نشد، بنابراین گذرواژه بازنشانی نشد."
+
+#: pretalx/orga/phrases.py:22
+#, python-brace-format
+msgid "{count} emails have been saved to the outbox – you can make individual changes there or just send them all."
+msgstr "{count} رایانامه به صندوق خروجی ذخیره شده است – می‌توانید تغییرات جداگانه در آنجا اعمال کنید یا همه آن‌ها را ارسال کنید."
+
+#: pretalx/orga/templates/orga/admin/admin.html:14 pretalx/orga/templates/orga/admin/admin.html:18
+msgid "Administrator information"
+msgstr "اطلاعات مدیریت"
+
+#: pretalx/orga/templates/orga/admin/admin.html:22
+#, python-format
+msgid "You are running %(site_name)s in development mode. Please <strong>STOP</strong> and set the DEBUG variable to False if this page is in any way reachable from the internet."
+msgstr "شما در حال اجرای %(site_name)s در حالت توسعه هستید. لطفا <strong>توقف کنید</strong> و متغیر DEBUG را به False تنظیم کنید اگر این صفحه به هر طریقی از اینترنت قابل دسترسی است."
+
+#: pretalx/orga/templates/orga/admin/admin.html:32
+msgid "Your eventyay version is:"
+msgstr "نسخه eventyay شما است:"
+
+#: pretalx/orga/templates/orga/admin/admin.html:34
+#, python-format
+msgid "You can check for updates <a href=\"%(update_url)s\">here</a>."
+msgstr "می‌توانید به‌روزرسانی‌ها را <a href=\"%(update_url)s\">اینجا</a> بررسی کنید."
+
+#: pretalx/orga/templates/orga/admin/admin.html:39 pretalx/orga/templates/orga/base.html:207 pretalx/orga/templates/orga/base.html:427 pretalx/orga/templates/orga/organiser/detail.html:6 pretalx/orga/templates/orga/settings/form.html:27 pretalx/orga/templates/orga/settings/form.html:30
+msgid "Settings"
+msgstr "تنظیمات"
+
+#: pretalx/orga/templates/orga/admin/admin.html:43
+msgid "Settings have been loaded from:"
+msgstr "تنظیمات از مکان زیر بارگذاری شده‌اند:"
+
+#: pretalx/orga/templates/orga/admin/admin.html:48
+msgid "No settings files were found, all settings are either set to their default value or have been read from environment variables."
+msgstr "هیچ پرونده تنظیماتی یافت نشد، تمام تنظیمات یا به مقدار پیش‌فرض تنظیم شده‌اند یا از متغیرهای محیطی خوانده شده‌اند."
+
+#: pretalx/orga/templates/orga/admin/admin.html:53
+msgid "Database"
+msgstr "پایگاه داده"
+
+#: pretalx/orga/templates/orga/admin/admin.html:56
+msgid "Driver"
+msgstr "درایور"
+
+#: pretalx/orga/templates/orga/admin/admin.html:64
+msgid "Files"
+msgstr "پرونده‌ها"
+
+#: pretalx/orga/templates/orga/admin/admin.html:67
+msgid "Log"
+msgstr "گزارش‌ها"
+
+#: pretalx/orga/templates/orga/admin/admin.html:70
+msgid "Static files"
+msgstr "پرونده‌های استاتیک"
+
+#: pretalx/orga/templates/orga/admin/admin.html:73
+msgid "Media files"
+msgstr "پرونده‌های رسانه‌ای"
+
+#: pretalx/orga/templates/orga/admin/admin.html:78 pretalx/orga/templates/orga/base.html:393
+msgid "Mails"
+msgstr "رایانامه‌ها"
+
+#: pretalx/orga/templates/orga/admin/admin.html:81
+msgid "Host"
+msgstr "میزبان"
+
+#: pretalx/orga/templates/orga/admin/admin.html:87 pretalx/orga/templates/orga/mails/_placeholder_group.html:12 pretalx/orga/views/admin.py:161
+msgid "User"
+msgstr "کاربر"
+
+#: pretalx/orga/templates/orga/admin/admin.html:92
+msgid "An email password has been set."
+msgstr "یک گذرواژه رایانامه تنظیم شده است."
+
+#: pretalx/orga/templates/orga/admin/admin.html:94
+msgid "No email password has been set."
+msgstr "هیچ گذرواژه رایانامه‌ای تنظیم نشده است."
+
+#: pretalx/orga/templates/orga/admin/admin.html:100
+msgid "System"
+msgstr "سیستم"
+
+#: pretalx/orga/templates/orga/admin/admin.html:103
+msgid "Executable"
+msgstr "پیوند اجرایی"
+
+#: pretalx/orga/templates/orga/admin/admin.html:117
+msgid "On errors, emails will be sent to:"
+msgstr "در صورت خطا، رایانامه‌ها به این نشانی ارسال خواهند شد:"
+
+#: pretalx/orga/templates/orga/admin/admin.html:123
+msgid "On errors, no emails will be sent."
+msgstr "در صورت خطا، هیچ رایانامه‌ای ارسال نخواهد شد."
+
+#: pretalx/orga/templates/orga/admin/admin.html:130
+msgid "No redis server has been configured."
+msgstr "هیچ سرور redis پیکربندی نشده است."
+
+#: pretalx/orga/templates/orga/admin/admin.html:132
+msgid "Redis is used as cache backend:"
+msgstr "Redis به‌عنوان بک‌اند کش استفاده می‌شود:"
+
+#: pretalx/orga/templates/orga/admin/admin.html:137
+msgid "No celery workers have been configured."
+msgstr "هیچ کارگر celery پیکربندی نشده است."
+
+#: pretalx/orga/templates/orga/admin/admin.html:141
+msgid "Broker"
+msgstr "واسطه"
+
+#: pretalx/orga/templates/orga/admin/admin.html:144
+msgid "Backend"
+msgstr "بک‌اند"
+
+#: pretalx/orga/templates/orga/admin/admin.html:147
+msgid "Current queue length"
+msgstr "طول صف فعلی"
+
+#: pretalx/orga/templates/orga/admin/update.html:5 pretalx/orga/templates/orga/admin/update.html:9
+msgid "Update check results"
+msgstr "نتایج بررسی به‌روزرسانی"
+
+#: pretalx/orga/templates/orga/admin/update.html:12
+msgid "Update checks are disabled."
+msgstr "بررسی‌های به‌روزرسانی غیرفعال هستند."
+
+#: pretalx/orga/templates/orga/admin/update.html:15
+msgid "No update check has been performed yet since the last update of this installation. Update checks are performed on a daily basis if your cronjob is set up properly."
+msgstr "هیچ بررسی به‌روزرسانی از آخرین به‌روزرسانی این نصب انجام نشده است. بررسی‌های به‌روزرسانی به صورت روزانه انجام می‌شوند اگر cronjob شما به درستی تنظیم شده باشد."
+
+#: pretalx/orga/templates/orga/admin/update.html:22 pretalx/orga/templates/orga/admin/update.html:42 pretalx/orga/templates/orga/admin/update.html:55
+msgid "Check for updates now"
+msgstr "اکنون به‌روزرسانی‌ها را بررسی کنید"
+
+#: pretalx/orga/templates/orga/admin/update.html:28
+msgid "The last update check was not successful."
+msgstr "آخرین بررسی به‌روزرسانی موفقیت‌آمیز نبود."
+
+#: pretalx/orga/templates/orga/admin/update.html:30
+msgid "The eventyay.com server returned an error code."
+msgstr "سرور eventyay.com یک کد خطا بازگرداند."
+
+#: pretalx/orga/templates/orga/admin/update.html:32
+msgid "The eventyay.com server could not be reached."
+msgstr "دسترسی به سرور eventyay.com امکان‌پذیر نبود."
+
+#: pretalx/orga/templates/orga/admin/update.html:34
+msgid "This installation appears to be a development installation."
+msgstr "به نظر می‌رسد این نصب یک نصب توسعه‌ای است."
+
+#: pretalx/orga/templates/orga/admin/update.html:50
+#, python-format
+msgid "Last updated: %(date)s"
+msgstr "آخرین به‌روزرسانی: %(date)s"
+
+#: pretalx/orga/templates/orga/admin/update.html:63
+msgid "Component"
+msgstr "مولفه"
+
+#: pretalx/orga/templates/orga/admin/update.html:64
+msgid "Installed version"
+msgstr "نسخه نصب شده"
+
+#: pretalx/orga/templates/orga/admin/update.html:65
+msgid "Latest version"
+msgstr "جدیدترین نسخه"
+
+#: pretalx/orga/templates/orga/admin/update.html:81
+msgid "Update check settings"
+msgstr "تنظیمات بررسی به‌روزرسانی"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:34
+msgid "Deactivate account"
+msgstr "غیرفعال کردن حساب کاربری"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:39
+msgid "Activate account"
+msgstr "فعال کردن حساب کاربری"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:53 pretalx/orga/templates/orga/admin/user_list.html:35
+msgid "Last login"
+msgstr "آخرین ورود"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:57 pretalx/orga/templates/orga/admin/user_list.html:36
+msgid "Password reset time"
+msgstr "زمان بازنشانی گذرواژه"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:65
+msgid "Timezone"
+msgstr "منطقه زمانی"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:80 pretalx/orga/templates/orga/admin/user_list.html:32 pretalx/orga/templates/orga/base.html:219 pretalx/orga/templates/orga/base.html:434 pretalx/orga/templates/orga/organiser/list.html:8 pretalx/orga/templates/orga/organiser/team_list.html:5 pretalx/orga/templates/orga/organiser/team_list.html:9
+msgid "Teams"
+msgstr "تیم‌ها"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:85 pretalx/orga/templates/orga/organiser/team_list.html:14 pretalx/orga/templates/orga/review/assignment.html:49 pretalx/orga/templates/orga/settings/team_detail.html:7 pretalx/orga/templates/orga/settings/team_detail.html:24 pretalx/orga/templates/orga/settings/team_detail.html:114 pretalx/orga/views/organiser.py:153
+msgid "Team"
+msgstr "تیم"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:88 pretalx/orga/templates/orga/settings/team_detail.html:114
+msgid "Permissions"
+msgstr "مجوزها"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:102 pretalx/orga/templates/orga/organiser/team_list.html:16
+msgid "All events"
+msgstr "تمام رویدادها"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:113
+msgid "User isn't in any teams"
+msgstr "کاربر در هیچ تیمی نیست"
+
+#: pretalx/orga/templates/orga/admin/user_detail.html:144
+msgid "User hasn't submitted any proposals"
+msgstr "کاربر هیچ طرح پیشنهادی ارسال نکرده است"
+
+#: pretalx/orga/templates/orga/admin/user_list.html:8 pretalx/orga/templates/orga/admin/user_list.html:17 pretalx/orga/templates/orga/base.html:479
+msgid "Users"
+msgstr "کاربران"
+
+#: pretalx/orga/templates/orga/admin/user_list.html:34
+msgid "Submissions"
+msgstr "ارسال‌ها"
+
+#: pretalx/orga/templates/orga/auth/login.html:4
+msgid "Sign in"
+msgstr "ورود"
+
+#: pretalx/orga/templates/orga/base.html:75
+msgid "The {{ site_config.name }} logo"
+msgstr "آرم {{ site_config.name }}"
+
+#: pretalx/orga/templates/orga/base.html:91 pretalx/orga/templates/orga/base.html:100
+msgid "View event"
+msgstr "مشاهده رویداد"
+
+#: pretalx/orga/templates/orga/base.html:135
+msgid "You’re using eventyay as a superuser. This is not recommended."
+msgstr "شما از eventyay به‌عنوان superuser استفاده می‌کنید. این کار توصیه نمی‌شود."
+
+#: pretalx/orga/templates/orga/base.html:139
+msgid "Please click here to switch to an administrator account."
+msgstr "لطفا اینجا کلیک کنید تا به یک حساب کاربری مدیریت تغییر دهید."
+
+#: pretalx/orga/templates/orga/base.html:146
+msgid "Starting with version 1.1.0, eventyay automatically checks for updates in the background. During this check, anonymous data is transmitted to servers operated by the eventyay developers. Click on this message to find out more, disable this feature or enter your email address to get notified via email if a new update arrives. This message will disappear once you clicked it."
+msgstr "از نسخه ۱.۱.۰ به بعد، eventyay به‌صورت خودکار به‌روزرسانی‌ها را در پس‌زمینه بررسی می‌کند. در طول این بررسی، داده‌های ناشناس به سرورهای توسعه‌دهندگان eventyay ارسال می‌شود. روی این پیام کلیک کنید تا بیشتر بدانید، این ویژگی را غیرفعال کنید یا نشانی رایانامه خود را وارد کنید تا در صورت دریافت یک به‌روزرسانی جدید مطلع شوید. این پیام پس از کلیک شما ناپدید خواهد شد."
+
+#: pretalx/orga/templates/orga/base.html:170
+msgid "Organiser account"
+msgstr "حساب کاربری برگزارکننده"
+
+#: pretalx/orga/templates/orga/base.html:198 pretalx/orga/templates/orga/base.html:423 pretalx/orga/templates/orga/event_list.html:8
+msgid "Dashboard"
+msgstr "پیشخوان"
+
+#: pretalx/orga/templates/orga/base.html:229
+msgid "Widget"
+msgstr "ابزارک"
+
+#: pretalx/orga/templates/orga/base.html:245
+msgid "Call for Speakers"
+msgstr "فراخوان سخنرانان"
+
+#: pretalx/orga/templates/orga/base.html:253 pretalx/orga/templates/orga/mails/_mail_editor.html:31 pretalx/orga/templates/orga/submission/base.html:53
+msgid "Content"
+msgstr "محتوا"
+
+#: pretalx/orga/templates/orga/base.html:256 pretalx/orga/templates/orga/base.html:377
+msgid "Editor"
+msgstr "ویرایشگر"
+
+#: pretalx/orga/templates/orga/base.html:267 pretalx/orga/templates/orga/cfp/submission_type_view.html:20 pretalx/orga/templates/orga/cfp/submission_type_view.html:24 pretalx/submission/forms/submission.py:251
+msgid "Session types"
+msgstr "انواع جلسه"
+
+#: pretalx/orga/templates/orga/base.html:270 pretalx/orga/templates/orga/cfp/access_code_view.html:22 pretalx/orga/templates/orga/cfp/access_code_view.html:26
+msgid "Access codes"
+msgstr "کدهای دسترسی"
+
+#: pretalx/orga/templates/orga/base.html:292 pretalx/orga/templates/orga/review/dashboard.html:102 pretalx/orga/templates/orga/review/dashboard.html:198 pretalx/orga/templates/orga/submission/tag_list.html:6 pretalx/orga/templates/orga/submission/tag_list.html:9 pretalx/submission/forms/submission.py:271 pretalx/submission/models/submission.py:163
+msgid "Tags"
+msgstr "برچسب‌ها"
+
+#: pretalx/orga/templates/orga/base.html:295 pretalx/orga/templates/orga/submission/stats.html:18
+msgid "Statistics"
+msgstr "آمار"
+
+#: pretalx/orga/templates/orga/base.html:303 pretalx/orga/templates/orga/base.html:357 pretalx/orga/templates/orga/base.html:383
+msgid "Export"
+msgstr "خروجی"
+
+#: pretalx/orga/templates/orga/base.html:323 pretalx/orga/templates/orga/review/assignment-import.html:8 pretalx/orga/templates/orga/review/assignment-import.html:11 pretalx/orga/templates/orga/review/assignment.html:8 pretalx/orga/templates/orga/review/assignment.html:25
+msgid "Assign reviewers"
+msgstr "اختصاص بازبین‌ها"
+
+#: pretalx/orga/templates/orga/base.html:326
+msgid "Export reviews"
+msgstr "خروجی بازبینی‌ها"
+
+#: pretalx/orga/templates/orga/base.html:353 pretalx/schedule/models/room.py:44
+msgid "Speaker Information"
+msgstr "اطلاعات سخنران"
+
+#: pretalx/orga/templates/orga/base.html:380
+msgid "Rooms"
+msgstr "اتاق‌ها"
+
+#: pretalx/orga/templates/orga/base.html:403
+msgid "Outbox"
+msgstr "صندوق خروجی"
+
+#: pretalx/orga/templates/orga/base.html:406
+msgid "Compose emails"
+msgstr "نوشتن رایانامه‌ها"
+
+#: pretalx/orga/templates/orga/base.html:409
+msgid "Sent emails"
+msgstr "‌رایانامه‌های ارسال‌شده"
+
+#: pretalx/orga/templates/orga/base.html:412 pretalx/orga/templates/orga/mails/template_list.html:16
+msgid "Templates"
+msgstr "قالب‌ها"
+
+#: pretalx/orga/templates/orga/base.html:440 pretalx/orga/templates/orga/submission/speakers.html:10 pretalx/schedule/phrases.py:18
+msgid "Speakers"
+msgstr "سخنرانان"
+
+#: pretalx/orga/templates/orga/base.html:467
+msgid "Administration"
+msgstr "مدیریت"
+
+#: pretalx/orga/templates/orga/base.html:476
+msgid "Admin information"
+msgstr "اطلاعات مدیریت"
+
+#: pretalx/orga/templates/orga/base.html:508
+msgid "running in development mode"
+msgstr "در حال اجرا در حالت توسعه"
+
+#: pretalx/orga/templates/orga/cfp/access_code_form.html:7 pretalx/orga/templates/orga/cfp/access_code_form.html:14 pretalx/orga/templates/orga/cfp/access_code_view.html:44
+msgid "New access code"
+msgstr "کد دسترسی جدید"
+
+#: pretalx/orga/templates/orga/cfp/access_code_form.html:12
+msgid "Edit access code"
+msgstr "ویرایش کد دسترسی"
+
+#: pretalx/orga/templates/orga/cfp/access_code_form.html:20
+msgid "This access code has already been used. You can’t delete it, but you can disable it by setting an expiration date."
+msgstr "این کد دسترسی قبلا استفاده شده است. نمی‌توانید آن را حذف کنید، اما می‌توانید با تنظیم یک تاریخ انقضا آن را غیرفعال کنید."
+
+#: pretalx/orga/templates/orga/cfp/access_code_send.html:6 pretalx/orga/templates/orga/cfp/access_code_send.html:9
+msgid "Send access code"
+msgstr "ارسال کد دسترسی"
+
+#: pretalx/orga/templates/orga/cfp/access_code_view.html:33
+msgid "Access codes can be used to allow proposals even when the CfP is over. You can also use them for hidden tracks or hidden session types, which can only be seen with a matching access code."
+msgstr "کدهای دسترسی می‌توانند برای پذیرش طرح‌های پیشنهادی حتی پس از اتمام فراخوان برای طرح پیشنهادی استفاده شوند. می‌توانید از آن‌ها برای مسیرهای مخفی یا انواع جلسات مخفی استفاده کنید، که فقط با کد دسترسی مطابقت‌شده قابل مشاهده هستند."
+
+#: pretalx/orga/templates/orga/cfp/access_code_view.html:52
+msgid "Code"
+msgstr "کد"
+
+#: pretalx/orga/templates/orga/cfp/access_code_view.html:57
+msgid "Uses"
+msgstr "موارد استفاده"
+
+#: pretalx/orga/templates/orga/cfp/access_code_view.html:85
+msgid "Copy access code link"
+msgstr "کپی پیوند کد دسترسی"
+
+#: pretalx/orga/templates/orga/cfp/access_code_view.html:90
+msgid "Send access code as email"
+msgstr "ارسال کد دسترسی به‌عنوان رایانامه"
+
+#: pretalx/orga/templates/orga/cfp/flow.html:28 pretalx/orga/templates/orga/cfp/flow.html:31
+msgid "CfP Editor"
+msgstr "ویرایشگر فراخوان برای طرح پیشنهادی"
+
+#: pretalx/orga/templates/orga/cfp/flow.html:33
+#, python-format
+msgid "This is the %(site_name)s CfP editor. This page allows you to change the headline and information text on all of the individual CfP steps. You can also add a custom help text to individual fields. Just click on the item you want to change!"
+msgstr "این ویرایشگر فراخوان برای طرح پیشنهادی %(site_name)s است. این صفحه به شما امکان تغییر عنوان و متن اطلاعات در تمام مراحل فردی فراخوان برای طرح پیشنهادی را می‌دهد. همچنین می‌توانید یک متن راهنمای سفارشی به فیلدهای فردی اضافه کنید. فقط روی موردی که می‌خواهید تغییر دهید کلیک کنید!"
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:34
+msgid "Filter"
+msgstr "فیلتر"
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:41 pretalx/orga/templates/orga/cfp/question_form.html:51
+msgid "This question is currently active, it will be asked during submission."
+msgstr "این سوال در حال حاضر فعال است و در حین ارسال پرسیده می‌شود."
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:42 pretalx/orga/templates/orga/cfp/question_form.html:53
+msgid "Hide question"
+msgstr "پنهان کردن سوال"
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:44 pretalx/orga/templates/orga/cfp/question_form.html:59
+msgid "This question is currently inactive, and will not be asked during submission."
+msgstr "این سوال در حال حاضر غیرفعال است و در حین ارسال پرسیده نخواهد شد."
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:45 pretalx/orga/templates/orga/cfp/question_form.html:60
+msgid "Activate question"
+msgstr "فعال کردن سوال"
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:50
+msgid "Nobody has answered this question at the moment."
+msgstr "در حال حاضر هیچ‌کس به این سوال پاسخ نداده است."
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:54
+#, python-format
+msgid "This question has been answered <strong>%(count)s</strong>, <strong>%(missing)s</strong> answers <a href=\"%(base_search_url)sunanswered=1\">are still missing</a>."
+msgstr "به این سوال <strong>%(count)s</strong> پاسخ داده شده است، <strong>%(missing)s</strong> پاسخ هنوز مفقود هستند <a href=\"%(base_search_url)sunanswered=1\">اینجا کلیک کنید</a>."
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:58
+#, python-format
+msgid "This question has been answered <strong>%(count)s</strong>, and no answers are missing."
+msgstr "به این سوال <strong>%(count)s</strong> پاسخ داده شده است و هیچ پاسخی مفقود نیست."
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:74 pretalx/submission/models/question.py:335
+msgid "Answer"
+msgstr "پاسخ"
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:75
+msgid "Count"
+msgstr "تعداد"
+
+#: pretalx/orga/templates/orga/cfp/question_detail.html:76
+#, python-format
+msgid "%%"
+msgstr "درصد"
+
+#: pretalx/orga/templates/orga/cfp/question_form.html:8 pretalx/orga/templates/orga/cfp/question_form.html:31
+msgid "New question"
+msgstr "سوال جدید"
+
+#: pretalx/orga/templates/orga/cfp/question_form.html:39
+msgid "This question has already been answered by some speakers – please consider carefully if modifying it would render those answers obsolete. You could also deactivate this question and start a new one instead."
+msgstr "این سوال قبلا توسط برخی سخنرانان پاسخ داده شده است – لطفا با دقت بررسی کنید که آیا تغییر آن پاسخ‌ها را منسوخ خواهد کرد یا خیر. همچنین می‌توانید این سوال را غیرفعال کنید و به جای آن یک سوال جدید شروع کنید."
+
+#: pretalx/orga/templates/orga/cfp/question_form.html:71
+msgid "If you mark a Yes/No question as required, it means that the user has to select Yes and No is not accepted. If you want to allow both options, do not make this field required."
+msgstr "اگر یک سوال بلی/خیر را به‌عنوان الزامی علامت بزنید، به این معناست که کاربر باید بلی را انتخاب کند و خیر پذیرفته نیست. اگر می‌خواهید هر دو گزینه مجاز باشند، این فیلد را الزامی نکنید."
+
+#: pretalx/orga/templates/orga/cfp/question_form.html:80
+msgid "Limit to specific proposals"
+msgstr "محدود به پیشنهادات خاص"
+
+#: pretalx/orga/templates/orga/cfp/question_form.html:89
+msgid "Input validation"
+msgstr "اعتبارسنجی ورودی"
+
+#: pretalx/orga/templates/orga/cfp/question_form.html:112
+msgid "Answer options"
+msgstr "گزینه‌های پاسخ"
+
+#: pretalx/orga/templates/orga/cfp/question_form.html:114
+msgid "Upload answer options"
+msgstr "بارگذاری گزینه‌های پاسخ"
+
+#: pretalx/orga/templates/orga/cfp/question_form.html:137 pretalx/orga/templates/orga/cfp/question_view.html:86 pretalx/orga/templates/orga/cfp/track_view.html:71 pretalx/orga/templates/orga/schedule/room_list.html:51
+msgid "Move item"
+msgstr "جابجایی مورد"
+
+#: pretalx/orga/templates/orga/cfp/question_form.html:172
+msgid "Add a new option"
+msgstr "افزودن گزینه جدید"
+
+#: pretalx/orga/templates/orga/cfp/question_remind.html:5 pretalx/orga/templates/orga/cfp/question_remind.html:8
+msgid "Send out reminders"
+msgstr "ارسال یادآوری‌ها"
+
+#: pretalx/orga/templates/orga/cfp/question_remind.html:11
+msgid "Here you can limit who will receive reminder emails. You will be able to review emails before they are sent out."
+msgstr "اینجا می‌توانید محدود کنید که چه کسانی رایانامه‌های یادآوری دریافت کنند. شما قادر خواهید بود رایانامه‌ها را قبل از ارسال بازبینی کنید."
+
+#: pretalx/orga/templates/orga/cfp/question_remind.html:17 pretalx/orga/templates/orga/mails/template_form.html:5 pretalx/orga/templates/orga/mails/template_form.html:7 pretalx/orga/templates/orga/schedule/release.html:51
+msgid "Email template"
+msgstr "قالب رایانامه"
+
+#: pretalx/orga/templates/orga/cfp/question_view.html:33
+msgid "Questions can help you sort out additional details with speakers, such as clothing sizes, special requirements such as dietary needs, or accommodation. Questions can be asked either on a per-proposal level, or per speaker, as you see fit."
+msgstr "سوالات می‌توانند به شما کمک کنند تا جزئیات اضافی را با سخنرانان بررسی کنید، مانند اندازه لباس‌ها، نیازهای ویژه مانند رژیم غذایی، یا اسکان. سوالات را می‌توان بر اساس هر پیشنهاد یا هر سخنران پرسید، همان‌طور که صلاح می‌دانید."
+
+#: pretalx/orga/templates/orga/cfp/question_view.html:45
+msgid "Send out reminders for unanswered questions"
+msgstr "ارسال یادآوری برای سوالات بی‌پاسخ"
+
+#: pretalx/orga/templates/orga/cfp/question_view.html:49
+msgid "Add a new question"
+msgstr "افزودن سوال جدید"
+
+#: pretalx/orga/templates/orga/cfp/question_view.html:59
+msgid "Target"
+msgstr "هدف"
+
+#: pretalx/orga/templates/orga/cfp/question_view.html:60
+msgid "required"
+msgstr "الزامی"
+
+#: pretalx/orga/templates/orga/cfp/question_view.html:61 pretalx/submission/models/question.py:184
+msgid "active"
+msgstr "فعال"
+
+#: pretalx/orga/templates/orga/cfp/question_view.html:62
+msgid "Answers"
+msgstr "پاسخ‌ها"
+
+#: pretalx/orga/templates/orga/cfp/question_view.html:77
+msgid "This question’s availability depends on a deadline."
+msgstr "دسترسی این سوال به یک مهلت وابسته است."
+
+#: pretalx/orga/templates/orga/cfp/question_view.html:100 pretalx/orga/views/event.py:194
+msgid "You have configured no questions yet."
+msgstr "شما هنوز هیچ سوالی پیکربندی نکرده‌اید."
+
+#: pretalx/orga/templates/orga/cfp/submission_type_form.html:7 pretalx/orga/templates/orga/cfp/submission_type_form.html:14
+msgid "New Session Type"
+msgstr "نوع جلسه جدید"
+
+#: pretalx/orga/templates/orga/cfp/submission_type_view.html:31
+msgid "Different session types may help to guide speakers into different slot lengths (short sessions vs long sessions) or different presentation formats (talk vs workshop vs metal concert)."
+msgstr "انواع مختلف جلسات می‌توانند به هدایت سخنرانان به طول‌های متفاوت زمانی (جلسات کوتاه در مقابل جلسات بلند) یا فرمت‌های مختلف ارائه (سخنرانی در مقابل کارگاه در مقابل کنسرت متال) کمک کنند."
+
+#: pretalx/orga/templates/orga/cfp/submission_type_view.html:41
+msgid "New type"
+msgstr "نوع جدید"
+
+#: pretalx/orga/templates/orga/cfp/submission_type_view.html:50
+msgid "Default duration"
+msgstr "مدت زمان پیش‌فرض"
+
+#: pretalx/orga/templates/orga/cfp/submission_type_view.html:59 pretalx/orga/templates/orga/cfp/track_view.html:61 pretalx/submission/models/track.py:39 pretalx/submission/models/type.py:44
+msgid "Requires access code"
+msgstr "نیاز به کد دسترسی دارد"
+
+#: pretalx/orga/templates/orga/cfp/submission_type_view.html:69
+msgid "Default"
+msgstr "پیش‌فرض"
+
+#: pretalx/orga/templates/orga/cfp/submission_type_view.html:74 pretalx/orga/templates/orga/cfp/track_view.html:75
+msgid "Go to pre-filled CfP form"
+msgstr "رفتن به فرم فراخوان برای طرح پیشنهادی از پیش پرشده"
+
+#: pretalx/orga/templates/orga/cfp/text.html:32
+msgid "A good Call for Participation will engage potential speakers. Remember to include:"
+msgstr "یک فراخوان خوب برای مشارکت سخنرانان بالقوه را جذب می‌کند. به یاد داشته باشید که شامل موارد زیر باشد:"
+
+#: pretalx/orga/templates/orga/cfp/text.html:35
+msgid "The formats (sessions, workshops, panels) and their durations"
+msgstr "فرمت‌ها (جلسات، کارگاه‌ها، پانل‌ها) و مدت زمان آن‌ها"
+
+#: pretalx/orga/templates/orga/cfp/text.html:36
+msgid "Topics you are looking for"
+msgstr "موضوعاتی که به دنبال آن‌ها هستید"
+
+#: pretalx/orga/templates/orga/cfp/text.html:37
+msgid "How open you are to alternative topics"
+msgstr "چقدر برای موضوعات جایگزین باز هستید"
+
+#: pretalx/orga/templates/orga/cfp/text.html:38
+msgid "The people coming to your conference: interests, experience level …"
+msgstr "افرادی که به کنفرانس شما می‌آیند: علایق، سطح تجربه …"
+
+#: pretalx/orga/templates/orga/cfp/text.html:39
+msgid "Link your Code of Conduct and Data Protection statements."
+msgstr "پیوند به قوانین رفتاری و بیانیه‌های حفاظت داده خود."
+
+#: pretalx/orga/templates/orga/cfp/text.html:40
+msgid "Do you offer financial or other support, e.g. support for first time speakers?"
+msgstr "آیا پشتیبانی مالی یا دیگر موارد، مثلا پشتیبانی برای سخنرانان بار اول، ارائه می‌دهید؟"
+
+#: pretalx/orga/templates/orga/cfp/text.html:41
+msgid "Dates and location"
+msgstr "تاریخ‌ها و مکان"
+
+#: pretalx/orga/templates/orga/cfp/text.html:60
+msgid "Some of your session types have different deadlines:"
+msgstr "برخی از انواع جلسات شما مهلت‌های متفاوتی دارند:"
+
+#: pretalx/orga/templates/orga/cfp/text.html:86
+msgid "Proposal information"
+msgstr "اطلاعات طرح پیشنهادی"
+
+#: pretalx/orga/templates/orga/cfp/text.html:93
+msgid "Select which information should be requested and/or required during CfP proposal."
+msgstr "انتخاب کنید که چه اطلاعاتی باید در طول طرح پیشنهادی فراخوان برای طرح پیشنهادی درخواست شود و یا الزامی باشد."
+
+#: pretalx/orga/templates/orga/cfp/text.html:94
+msgid "Click here to view the proposal form."
+msgstr "برای مشاهده فرم پیشنهاد اینجا کلیک کنید."
+
+#: pretalx/orga/templates/orga/cfp/text.html:102 pretalx/orga/templates/orga/cfp/text.html:186
+msgid "Minimum length"
+msgstr "حداقل طول"
+
+#: pretalx/orga/templates/orga/cfp/text.html:103 pretalx/orga/templates/orga/cfp/text.html:187
+msgid "Maximum length"
+msgstr "حداکثر طول"
+
+#: pretalx/orga/templates/orga/cfp/text.html:114 pretalx/orga/templates/orga/submission/review.html:73 pretalx/submission/models/submission.py:182
+msgid "Abstract"
+msgstr "چکیده"
+
+#: pretalx/orga/templates/orga/cfp/text.html:120 pretalx/orga/templates/orga/submission/review.html:85 pretalx/schedule/models/room.py:37 pretalx/submission/models/resource.py:33 pretalx/submission/models/submission.py:188 pretalx/submission/models/tag.py:17 pretalx/submission/models/track.py:27
+msgid "Description"
+msgstr "توضیحات"
+
+#: pretalx/orga/templates/orga/cfp/text.html:140
+msgid "Additional speakers"
+msgstr "سخنرانان اضافی"
+
+#: pretalx/orga/templates/orga/cfp/text.html:146 pretalx/orga/templates/orga/submission/review.html:97 pretalx/submission/models/submission.py:194
+msgid "Notes"
+msgstr "یادداشت‌ها"
+
+#: pretalx/orga/templates/orga/cfp/text.html:152
+msgid "Recording opt-out"
+msgstr "انصراف از ضبط"
+
+#: pretalx/orga/templates/orga/cfp/text.html:158 pretalx/submission/forms/submission.py:39 pretalx/submission/models/submission.py:235
+msgid "Session image"
+msgstr "تصویر جلسه"
+
+#: pretalx/orga/templates/orga/cfp/text.html:175
+msgid "Speaker information"
+msgstr "اطلاعات سخنران"
+
+#: pretalx/orga/templates/orga/cfp/text.html:204 pretalx/schedule/forms.py:19
+msgid "Availability"
+msgstr "در دسترس بودن"
+
+#: pretalx/orga/templates/orga/cfp/text.html:210
+msgid "Profile picture source"
+msgstr "منبع تصویر نمایه"
+
+#: pretalx/orga/templates/orga/cfp/text.html:216
+msgid "Profile picture license"
+msgstr "مجوز تصویر نمایه"
+
+#: pretalx/orga/templates/orga/cfp/track_form.html:17 pretalx/orga/templates/orga/cfp/track_form.html:24 pretalx/orga/templates/orga/cfp/track_view.html:42
+msgid "New track"
+msgstr "مسیر جدید"
+
+#: pretalx/orga/templates/orga/cfp/track_view.html:32
+msgid "Tracks are used to sort your sessions into categories. You can use the CfP settings to determine if speakers can select the track for their session themselves. Track colors are helpful to help attendees navigate your schedule."
+msgstr "مسیرها برای دسته‌بندی جلسات شما استفاده می‌شوند. می‌توانید از تنظیمات فراخوان برای طرح پیشنهادی استفاده کنید تا تعیین کنید آیا سخنرانان می‌توانند مسیر جلسه خود را خودشان انتخاب کنند. رنگ‌های مسیرها برای کمک به شرکت‌کنندگان در جهت‌یابی برنامه زمان‌بندی شما مفید هستند."
+
+#: pretalx/orga/templates/orga/cfp/track_view.html:50 pretalx/orga/templates/orga/submission/tag_list.html:24 pretalx/submission/models/tag.py:22 pretalx/submission/models/track.py:32
+msgid "Color"
+msgstr "رنگ"
+
+#: pretalx/orga/templates/orga/event/dashboard.html:20
+msgid "Your event has been created and you’re ready to go! Check out the event settings, set up your Call for Papers with session types and questions, and you’re ready to go!"
+msgstr "رویداد شما ایجاد شده و آماده شروع است! تنظیمات رویداد را بررسی کنید، فراخوان مقالات خود را با انواع جلسات و سوالات تنظیم کنید و آماده شروع شوید!"
+
+#: pretalx/orga/templates/orga/event/dashboard.html:62
+msgid "Your event is currently"
+msgstr "رویداد شما در حال حاضر"
+
+#: pretalx/orga/templates/orga/event/dashboard.html:67 pretalx/orga/templates/orga/includes/dashboard_block_event.html:24
+msgid "live"
+msgstr "فعال"
+
+#: pretalx/orga/templates/orga/event/dashboard.html:72
+msgid "not live"
+msgstr "غیرفعال"
+
+#: pretalx/orga/templates/orga/event/dashboard.html:76
+msgid "Click here to change"
+msgstr "برای تغییر اینجا کلیک کنید"
+
+#: pretalx/orga/templates/orga/event/dashboard.html:111
+msgid "History"
+msgstr "تاریخچه"
+
+#: pretalx/orga/templates/orga/event/dashboard.html:115
+msgid "Full history"
+msgstr "تاریخچه کامل"
+
+#: pretalx/orga/templates/orga/event/history.html:5 pretalx/orga/templates/orga/event/history.html:8
+msgid "Event History"
+msgstr "تاریخچه رویداد"
+
+#: pretalx/orga/templates/orga/event/live.html:5 pretalx/orga/templates/orga/event/live.html:10
+msgid "Deactivate event"
+msgstr "غیرفعال کردن رویداد"
+
+#: pretalx/orga/templates/orga/event/live.html:5 pretalx/orga/templates/orga/event/live.html:12 pretalx/orga/templates/orga/event/live.html:60
+msgid "Go live"
+msgstr "فعال کردن رویداد"
+
+#: pretalx/orga/templates/orga/event/live.html:17
+msgid "Your event is currently live and publicly visible. If you take it down, it will only be visible to you and your team."
+msgstr "رویداد شما در حال حاضر فعال و به‌صورت عمومی قابل مشاهده است. اگر آن را غیرفعال کنید، فقط برای شما و تیم شما قابل مشاهده خواهد بود."
+
+#: pretalx/orga/templates/orga/event/live.html:22
+msgid "Your event is currently only visible to you and your team. By going live, it will be publicly visible."
+msgstr "رویداد شما در حال حاضر فقط برای شما و تیم شما قابل مشاهده است. با فعال کردن، به‌صورت عمومی قابل مشاهده خواهد بود."
+
+#: pretalx/orga/templates/orga/event/live.html:29
+msgid "Your event may not be ready for release yet!"
+msgstr "رویداد شما ممکن است هنوز برای انتشار آماده نباشد!"
+
+#: pretalx/orga/templates/orga/event/live.html:33 pretalx/orga/templates/orga/event/live.html:45
+msgid "Fix me"
+msgstr "من را درست کنید"
+
+#: pretalx/orga/templates/orga/event/live.html:41
+msgid "There may be easy ways to improve your event before its release!"
+msgstr "ممکن است راه‌های آسانی برای بهبود رویداد شما قبل از انتشار وجود داشته باشد!"
+
+#: pretalx/orga/templates/orga/event/live.html:58
+msgid "Go offline"
+msgstr "غیرفعال کردن"
+
+#: pretalx/orga/templates/orga/event/wizard/base.html:5 pretalx/orga/templates/orga/event/wizard/base.html:11
+msgid "New event"
+msgstr "رویداد جدید"
+
+#: pretalx/orga/templates/orga/event/wizard/base.html:12
+#, python-format
+msgid "Step %(current)s of %(total)s"
+msgstr "مرحله %(current)s از %(total)s"
+
+#: pretalx/orga/templates/orga/event/wizard/base.html:24
+msgid "Next step"
+msgstr "مرحله بعدی"
+
+#: pretalx/orga/templates/orga/event/wizard/base.html:26
+msgid "Previous step"
+msgstr "مرحله قبلی"
+
+#: pretalx/orga/templates/orga/event/wizard/display.html:20
+msgid "Choose your inital customisations here – you can always change them later, or enhance them with custom CSS."
+msgstr "اینجا تنظیمات اولیه خود را انتخاب کنید – همیشه می‌توانید آن‌ها را بعداً تغییر دهید یا با CSS سفارشی بهبود دهید."
+
+#: pretalx/orga/templates/orga/event_list.html:24
+msgid "Your upcoming events"
+msgstr "رویدادهای آینده شما"
+
+#: pretalx/orga/templates/orga/event_list.html:31
+msgid "Create a new event"
+msgstr "ایجاد رویداد جدید"
+
+#: pretalx/orga/templates/orga/event_list.html:37
+msgid "Your most recent events"
+msgstr "جدیدترین رویدادهای شما"
+
+#: pretalx/orga/templates/orga/event_list.html:48
+msgid "You are currently in the organiser area of eventyay. To view your submitted proposals, please go directly to the event page:"
+msgstr "شما در حال حاضر در بخش برگزارکننده eventyay هستید. برای مشاهده طرح‌های پیشنهادی ارسال‌شده خود، لطفا مستقیما به صفحه رویداد بروید:"
+
+#: pretalx/orga/templates/orga/includes/dashboard_block_event.html:13 pretalx/orga/templates/orga/speaker/form.html:37 pretalx/orga/views/dashboard.py:324
+msgid "proposal"
+msgid_plural "proposals"
+msgstr[0] "پیشنهاد"
+msgstr[1] "پیشنهادات"
+
+#: pretalx/orga/templates/orga/includes/dashboard_block_event.html:19
+msgid "No proposals yet"
+msgstr "هنوز هیچ طرح پیشنهادی وجود ندارد"
+
+#: pretalx/orga/templates/orga/includes/dashboard_block_event.html:26
+msgid "Not public"
+msgstr "غیرفعال"
+
+#: pretalx/orga/templates/orga/includes/event_links_formset.html:47
+msgid "Add link"
+msgstr "افزودن پیوند"
+
+#: pretalx/orga/templates/orga/includes/mail_template_role.html:3
+msgid "Accept email"
+msgstr "رایانامه پذیرش"
+
+#: pretalx/orga/templates/orga/includes/mail_template_role.html:5
+msgid "Reject email"
+msgstr "رایانامه رد"
+
+#: pretalx/orga/templates/orga/includes/mail_template_role.html:7
+msgid "Schedule update"
+msgstr "به‌روزرسانی برنامه زمان‌بندی"
+
+#: pretalx/orga/templates/orga/includes/pagination.html:17
+#, python-format
+msgid "Page %(page)s of %(of)s (%(count)s elements)"
+msgstr "صفحه %(page)s از %(of)s (%(count)s عناصر)"
+
+#: pretalx/orga/templates/orga/includes/pagination.html:33
+#, python-format
+msgctxt "Shown at the bottom of lists, always > 1 elements."
+msgid "%(count)s elements"
+msgstr "%(count)s عناصر"
+
+#: pretalx/orga/templates/orga/includes/pagination.html:44
+msgctxt "Allows users to select how many lines/elements are shown in lists."
+msgid "Show per page:"
+msgstr "نمایش در هر صفحه:"
+
+#: pretalx/orga/templates/orga/includes/review_filter_form.html:10
+msgid "Number of reviews"
+msgstr "تعداد بازبینی‌ها"
+
+#: pretalx/orga/templates/orga/includes/submission_filter_form.html:26 pretalx/orga/templates/orga/speaker/list.html:23
+#, python-format
+msgid "List filtered by answers to question “%(question)s”."
+msgstr "فهرست فیلتر شده توسط پاسخ‌ها به سوال «%(question)s»."
+
+#: pretalx/orga/templates/orga/includes/submission_filter_form.html:31 pretalx/orga/templates/orga/mails/compose_session_mail_form.html:21 pretalx/orga/templates/orga/mails/compose_session_mail_form.html:33 pretalx/orga/templates/orga/speaker/list.html:28
+msgid "Remove filter"
+msgstr "حذف فیلتر"
+
+#: pretalx/orga/templates/orga/invitation.html:4
+msgid "Invitation"
+msgstr "دعوت‌نامه"
+
+#: pretalx/orga/templates/orga/invitation.html:7
+#, python-format
+msgid "Invitation to the %(organiser)s team “%(name)s”"
+msgstr "دعوت‌نامه به تیم %(organiser)s «%(name)s»"
+
+#: pretalx/orga/templates/orga/invitation.html:15 pretalx/orga/templates/orga/invitation.html:34
+#, python-format
+msgid "You have been invited to join the organiser team %(name)s."
+msgstr "شما به تیم برگزارکننده %(name)s دعوت شده‌اید."
+
+#: pretalx/orga/templates/orga/invitation.html:20
+#, python-format
+msgid "If you already have an account – either as a speaker or an organiser – at <a href=\"%(domain)s\">%(domain)s</a>, please log in now. Otherwise, create a new account to join the team!"
+msgstr "اگر قبلا یک حساب کاربری دارید – چه به‌عنوان سخنران یا برگزارکننده – در <a href=\"%(domain)s\">%(domain)s</a>، لطفا اکنون وارد شوید. در غیر این صورت، یک حساب کاربری جدید ایجاد کنید تا به تیم بپیوندید!"
+
+#: pretalx/orga/templates/orga/invitation.html:37
+#, python-format
+msgid "To accept the invitation with the account you’re currently active, please use the button below. If you want to accept the invitation with a different account, you can <a href=\"/orga/logout/?next=%(link)s\">log out</a> and log in with the other account. </p><p> If you believe to have received this invitation by mistake, please contact the organiser directly."
+msgstr "برای پذیرش دعوت با حسابی که در حال حاضر فعال هستید، لطفا از دکمه زیر استفاده کنید. اگر می‌خواهید دعوت را با حسابی دیگر بپذیرید، می‌توانید <a href=\"/orga/logout/?next=%(link)s\">خروج کنید</a> و با حساب دیگر وارد شوید. </p><p> اگر فکر می‌کنید این دعوت را به‌اشتباه دریافت کرده‌اید، لطفا مستقیما با برگزارکننده تماس بگیرید."
+
+#: pretalx/orga/templates/orga/invitation.html:45
+msgid "Join the team!"
+msgstr "به تیم بپیوندید!"
+
+#: pretalx/orga/templates/orga/mails/_mail_editor.html:6 pretalx/orga/templates/orga/mails/_mail_editor.html:15
+msgid "Email editor"
+msgstr "ویرایشگر رایانامه"
+
+#: pretalx/orga/templates/orga/mails/_mail_editor.html:38 pretalx/orga/templates/orga/schedule/room_form.html:29
+msgid "Advanced settings"
+msgstr "تنظیمات پیشرفته"
+
+#: pretalx/orga/templates/orga/mails/_mail_editor.html:56
+msgid "Placeholders"
+msgstr "جای‌نگهدارها"
+
+#: pretalx/orga/templates/orga/mails/_mail_editor.html:69
+msgid "Email preview"
+msgstr "پیش‌نمایش رایانامه"
+
+#: pretalx/orga/templates/orga/mails/_mail_editor.html:71
+#, python-format
+msgid "Roughly %(count)s emails will be generated."
+msgstr "تقریبا %(count)s رایانامه ایجاد خواهد شد."
+
+#: pretalx/orga/templates/orga/mails/_mail_editor.html:78
+msgid "You have placeholders in your email that are either not valid or not valid for every email!"
+msgstr "شما جای‌نگهدارهایی در رایانامه خود دارید که یا معتبر نیستند یا برای هر رایانامه معتبر نیستند!"
+
+#: pretalx/orga/templates/orga/mails/_mail_editor.html:85
+#, python-brace-format
+msgid "Emails where placeholders are invalid will <b>not</b> be created! For example, if you are using {session_room}, but some proposals don’t have a room yet, only emails for proposals with a scheduled room will be created."
+msgstr "رایانامه‌هایی که جای‌نگهدارهایشان نامعتبر هستند <b>ایجاد نمی‌شوند!</b> برای مثال، اگر از {session_room} استفاده می‌کنید اما برخی از طرح‌های پیشنهادی هنوز اتاقی ندارند، فقط رایانامه‌هایی برای طرح‌های پیشنهادی با اتاق زمان‌بندی‌شده ایجاد خواهند شد."
+
+#: pretalx/orga/templates/orga/mails/_mail_editor.html:118
+msgid "Preview email"
+msgstr "پیش‌نمایش رایانامه"
+
+#: pretalx/orga/templates/orga/mails/_mail_editor.html:123
+msgid "Send to outbox"
+msgstr "ارسال به صندوق خروجی"
+
+#: pretalx/orga/templates/orga/mails/_placeholder_group.html:26
+msgid "Unavailable"
+msgstr "غیرقابل دسترس"
+
+#: pretalx/orga/templates/orga/mails/_placeholder_group.html:41
+msgid "e.g."
+msgstr "برای مثال"
+
+#: pretalx/orga/templates/orga/mails/compose_choice.html:5 pretalx/orga/templates/orga/mails/compose_choice.html:8 pretalx/orga/views/mails.py:141
+msgid "Send emails"
+msgstr "ارسال رایانامه‌ها"
+
+#: pretalx/orga/templates/orga/mails/compose_choice.html:12 pretalx/orga/templates/orga/mails/compose_session_mail_form.html:6
+msgid "Sessions, proposals, speakers"
+msgstr "جلسات، پیشنهادات، سخنرانان"
+
+#: pretalx/orga/templates/orga/mails/compose_choice.html:15
+msgid "Send an email to speakers, authors, submitters, based on their proposal status and other filters."
+msgstr "ارسال رایانامه به سخنرانان، نویسندگان، ارسال‌کنندگان، بر اساس وضعیت پیشنهاد و فیلترهای دیگر."
+
+#: pretalx/orga/templates/orga/mails/compose_choice.html:19 pretalx/orga/templates/orga/mails/compose_reviewer_mail_form.html:6
+msgid "Reviewers and team members"
+msgstr "بازبین‌ها و اعضای تیم"
+
+#: pretalx/orga/templates/orga/mails/compose_choice.html:22
+msgid "Send an email to your reviewers or other team members."
+msgstr "ارسال رایانامه به بازبین‌ها یا اعضای دیگر تیم."
+
+#: pretalx/orga/templates/orga/mails/compose_reviewer_mail_form.html:11
+msgid "Emails to reviewers and other team members are always sent out directly, and are not placed in the outbox first. They also do not show up in the list of sent mails."
+msgstr "رایانامه‌های ارسال‌شده به بازبین‌ها و سایر اعضای تیم همیشه مستقیما ارسال می‌شوند و ابتدا در صندوق خروجی قرار نمی‌گیرند. همچنین در فهرست رایانامه‌های ارسال‌شده نشان داده نمی‌شوند."
+
+#: pretalx/orga/templates/orga/mails/compose_session_mail_form.html:16
+#, python-format
+msgid "Recipients filtered by answers to question “%(question)s”."
+msgstr "گیرندگان فیلتر شده توسط پاسخ‌ها به سوال «%(question)s»."
+
+#: pretalx/orga/templates/orga/mails/compose_session_mail_form.html:28
+#, python-format
+msgid "Recipients filtered by search “%(search)s”."
+msgstr "گیرندگان فیلتر شده توسط جستجوی «%(search)s»."
+
+#: pretalx/orga/templates/orga/mails/outbox_form.html:5 pretalx/orga/templates/orga/mails/outbox_form.html:17
+msgid "Mail Editor"
+msgstr "ویرایشگر رایانامه"
+
+#: pretalx/orga/templates/orga/mails/outbox_form.html:10
+#, python-format
+msgid "This email was sent on %(timestamp)s."
+msgstr "این رایانامه در تاریخ %(timestamp)s ارسال شده است."
+
+#: pretalx/orga/templates/orga/mails/outbox_form.html:87
+msgid "Discard all from this template"
+msgstr "حذف همه از این قالب"
+
+#: pretalx/orga/templates/orga/mails/outbox_form.html:92
+msgid "Save and send"
+msgstr "ذخیره و ارسال"
+
+#: pretalx/orga/templates/orga/mails/outbox_form.html:96
+msgid "Copy to draft"
+msgstr "کپی به پیش‌نویس"
+
+#: pretalx/orga/templates/orga/mails/outbox_list.html:9
+msgid "pending mail"
+msgid_plural "pending mails"
+msgstr[0] "رایانامه در انتظار"
+msgstr[1] "ایمیل‌های در انتظار"
+
+#: pretalx/orga/templates/orga/mails/outbox_list.html:24
+msgid "Send all on this page"
+msgstr "ارسال همه در این صفحه"
+
+#: pretalx/orga/templates/orga/mails/outbox_list.html:28
+msgid "Send all"
+msgstr "ارسال همه"
+
+#: pretalx/orga/templates/orga/mails/outbox_list.html:31
+msgid "Discard all"
+msgstr "حذف همه"
+
+#: pretalx/orga/templates/orga/mails/outbox_list.html:38
+msgid "The current filters will be used when sending/discarding emails."
+msgstr "فیلترهای فعلی هنگام ارسال/حذف رایانامه‌ها استفاده خواهند شد."
+
+#: pretalx/orga/templates/orga/mails/outbox_list.html:50 pretalx/orga/templates/orga/mails/outbox_list.html:55 pretalx/orga/templates/orga/mails/sent_list.html:17 pretalx/orga/templates/orga/mails/sent_list.html:22 pretalx/orga/templates/orga/organiser/speaker_list.html:37 pretalx/orga/templates/orga/organiser/speaker_list.html:42 pretalx/orga/templates/orga/submission/list.html:68
+#: pretalx/orga/templates/orga/submission/list.html:74 pretalx/orga/templates/orga/submission/list.html:81 pretalx/orga/templates/orga/submission/list.html:87
+msgid "Sort (a-z)"
+msgstr "مرتب‌سازی (الف-ی)"
+
+#: pretalx/orga/templates/orga/mails/outbox_list.html:51 pretalx/orga/templates/orga/mails/outbox_list.html:56 pretalx/orga/templates/orga/mails/sent_list.html:18 pretalx/orga/templates/orga/mails/sent_list.html:23 pretalx/orga/templates/orga/organiser/speaker_list.html:38 pretalx/orga/templates/orga/organiser/speaker_list.html:43 pretalx/orga/templates/orga/submission/list.html:69
+#: pretalx/orga/templates/orga/submission/list.html:75 pretalx/orga/templates/orga/submission/list.html:82 pretalx/orga/templates/orga/submission/list.html:88
+msgid "Sort (z-a)"
+msgstr "مرتب‌سازی (ی-الف)"
+
+#: pretalx/orga/templates/orga/mails/outbox_list.html:93 pretalx/orga/templates/orga/mails/sent_list.html:64
+msgid "Contains an attachment"
+msgstr "حاوی یک پیوست"
+
+#: pretalx/orga/templates/orga/mails/send_draft_reminders.html:6
+msgid "Send reminder to unsubmitted proposal drafts"
+msgstr "ارسال یادآوری به پیش‌نویس‌های ارسال‌نشده"
+
+#: pretalx/orga/templates/orga/mails/send_draft_reminders.html:8
+msgid "These emails will be sent out immediately! They will not be saved to the outbox or logged first, to protect the privacy of the draft authors."
+msgstr "این رایانامه‌ها بلافاصله ارسال می‌شوند! برای محافظت از حریم خصوصی نویسندگان پیش‌نویس، ابتدا در صندوق خروجی ذخیره یا ثبت نمی‌شوند."
+
+#: pretalx/orga/templates/orga/mails/sent_list.html:8
+msgid "Sent Mails"
+msgstr "رایانامه‌های ارسال‌شده"
+
+#: pretalx/orga/templates/orga/mails/sent_list.html:28
+msgid "Sent"
+msgstr "ارسال شده"
+
+#: pretalx/orga/templates/orga/mails/sent_list.html:29
+msgid "Sort (latest first)"
+msgstr "مرتب‌سازی (جدیدترین اول)"
+
+#: pretalx/orga/templates/orga/mails/sent_list.html:30
+msgid "Sort (oldest first)"
+msgstr "مرتب‌سازی (قدیمی‌ترین اول)"
+
+#: pretalx/orga/templates/orga/mails/template_list.html:22
+msgid "New custom template"
+msgstr "قالب سفارشی جدید"
+
+#: pretalx/orga/templates/orga/mails/template_list.html:29
+msgid "You can edit the default templates and your custom templates for emails here. If you want to send emails to some or all of your speakers, head over to the “Send Emails” tab. Mails queued for sending are in the “Outbox” tab."
+msgstr "اینجا می‌توانید قالب‌های پیش‌فرض و قالب‌های سفارشی رایانامه‌های خود را ویرایش کنید. اگر می‌خواهید رایانامه‌هایی به برخی یا همه سخنرانان خود ارسال کنید، به زبانه «ارسال رایانامه‌ها» بروید. رایانامه‌هایی که در صف ارسال هستند در زبانه «صندوق خروجی» قرار دارند."
+
+#: pretalx/orga/templates/orga/mails/template_list.html:36
+msgid "There are different placeholders available depending on the template type. They are explained in detail once you start editing a template."
+msgstr "بسته به نوع قالب، جای‌نگهدارهای متفاوتی در دسترس هستند. هنگامی که ویرایش یک قالب را شروع کنید، آن‌ها به‌صورت کامل توضیح داده می‌شوند."
+
+#: pretalx/orga/templates/orga/mails/template_list.html:54
+msgid "Custom Mail"
+msgstr "رایانامه سفارشی"
+
+#: pretalx/orga/templates/orga/mails/template_list.html:63
+msgid "Delete template"
+msgstr "حذف قالب"
+
+#: pretalx/orga/templates/orga/mails/template_list.html:64
+msgid "Send mails"
+msgstr "ارسال رایانامه‌ها"
+
+#: pretalx/orga/templates/orga/mails/template_list.html:66
+msgid "Edit template"
+msgstr "ویرایش قالب"
+
+#: pretalx/orga/templates/orga/organiser/detail.html:15
+msgid "Delete organiser"
+msgstr "حذف برگزارکننده"
+
+#: pretalx/orga/templates/orga/organiser/list.html:41
+msgctxt "number of teams"
+msgid "Team"
+msgid_plural "Teams"
+msgstr[0] "تیم"
+msgstr[1] "تیم‌ها"
+
+#: pretalx/orga/templates/orga/organiser/list.html:52
+msgid "There are no organisers you can edit."
+msgstr "هیچ برگزارکننده‌ای برای ویرایش وجود ندارد."
+
+#: pretalx/orga/templates/orga/organiser/speaker_list.html:6 pretalx/orga/templates/orga/organiser/speaker_list.html:22 pretalx/orga/views/dashboard.py:340
+msgid "speaker"
+msgid_plural "speakers"
+msgstr[0] "سخنران"
+msgstr[1] "سخنرانان"
+
+#: pretalx/orga/templates/orga/organiser/speaker_list.html:46 pretalx/orga/templates/orga/speaker/list.html:40
+msgid "Accepted Proposals"
+msgstr "پیشنهادات پذیرفته‌شده"
+
+#: pretalx/orga/templates/orga/organiser/speaker_list.html:47 pretalx/orga/templates/orga/organiser/speaker_list.html:52 pretalx/orga/templates/orga/review/dashboard.html:164 pretalx/orga/templates/orga/review/dashboard.html:176 pretalx/orga/templates/orga/review/dashboard.html:187
+msgid "Sort (high-low)"
+msgstr "مرتب‌سازی (زیاد-کم)"
+
+#: pretalx/orga/templates/orga/organiser/speaker_list.html:48 pretalx/orga/templates/orga/organiser/speaker_list.html:53 pretalx/orga/templates/orga/review/dashboard.html:165 pretalx/orga/templates/orga/review/dashboard.html:177 pretalx/orga/templates/orga/review/dashboard.html:188
+msgid "Sort (low-high)"
+msgstr "مرتب‌سازی (کم-زیاد)"
+
+#: pretalx/orga/templates/orga/organiser/team_list.html:15 pretalx/orga/templates/orga/review/assignment.html:50 pretalx/orga/templates/orga/settings/team_detail.html:24
+msgid "Members"
+msgstr "اعضا"
+
+#: pretalx/orga/templates/orga/organiser/team_list.html:17
+msgid "Reviewer"
+msgstr "بازبین"
+
+#: pretalx/orga/templates/orga/organiser/team_list.html:28 pretalx/orga/templates/orga/review/assignment.html:64
+msgid "You are a member of this team"
+msgstr "شما عضو این تیم هستید"
+
+#: pretalx/orga/templates/orga/organiser/team_list.html:56 pretalx/orga/templates/orga/review/assignment.html:43 pretalx/orga/templates/orga/settings/team_detail.html:117
+msgid "New team"
+msgstr "تیم جدید"
+
+#: pretalx/orga/templates/orga/plugins.html:22
+msgid "Disable"
+msgstr "غیرفعال کردن"
+
+#: pretalx/orga/templates/orga/plugins.html:24
+msgid "Enable"
+msgstr "فعال کردن"
+
+#: pretalx/orga/templates/orga/plugins.html:31
+#, python-format
+msgid "Version %(v)s by <em>%(a)s</em>"
+msgstr "نسخه %(v)s توسط <em>%(a)s</em>"
+
+#: pretalx/orga/templates/orga/plugins.html:37
+#, python-format
+msgid "Version %(v)s"
+msgstr "نسخه %(v)s"
+
+#: pretalx/orga/templates/orga/plugins.html:53
+msgid "This instance does currently not have any plugins installed."
+msgstr "این نمونه در حال حاضر هیچ افزونه‌ای نصب ندارد."
+
+#: pretalx/orga/templates/orga/review/assignment-import.html:13
+#, python-format
+msgid "You can upload your reviewer assignments from a JSON file here. You can either have the proposal codes (e.g. “UX3N1”) as keys, and user identification as values, or the other way around. User identification can be either the reviewer’s email address or their user code (e.g. “34KJN”). You can find an example file <a href=\"%(href)s\">here</a>."
+msgstr "شما می‌توانید تخصیص‌های بازبین خود را از یک پرونده JSON اینجا بارگذاری کنید. می‌توانید کدهای پیشنهاد (مثلا «UX3N1») به‌عنوان کلید و شناسایی کاربر به‌عنوان مقدار یا برعکس داشته باشید. شناسایی کاربر می‌تواند نشانی رایانامه بازبین یا کد کاربری آن‌ها باشد (مثلا «34KJN»). می‌توانید یک پرونده نمونه را <a href=\"%(href)s\">اینجا</a> پیدا کنید."
+
+#: pretalx/orga/templates/orga/review/assignment-import.html:18
+msgid "Import"
+msgstr "وارد کردن"
+
+#: pretalx/orga/templates/orga/review/assignment.html:31
+msgid "Reviewers can be assigned to tracks by way of review teams. If you require more granular assignments, you can also assign reviewers to proposals individually."
+msgstr "بازبین‌ها می‌توانند از طریق تیم‌های بازبینی به مسیرها اختصاص داده شوند. اگر نیاز به تخصیص‌های دقیق‌تری دارید، می‌توانید بازبین‌ها را به طرح‌های پیشنهادی به‌صورت جداگانه اختصاص دهید."
+
+#: pretalx/orga/templates/orga/review/assignment.html:37
+msgid "As teams can belong to multiple events, teams are managed in your organiser settings."
+msgstr "از آنجا که تیم‌ها می‌توانند به چندین رویداد تعلق داشته باشند، تیم‌ها در تنظیمات برگزارکننده شما مدیریت می‌شوند."
+
+#: pretalx/orga/templates/orga/review/assignment.html:52
+msgid "Limited to tracks"
+msgstr "محدود به مسیرها"
+
+#: pretalx/orga/templates/orga/review/assignment.html:108
+#, python-format
+msgid "Reviewers will be able to see and review <b>only their assigned</b> proposals. You can change this in your <a href=\"%(href)s\">review settings</a>."
+msgstr "بازبین‌ها فقط می‌توانند طرح‌های پیشنهادی <b>اختصاص‌داده‌شده به خود</b> را مشاهده و بازبینی کنند. شما می‌توانید این مورد را در <a href=\"%(href)s\">تنظیمات بازبینی</a> تغییر دهید."
+
+#: pretalx/orga/templates/orga/review/assignment.html:113
+#, python-format
+msgid "Reviewers will be able to see and review <b>all proposals</b>, but their assigned reviews will appear highlighted, and they will be directed to them first. You can change this in your <a href=\"%(href)s\">review settings</a>."
+msgstr "بازبین‌ها می‌توانند <b>تمام طرح‌های پیشنهادی</b> را مشاهده و بازبینی کنند، اما بازبینی‌های اختصاص‌یافته به آن‌ها برجسته خواهد شد و ابتدا به آن‌ها هدایت می‌شوند. شما می‌توانید این مورد را در <a href=\"%(href)s\">تنظیمات بازبینی</a> تغییر دهید."
+
+#: pretalx/orga/templates/orga/review/assignment.html:122
+msgid "This is where you can assign reviewers to specific proposals! Please use this drop-down to switch between the two assignment modes (assigning reviewers to proposals or proposals to reviewers)."
+msgstr "اینجا مکانی است که می‌توانید بازبین‌ها را به طرح‌های پیشنهادی خاص اختصاص دهید! لطفا از این منوی کشویی استفاده کنید تا بین دو حالت اختصاصی (اختصاص بازبین‌ها به طرح‌های پیشنهادی یا طرح‌های پیشنهادی به بازبین‌ها) جابجا شوید."
+
+#: pretalx/orga/templates/orga/review/assignment.html:126
+msgid "You can also use the Actions menu above to import your assignments from a prepared file."
+msgstr "شما همچنین می‌توانید از منوی عملیات بالا برای وارد کردن تخصیص‌های خود از یک پرونده آماده استفاده کنید."
+
+#: pretalx/orga/templates/orga/review/assignment.html:133 pretalx/orga/templates/orga/review/dashboard.html:113 pretalx/orga/templates/orga/schedule/index.html:40
+msgid "Actions"
+msgstr "عملیات‌ها"
+
+#: pretalx/orga/templates/orga/review/assignment.html:138
+msgid "Import assignments"
+msgstr "وارد کردن تخصیص‌ها"
+
+#: pretalx/orga/templates/orga/review/bulk.html:20 pretalx/orga/templates/orga/review/dashboard.html:23 pretalx/orga/templates/orga/review/dashboard.html:72 pretalx/orga/templates/orga/review/dashboard.html:186 pretalx/orga/templates/orga/submission/base.html:72 pretalx/orga/templates/orga/submission/content.html:62 pretalx/orga/templates/orga/submission/review.html:9
+#: pretalx/orga/views/dashboard.py:189
+msgid "Reviews"
+msgstr "بازبینی‌ها"
+
+#: pretalx/orga/templates/orga/review/bulk.html:26
+#, python-format
+msgid "Or review the missing proposal here."
+msgid_plural "Or review the missing %(count)s proposals one-by-one."
+msgstr[0] "یا اینجا طرح پیشنهادی گمشده را بازبینی کنید."
+msgstr[1] "یا طرح‌های پیشنهادی گمشده %(count)s را یکی‌یکی بازبینی کنید."
+
+#: pretalx/orga/templates/orga/review/bulk.html:35 pretalx/orga/templates/orga/review/dashboard.html:40
+msgid "You’ve got no proposals left to review!"
+msgstr "هیچ طرح پیشنهادی برای بازبینی باقی نمانده است!"
+
+#: pretalx/orga/templates/orga/review/bulk.html:50
+msgid "Comment"
+msgstr "دیدگاه"
+
+#: pretalx/orga/templates/orga/review/bulk.html:79 pretalx/orga/templates/orga/review/dashboard.html:301 pretalx/orga/views/cards.py:140
+msgid "You don’t seem to have any proposals yet."
+msgstr "به نظر می‌رسد هنوز هیچ طرح پیشنهادی ندارید."
+
+#: pretalx/orga/templates/orga/review/dashboard.html:31
+#, python-format
+msgid "%(count)s proposal is waiting for your review."
+msgid_plural "%(count)s proposals are waiting for your review."
+msgstr[0] "%(count)s طرح پیشنهادی در انتظار بازبینی شما است."
+msgstr[1] "%(count)s طرح پیشنهادی در انتظار بازبینی شما هستند."
+
+#: pretalx/orga/templates/orga/review/dashboard.html:36
+msgid "Click here to get started!"
+msgstr "برای شروع اینجا کلیک کنید!"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:38 pretalx/orga/templates/orga/submission/review.html:216
+msgid "Or review all proposals at once."
+msgstr "یا همه طرح‌های پیشنهادی را یک‌جا بازبینی کنید."
+
+#: pretalx/orga/templates/orga/review/dashboard.html:43
+msgid "Reviews are currently closed."
+msgstr "بازبینی‌ها در حال حاضر بسته شده‌اند."
+
+#: pretalx/orga/templates/orga/review/dashboard.html:45
+msgid "You don’t have reviewer permissions for this event."
+msgstr "شما اجازه بازبینی برای این رویداد را ندارید."
+
+#: pretalx/orga/templates/orga/review/dashboard.html:54
+msgid "Columns"
+msgstr "ستون‌ها"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:66 pretalx/orga/templates/orga/review/dashboard.html:175
+msgid "Your score"
+msgstr "امتیاز شما"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:117 pretalx/orga/views/review.py:695 pretalx/orga/views/review.py:696
+msgid "Regenerate decision emails"
+msgstr "رایانامه‌های تصمیم‌گیری را دوباره تولید کنید"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:120 pretalx/orga/templates/orga/submission/apply_pending.html:5 pretalx/orga/templates/orga/submission/list.html:46
+msgid "Apply pending changes"
+msgstr "تغییرات در انتظار را اعمال کنید"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:162
+msgid "Average"
+msgstr "میانگین"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:197 pretalx/orga/templates/orga/submission/list.html:80
+msgid "Type"
+msgstr "نوع"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:204
+msgid "Accept all"
+msgstr "همه را قبول کنید"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:208
+msgid "Reject all"
+msgstr "همه را رد کنید"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:210
+msgid "Unset accept/reject vote for all"
+msgstr "رای قبول/رد برای همه را بازنشانی کنید"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:242
+msgid "You have reviewed this proposal"
+msgstr "شما این طرح پیشنهادی را بازبینی کرده‌اید"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:244
+msgid "You cannot review this proposal"
+msgstr "شما نمی‌توانید این طرح پیشنهادی را بازبینی کنید"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:247
+msgid "You have been assigned to this proposal"
+msgstr "این طرح پیشنهادی به شما اختصاص داده شده است"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:280 pretalx/orga/templates/orga/speaker/form.html:64
+msgid "pending"
+msgstr "در انتظار"
+
+#. Translators: This is a button to mark a proposal as accepted
+#: pretalx/orga/templates/orga/review/dashboard.html:288 pretalx/orga/templates/orga/review/dashboard.html:314
+msgid "Accept"
+msgstr "پذیرفتن"
+
+#. Translators: This is a button to mark a proposal as rejected
+#: pretalx/orga/templates/orga/review/dashboard.html:293 pretalx/orga/templates/orga/review/dashboard.html:315
+msgid "Reject"
+msgstr "رد کردن"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:295
+msgid "Unset accept/reject vote"
+msgstr "لغو رای پذیرش/رد"
+
+#: pretalx/orga/templates/orga/review/dashboard.html:317
+msgid "Go!"
+msgstr "برو!"
+
+#: pretalx/orga/templates/orga/review/export.html:5 pretalx/orga/templates/orga/review/export.html:8
+msgid "Export review data"
+msgstr "خروجی داده‌های بازبینی"
+
+#: pretalx/orga/templates/orga/review/export.html:14 pretalx/orga/templates/orga/speaker/export.html:15
+msgid "Build your own custom export here, by selecting all the data you need, and the export format. CSV exports can be opened with Excel and similar applications, while JSON exports are often used for integration with other tools."
+msgstr "در اینجا خروجی سفارشی خود را با انتخاب تمام داده‌های مورد نیاز و فرمت خروجی ایجاد کنید. خروجی CSV می‌تواند در Excel و برنامه‌های مشابه باز شود، در حالی که خروجی JSON اغلب برای یکپارچه‌سازی با ابزارهای دیگر استفاده می‌شود."
+
+#: pretalx/orga/templates/orga/review/export.html:24 pretalx/orga/templates/orga/schedule/export.html:26 pretalx/orga/templates/orga/speaker/export.html:25
+msgid "Dataset"
+msgstr "مجموعه داده"
+
+#: pretalx/orga/templates/orga/review/export.html:28 pretalx/orga/templates/orga/schedule/export.html:30 pretalx/orga/templates/orga/speaker/export.html:29
+msgid "Data fields"
+msgstr "فیلدهای داده"
+
+#: pretalx/orga/templates/orga/review/export.html:32 pretalx/orga/templates/orga/schedule/export.html:34 pretalx/orga/templates/orga/speaker/export.html:33
+msgid "Select all"
+msgstr "انتخاب همه"
+
+#: pretalx/orga/templates/orga/review/export.html:40 pretalx/orga/templates/orga/schedule/export.html:19 pretalx/orga/templates/orga/speaker/export.html:41
+msgid "Export settings"
+msgstr "تنظیمات خروجی"
+
+#: pretalx/orga/templates/orga/review/export.html:51 pretalx/orga/templates/orga/schedule/export.html:120 pretalx/orga/templates/orga/speaker/export.html:94
+msgid "You can also use the API to export or use data."
+msgstr "شما همچنین می‌توانید از API برای خروجی یا استفاده از داده‌ها استفاده کنید."
+
+#: pretalx/orga/templates/orga/review/export.html:55 pretalx/orga/templates/orga/schedule/export.html:123 pretalx/orga/templates/orga/speaker/export.html:98
+msgid "Some of the general exports are only accessible for organisers, or include more information when accessed with your organiser account. If you want to access the organiser version in automatic integrations, you’ll have to provide your authentication token just like in the API, like this:"
+msgstr "برخی از خروجی‌های عمومی فقط برای برگزارکننده‌گان قابل دسترسی هستند یا در صورت دسترسی با حساب برگزارکننده شما اطلاعات بیشتری را شامل می‌شوند. اگر می‌خواهید نسخه برگزارکننده را در یکپارچه‌سازی‌های خودکار دسترسی داشته باشید، باید مانند API توکن احراز هویت خود را ارائه دهید، مانند این:"
+
+#: pretalx/orga/templates/orga/review/export.html:68 pretalx/orga/templates/orga/schedule/export.html:137 pretalx/orga/templates/orga/speaker/export.html:111
+msgid "Documentation"
+msgstr "مستندات"
+
+#: pretalx/orga/templates/orga/review/export.html:71 pretalx/orga/templates/orga/schedule/export.html:140 pretalx/orga/templates/orga/speaker/export.html:114
+msgid "Go to API"
+msgstr "رفتن به API"
+
+#: pretalx/orga/templates/orga/schedule/export.html:7 pretalx/orga/templates/orga/schedule/export.html:10
+msgid "Export schedule data"
+msgstr "خروجی داده‌های برنامه زمان‌بندی"
+
+#: pretalx/orga/templates/orga/schedule/export.html:47 pretalx/orga/templates/orga/speaker/export.html:55
+msgid "eventyay provides a range of exports. If none of these match what you are looking for, you can also provide a custom plugin to export the data – please ask your administrator to install the plugin."
+msgstr "eventyay مجموعه‌ای از خروجی‌ها را فراهم می‌کند. اگر هیچ‌یک از این‌ها مطابق با آنچه که به دنبال آن هستید نیست، می‌توانید یک افزونه سفارشی برای خروجی داده ارائه دهید – لطفا از مدیریت خود بخواهید که افزونه را نصب کند."
+
+#: pretalx/orga/templates/orga/schedule/export.html:52 pretalx/orga/templates/orga/speaker/export.html:60
+msgid "If you are looking for exports of proposals, sessions or schedule data, please head here:"
+msgstr "اگر به دنبال خروجی پیشنهادات، جلسات یا داده‌های برنامه زمان‌بندی هستید، لطفا به اینجا بروید:"
+
+#: pretalx/orga/templates/orga/schedule/export.html:56
+msgid "Speaker exports"
+msgstr "خروجی‌های سخنران"
+
+#: pretalx/orga/templates/orga/schedule/export.html:59
+msgid "You haven’t released a schedule yet – many of these data exporters only work on a released schedule."
+msgstr "شما هنوز برنامه‌ای منتشر نکرده‌اید – بسیاری از این خروجی‌های داده فقط روی یک برنامه زمان‌بندی منتشرشده کار می‌کنند."
+
+#: pretalx/orga/templates/orga/schedule/export.html:86
+msgid "HTML Export"
+msgstr "خروجی HTML"
+
+#: pretalx/orga/templates/orga/schedule/export.html:89
+msgid "The event schedule can be exported to a static HTML dump, so you can upload it to a normal file-serving web server like nginx."
+msgstr "برنامه زمان‌بندی رویداد می‌تواند به یک پرونده HTML استاتیک خروجی گرفته شود، بنابراین می‌توانید آن را به یک سرور وب معمولی مانند nginx آپلود کنید."
+
+#: pretalx/orga/templates/orga/schedule/export.html:94
+msgid "This is done automatically on schedule release, but you can also trigger that action here."
+msgstr "این به‌طور خودکار هنگام انتشار برنامه زمان‌بندی انجام می‌شود، اما می‌توانید این عمل را از اینجا نیز فعال کنید."
+
+#: pretalx/orga/templates/orga/schedule/export.html:104
+msgid "Download ZIP"
+msgstr "دانلود ZIP"
+
+#: pretalx/orga/templates/orga/schedule/export.html:110
+msgid "Regenerate Export"
+msgstr "تولید مجدد خروجی"
+
+#: pretalx/orga/templates/orga/schedule/export.html:118 pretalx/orga/views/review.py:810 pretalx/orga/views/schedule.py:103 pretalx/orga/views/speaker.py:353
+msgid "API"
+msgstr "API"
+
+#: pretalx/orga/templates/orga/schedule/index.html:31
+msgid "New release"
+msgstr "انتشار جدید"
+
+#: pretalx/orga/templates/orga/schedule/index.html:35
+msgid "Override WIP schedule with this version"
+msgstr "جایگزینی برنامه زمان‌بندی در دست اقدام با این نسخه"
+
+#: pretalx/orga/templates/orga/schedule/index.html:45
+msgid "View in frontend"
+msgstr "مشاهده در رابط کاربری"
+
+#: pretalx/orga/templates/orga/schedule/index.html:50
+msgid "Hide schedule"
+msgstr "پنهان کردن برنامه زمان‌بندی"
+
+#: pretalx/orga/templates/orga/schedule/index.html:54
+msgid "Make schedule public"
+msgstr "عمومی کردن برنامه زمان‌بندی"
+
+#: pretalx/orga/templates/orga/schedule/index.html:58
+msgid "Print cards"
+msgstr "چاپ کارت‌ها"
+
+#: pretalx/orga/templates/orga/schedule/index.html:61
+msgid "Resend speaker notifications"
+msgstr "ارسال مجدد آگاه‌سازی‌های سخنران"
+
+#: pretalx/orga/templates/orga/schedule/index.html:70
+msgid "You can start planning your schedule once you have configured some rooms for sessions to take place in."
+msgstr "شما می‌توانید برنامه زمان‌بندی خود را شروع کنید زمانی که برخی اتاق‌ها برای برگزاری جلسات تنظیم کرده باشید."
+
+#: pretalx/orga/templates/orga/schedule/index.html:71
+msgid "Configure rooms"
+msgstr "تنظیم اتاق‌ها"
+
+#: pretalx/orga/templates/orga/schedule/quick.html:7 pretalx/orga/templates/orga/schedule/quick.html:11
+msgid "Schedule session"
+msgstr "برنامه زمان‌بندی جلسه"
+
+#: pretalx/orga/templates/orga/schedule/release.html:7 pretalx/orga/templates/orga/schedule/release.html:14
+msgid "Release new schedule"
+msgstr "انتشار برنامه زمان‌بندی جدید"
+
+#: pretalx/orga/templates/orga/schedule/release.html:22
+msgid "There are still warnings about the release of this schedule. Please review them carefully!"
+msgstr "هنوز هشدارهایی در مورد انتشار این برنامه زمان‌بندی وجود دارد. لطفا آن‌ها را با دقت بررسی کنید!"
+
+#: pretalx/orga/templates/orga/schedule/release.html:32
+#, python-format
+msgid "The previous schedule (%(prev)s) was released %(since)s ago."
+msgstr "برنامه زمان‌بندی قبلی (%(prev)s) %(since)s پیش منتشر شده است."
+
+#: pretalx/orga/templates/orga/schedule/release.html:36
+msgid "This will be the very first schedule release."
+msgstr "این اولین انتشار برنامه زمان‌بندی خواهد بود."
+
+#: pretalx/orga/templates/orga/schedule/release.html:41
+#, python-format
+msgid "When releasing this new schedule, <strong>one notifications email </strong> can be generated and placed in the outbox, to tell speakers about their session slots."
+msgid_plural "When releasing this new schedule, <strong>%(count)s notifications emails </strong> can be generated and placed in the outbox, to tell speakers about their session slots."
+msgstr[0] "هنگام انتشار این برنامه زمان‌بندی جدید، <strong>یک رایانامه آگاه‌ساری</strong> می‌تواند تولید شده و در صندوق خروجی قرار گیرد تا سخنرانان از فاصله جلسات خود مطلع شوند."
+msgstr[1] "هنگام انتشار این برنامه زمان‌بندی جدید، <strong>%(count)s رایانامه آگاه‌ساری</strong> می‌توانند تولید شده و در صندوق خروجی قرار گیرند تا سخنرانان از فاصله جلسات خود مطلع شوند."
+
+#: pretalx/orga/templates/orga/schedule/release.html:51
+msgid "New schedule version"
+msgstr "نسخه جدید برنامه زمان‌بندی"
+
+#: pretalx/orga/templates/orga/schedule/release.html:53
+msgid "This schedule release would result in <strong>no notification emails</strong> for speakers."
+msgstr "این انتشار برنامه زمان‌بندی منجر به <strong>هیچ رایانامه آگاه‌سازی</strong> برای سخنرانان نخواهد شد."
+
+#: pretalx/orga/templates/orga/schedule/release.html:60
+#, python-format
+msgid "One session is still <strong>unconfirmed</strong> and will not show up on the public schedule."
+msgid_plural "%(count)s sessions are still <strong>unconfirmed</strong> and will not show up on the public schedule."
+msgstr[0] "یک جلسه همچنان <strong>تایید نشده</strong> است و در برنامه زمان‌بندی عمومی نمایش داده نخواهد شد."
+msgstr[1] "%(count)s جلسه همچنان <strong>تأیید نشده</strong> هستند و در برنامه زمان‌بندی عمومی نمایش داده نخواهند شد."
+
+#: pretalx/orga/templates/orga/schedule/release.html:66
+msgid "See all unconfirmed sessions."
+msgstr "مشاهده همه جلسات تأیید نشده."
+
+#: pretalx/orga/templates/orga/settings/review.html:75
+msgid "Review Score category"
+msgstr "دسته‌بندی امتیازات بازبینی"
+
+#: pretalx/orga/templates/orga/settings/review.html:108 pretalx/orga/templates/orga/settings/review.html:126 pretalx/orga/templates/orga/settings/review.html:162
+msgid "Scores"
+msgstr "امتیازات"
+
+#: pretalx/orga/templates/orga/settings/review.html:141
+msgid "Score Category"
+msgstr "دسته‌بندی امتیاز"
+
+#: pretalx/orga/templates/orga/settings/review.html:177
+msgid "Add another score category"
+msgstr "اضافه کردن دسته‌بندی امتیاز دیگر"
+
+#: pretalx/orga/templates/orga/settings/review.html:186
+msgid "Review phases allow you to structure your review process. By default, there are two review phases: The review itself, and the selection process once the review phase is over. But you could for example add another review and selection phase after that, if you require additional review rounds."
+msgstr "فازهای بازبینی به شما اجازه می‌دهند فرآیند بازبینی خود را سازماندهی کنید. به طور پیش‌فرض، دو فاز بازبینی وجود دارد: خود بازبینی و فرآیند انتخاب پس از پایان فاز بازبینی. اما شما می‌توانید، به عنوان مثال، یک فاز بازبینی و انتخاب دیگر اضافه کنید اگر به دورهای بازبینی اضافی نیاز دارید."
+
+#: pretalx/orga/templates/orga/settings/review.html:202 pretalx/orga/templates/orga/settings/review.html:250
+msgid "Review Phase"
+msgstr "فاز بازبینی"
+
+#: pretalx/orga/templates/orga/settings/review.html:214
+msgid "Activate phase"
+msgstr "فعال کردن فاز"
+
+#: pretalx/orga/templates/orga/settings/review.html:220
+msgid "Phase is active"
+msgstr "فاز فعال است"
+
+#: pretalx/orga/templates/orga/settings/review.html:275
+msgid "Add another phase"
+msgstr "اضافه کردن فاز دیگر"
+
+#: pretalx/orga/templates/orga/settings/team_detail.html:56
+msgid "Remove team member"
+msgstr "حذف عضو تیم"
+
+#: pretalx/orga/templates/orga/settings/team_detail.html:66
+msgid "pending Invitation"
+msgstr "دعوت‌نامه در انتظار"
+
+#: pretalx/orga/templates/orga/settings/team_detail.html:79
+msgid "Resend invite"
+msgstr "ارسال مجدد دعوت‌نامه"
+
+#: pretalx/orga/templates/orga/settings/team_detail.html:92
+msgid "Add member"
+msgstr "اضافه کردن عضو"
+
+#: pretalx/orga/templates/orga/settings/team_detail.html:94
+msgid "Add multiple team members?"
+msgstr "اضافه کردن چندین عضو تیم؟"
+
+#: pretalx/orga/templates/orga/settings/widget.html:8 pretalx/orga/templates/orga/settings/widget.html:42
+msgid "Widget generation"
+msgstr "ایجاد ابزارک"
+
+#: pretalx/orga/templates/orga/settings/widget.html:25
+msgid "Widget settings"
+msgstr "تنظیمات ابزارک"
+
+#: pretalx/orga/templates/orga/settings/widget.html:32
+msgid "You can configure a eventyay schedule widget to show your event schedule on your homepage, instead of using this page. If you want to disable the schedule on here entirely, please activate the setting below."
+msgstr "می‌توانید ابزارک برنامه زمان‌بندی eventyay را تنظیم کنید تا برنامه زمان‌بندی رویداد خود را در صفحه اصلی خود نمایش دهید، به جای استفاده از این صفحه. اگر می‌خواهید برنامه زمان‌بندی را در اینجا به‌طور کامل غیرفعال کنید، لطفاً تنظیم زیر را فعال کنید."
+
+#: pretalx/orga/templates/orga/settings/widget.html:44
+msgid "The eventyay schedule widget is a way to embed your schedule into your event website. This way, your attendees can see your schedule without leaving your website, and you can style the schedule to fit right in with your website."
+msgstr "ابزارک برنامه eventyay راهی است برای جایگذاری برنامه زمان‌بندی شما در وبگاه رویدادتان. به این ترتیب، شرکت‌کنندگان می‌توانند برنامه زمان‌بندی شما را بدون ترک وبگاه مشاهده کنند و می‌توانید ظاهر برنامه زمان‌بندی را با وبگاه خود هماهنگ کنید."
+
+#: pretalx/orga/templates/orga/settings/widget.html:51
+msgid "Using this form, you can generate code to copy and paste to your website source."
+msgstr "با استفاده از این فرم، می‌توانید کدی تولید کنید که به منبع وبگاه خود کپی و جایگذاری کنید."
+
+#: pretalx/orga/templates/orga/settings/widget.html:59
+msgid "Generate widget"
+msgstr "ایجاد ابزارک"
+
+#: pretalx/orga/templates/orga/settings/widget.html:65
+msgid "To embed the widget into your website, copy the following code to the <code>&lt;head></code> section of your website:"
+msgstr "برای جایگذاری ابزارک در وبگاه خود، کد زیر را در بخش <code>&lt;head></code> وبگاه خود کپی کنید:"
+
+#: pretalx/orga/templates/orga/settings/widget.html:72
+msgid "Then, copy the following code to the place of your website where you want the widget to show up:"
+msgstr "سپس، کد زیر را در جایی از وبگاه خود که می‌خواهید ابزارک نمایش داده شود، کپی کنید:"
+
+#: pretalx/orga/templates/orga/settings/widget.html:90
+#, python-format
+msgid "Please look at <a href=\"%(link)s\">our documentation</a> for more information."
+msgstr "لطفاً برای اطلاعات بیشتر به <a href=\"%(link)s\">مستندات ما</a> نگاه کنید."
+
+#: pretalx/orga/templates/orga/settings/widget.html:99
+msgid "Widget preview"
+msgstr "پیش‌نمایش ابزارک"
+
+#: pretalx/orga/templates/orga/settings/widget.html:101
+msgid "This is roughly what your widget will look like if you choose the grid format:"
+msgstr "تقریبا اینگونه است که ابزارک شما در صورت انتخاب فرمت شبکه نمایش داده می‌شود."
+
+#: pretalx/orga/templates/orga/speaker/export.html:6 pretalx/orga/templates/orga/speaker/export.html:9
+msgid "Export speaker data"
+msgstr "خروجی داده‌های سخنران"
+
+#: pretalx/orga/templates/orga/speaker/export.html:64
+msgid "Schedule exports"
+msgstr "خروجی‌های برنامه زمان‌بندی"
+
+#: pretalx/orga/templates/orga/speaker/export.html:67
+msgid "You can either create exactly the export you need in the “Custom” tab, or use these pre-built exports:"
+msgstr "می‌توانید دقیقا خروجی موردنیاز خود را در زبانه «سفارشی» ایجاد کنید یا از این خروجی‌های از پیش‌ساخته‌شده استفاده کنید:"
+
+#: pretalx/orga/templates/orga/speaker/form.html:49 pretalx/orga/templates/orga/submission/list.html:41 pretalx/orga/templates/orga/submission/speakers.html:65
+msgid "Send email"
+msgstr "ارسال رایانامه"
+
+#: pretalx/orga/templates/orga/speaker/form.html:98
+msgid "Emails"
+msgstr "رایانامه‌ها"
+
+#: pretalx/orga/templates/orga/speaker/form.html:104
+msgid "No mails were sent to this speaker yet."
+msgstr "هنوز هیچ رایانامه‌ای به این سخنران ارسال نشده است."
+
+#: pretalx/orga/templates/orga/speaker/information_form.html:5 pretalx/orga/templates/orga/speaker/information_form.html:9 pretalx/orga/templates/orga/speaker/information_list.html:19 pretalx/orga/templates/orga/speaker/information_list.html:24
+msgid "Speaker Information Note"
+msgid_plural "Speaker Information Notes"
+msgstr[0] "یادداشت اطلاعات سخنران"
+msgstr[1] "یادداشت‌های اطلاعات سخنران"
+
+#: pretalx/orga/templates/orga/speaker/information_list.html:35
+msgid "Add important messages (e.g. “Please bring an HDMI adapter if required.”) or files (e.g. a conference styleguide). <br> They are shown to the selected speakers above the list of their submitted sessions."
+msgstr "پیام‌های مهم (مثلا «لطفا در صورت نیاز آداپتور HDMI بیاورید.») یا به پرونده‌ها (مثلا یک راهنمای سبک کنفرانس) اضافه کنید.<br> این موارد به سخنرانان انتخاب‌شده بالای فهرست جلسات ارسال‌شده آن‌ها نمایش داده می‌شود."
+
+#: pretalx/orga/templates/orga/speaker/information_list.html:45
+msgid "Add a new note"
+msgstr "اضافه کردن یادداشت جدید"
+
+#: pretalx/orga/templates/orga/speaker/list.html:6 pretalx/orga/templates/orga/speaker/list.html:11 pretalx/orga/views/dashboard.py:359
+msgid "submitter"
+msgid_plural "submitters"
+msgstr[0] "ارسال‌کننده"
+msgstr[1] "ارسال‌کنندگان"
+
+#: pretalx/orga/templates/orga/speaker/list.html:61
+msgid "Mark speaker as not arrived"
+msgstr "علامت‌گذاری سخنران به‌عنوان نرسیده"
+
+#: pretalx/orga/templates/orga/speaker/list.html:63
+msgid "Mark speaker as arrived"
+msgstr "علامت‌گذاری سخنران به‌عنوان رسیده"
+
+#: pretalx/orga/templates/orga/speaker/list.html:68
+msgid "Arrived"
+msgstr "رسیده"
+
+#: pretalx/orga/templates/orga/speaker/list.html:70
+msgid "Not arrived"
+msgstr "نرسیده"
+
+#: pretalx/orga/templates/orga/submission/anonymise.html:9 pretalx/orga/templates/orga/submission/base.html:62
+msgid "Anonymisation"
+msgstr "ناشناس‌سازی"
+
+#: pretalx/orga/templates/orga/submission/anonymise.html:27
+msgid "Original"
+msgstr "اصلی"
+
+#: pretalx/orga/templates/orga/submission/anonymise.html:31
+msgid "Anonymised"
+msgstr "ناشناس‌شده"
+
+#: pretalx/orga/templates/orga/submission/anonymise.html:40
+msgid "If a review phase with anonymisation is currently active, all reviewers who have no permissions to change this proposal will be shown the anonymised proposal content."
+msgstr "اگر یک فاز بازبینی با ناشناس‌سازی در حال حاضر فعال باشد، تمام بازبین‌هایی که اجازه تغییر این پیشنهاد را ندارند، محتوای پیشنهاد ناشناس‌شده را مشاهده خواهند کرد."
+
+#: pretalx/orga/templates/orga/submission/anonymise.html:65
+msgid "Save and go to next unanonymised"
+msgstr "ذخیره و رفتن به ناشناس‌نشده بعدی"
+
+#: pretalx/orga/templates/orga/submission/anonymise.html:73
+msgid "Replace selection with █"
+msgstr "جایگزین‌کردن انتخاب با █"
+
+#: pretalx/orga/templates/orga/submission/apply_pending.html:11
+#, python-format
+msgid "Apply %(count)s pending changes?"
+msgstr "اعمال %(count)s تغییرات در انتظار؟"
+
+#: pretalx/orga/templates/orga/submission/apply_pending.html:17
+#, python-format
+msgid "Please confirm that you really want to change the state of these %(count)s proposals."
+msgstr "لطفا تأیید کنید که واقعاً می‌خواهید وضعیت این %(count)s طرح‌های پیشنهادی را تغییر دهید."
+
+#: pretalx/orga/templates/orga/submission/apply_pending.html:33 pretalx/orga/templates/orga/submission/state_change.html:34
+msgid "Do it"
+msgstr "انجام بده"
+
+#: pretalx/orga/templates/orga/submission/apply_pending.html:38
+msgid "There are no pending changes to apply right now."
+msgstr "هیچ تغییری برای اعمال در حال حاضر وجود ندارد."
+
+#: pretalx/orga/templates/orga/submission/base.html:79
+msgid "Send email to speakers"
+msgstr "ارسال رایانامه به سخنرانان"
+
+#: pretalx/orga/templates/orga/submission/base.html:85
+msgid "Links"
+msgstr "پیوندها"
+
+#: pretalx/orga/templates/orga/submission/base.html:91
+msgid "Public link"
+msgstr "پیوند عمومی"
+
+#: pretalx/orga/templates/orga/submission/base.html:93
+msgid "not public yet"
+msgstr "هنوز عمومی نشده"
+
+#: pretalx/orga/templates/orga/submission/base.html:100
+msgid "Secret public link"
+msgstr "پیوند عمومی محرمانه"
+
+#: pretalx/orga/templates/orga/submission/content.html:32
+msgid "This proposal was created using an access code:"
+msgstr "این طرح پیشنهادی با استفاده از یک کد دسترسی ایجاد شده است:"
+
+#: pretalx/orga/templates/orga/submission/content.html:50
+msgid "Proposal"
+msgstr "طرح پیشنهادی"
+
+#: pretalx/orga/templates/orga/submission/content.html:66
+msgid "reviews"
+msgstr "بازبینی‌ها"
+
+#: pretalx/orga/templates/orga/submission/feedback_list.html:6 pretalx/orga/templates/orga/submission/feedbacks_list.html:7 pretalx/orga/templates/orga/submission/feedbacks_list.html:10
+msgid "Attendee feedback"
+msgstr "بازخورد شرکت‌کننده"
+
+#: pretalx/orga/templates/orga/submission/feedbacks_list.html:30
+msgid "There has been no feedback for sessions in this event yet."
+msgstr "هنوز هیچ بازخوردی برای جلسات این رویداد وجود نداشته است."
+
+#: pretalx/orga/templates/orga/submission/list.html:17 pretalx/orga/templates/orga/submission/list.html:53
+msgid "Proposal feed"
+msgstr "خوراک طرح پیشنهادی"
+
+#: pretalx/orga/templates/orga/submission/list.html:21 pretalx/orga/templates/orga/submission/list.html:31 pretalx/orga/views/dashboard.py:301
+msgid "session"
+msgid_plural "sessions"
+msgstr[0] "جلسه"
+msgstr[1] "جلسات"
+
+#: pretalx/orga/templates/orga/submission/list.html:51
+msgid "Add new session or proposal"
+msgstr "اضافه کردن جلسه یا طرح پیشنهادی جدید"
+
+#: pretalx/orga/templates/orga/submission/list.html:92
+msgid "Featured"
+msgstr "ویژه"
+
+#: pretalx/orga/templates/orga/submission/list.html:92
+msgid "Show this session on the list of featured sessions, once it was accepted"
+msgstr "این جلسه را در فهرست جلسات ویژه نشان دهید، زمانی که پذیرفته شد."
+
+#: pretalx/orga/templates/orga/submission/list.html:109 pretalx/orga/templates/orga/submission/list.html:113
+msgid "anonymised"
+msgstr "ناشناس‌شده"
+
+#: pretalx/orga/templates/orga/submission/list.html:147
+msgid "Show this proposal in the list of featured sessions."
+msgstr "این طرح پیشنهادی را در فهرست جلسات ویژه نشان دهید."
+
+#: pretalx/orga/templates/orga/submission/review.html:24
+msgid "You’re not allowed to review or see reviews for your own proposals."
+msgstr "شما مجاز به بازبینی یا مشاهده بازبینی‌های طرح‌های پیشنهادی خود نیستید."
+
+#: pretalx/orga/templates/orga/submission/review.html:40
+msgid "You will be able to see other reviews once you have given yours."
+msgstr "شما پس از ارائه بازبینی خود می‌توانید بازبینی‌های دیگران را مشاهده کنید."
+
+#: pretalx/orga/templates/orga/submission/review.html:143
+msgid "Other proposals"
+msgstr "طرح‌های پیشنهادی دیگر"
+
+#: pretalx/orga/templates/orga/submission/review.html:190
+msgid "Nobody else has submitted a review yet."
+msgstr "هنوز کسی دیگر بازبینی ارسال نکرده است."
+
+#: pretalx/orga/templates/orga/submission/review.html:200 pretalx/orga/templates/orga/submission/review.html:201
+msgid "Review progress"
+msgstr "پیشرفت بازبینی"
+
+#: pretalx/orga/templates/orga/submission/review.html:208 pretalx/orga/templates/orga/submission/review.html:210
+msgid "Go to random next unreviewed proposal"
+msgstr "رفتن به طرح پیشنهادی ناشناخته بعدی به‌طور تصادفی"
+
+#: pretalx/orga/templates/orga/submission/review.html:208
+msgid "Save and next"
+msgstr "ذخیره و بعدی"
+
+#: pretalx/orga/templates/orga/submission/review.html:210
+msgid "Abstain"
+msgstr "امتناع"
+
+#: pretalx/orga/templates/orga/submission/review.html:212
+msgid "Go to random next unreviewed proposal, mark this one as skipped"
+msgstr "رفتن به طرح پیشنهادی ناشناخته بعدی به‌طور تصادفی، علامت‌گذاری این طرح پیشنهادی به‌عنوان رد شده"
+
+#: pretalx/orga/templates/orga/submission/review.html:212
+msgid "Skip for now"
+msgstr "فعلاً رد کن"
+
+#: pretalx/orga/templates/orga/submission/review.html:222 pretalx/orga/templates/orga/submission/review_delete.html:5
+msgid "Delete review"
+msgstr "حذف بازبینی"
+
+#: pretalx/orga/templates/orga/submission/speakers.html:24
+msgid "Add speaker"
+msgstr "اضافه کردن سخنران"
+
+#: pretalx/orga/templates/orga/submission/speakers.html:51
+msgid "Other proposals by this speaker:"
+msgstr "طرح‌های پیشنهادی دیگر از این سخنران:"
+
+#: pretalx/orga/templates/orga/submission/speakers.html:74
+msgid "Remove"
+msgstr "حذف"
+
+#: pretalx/orga/templates/orga/submission/state_change.html:18
+msgid "Please confirm that you really want to change the state of this proposal."
+msgstr "لطفاً تأیید کنید که واقعاً می‌خواهید وضعیت این طرح پیشنهادی را تغییر دهید."
+
+#: pretalx/orga/templates/orga/submission/stats.html:23
+msgid "Proposal Statistics"
+msgstr "آمار طرح‌های پیشنهادی"
+
+#: pretalx/orga/templates/orga/submission/stats.html:35
+msgid "Proposals by submission date"
+msgstr "طرح‌های پیشنهادی بر اساس تاریخ ارسال"
+
+#: pretalx/orga/templates/orga/submission/stats.html:36
+msgid "Sessions by submission date"
+msgstr "جلسات بر اساس تاریخ ارسال"
+
+#: pretalx/orga/templates/orga/submission/stats.html:39
+msgid "Total proposals"
+msgstr "کل طرح‌های پیشنهادی"
+
+#: pretalx/orga/templates/orga/submission/stats.html:46
+msgid "Proposals by session type"
+msgstr "طرح‌های پیشنهادی بر اساس نوع جلسه"
+
+#: pretalx/orga/templates/orga/submission/stats.html:47
+msgid "Sessions by session type"
+msgstr "جلسات بر اساس نوع جلسه"
+
+#: pretalx/orga/templates/orga/submission/stats.html:57
+msgid "Proposals by track"
+msgstr "طرح‌های پیشنهادی بر اساس مسیر"
+
+#: pretalx/orga/templates/orga/submission/stats.html:58
+msgid "Sessions by track"
+msgstr "جلسات بر اساس مسیر"
+
+#: pretalx/orga/templates/orga/submission/stats.html:68
+msgid "Proposals by state"
+msgstr "طرح‌های پیشنهادی بر اساس وضعیت"
+
+#: pretalx/orga/templates/orga/submission/stats.html:69
+msgid "Sessions by state"
+msgstr "جلسات بر اساس وضعیت"
+
+#: pretalx/orga/templates/orga/submission/tag_form.html:18 pretalx/orga/templates/orga/submission/tag_form.html:24 pretalx/orga/templates/orga/submission/tag_list.html:23 pretalx/orga/views/submission.py:967
+msgid "Tag"
+msgstr "برچسب"
+
+#: pretalx/orga/templates/orga/submission/tag_form.html:18 pretalx/orga/templates/orga/submission/tag_form.html:26 pretalx/orga/templates/orga/submission/tag_list.html:15
+msgid "New tag"
+msgstr "برچسب جدید"
+
+#: pretalx/orga/templates/orga/user.html:14 pretalx/orga/templates/orga/user.html:17
+msgid "User settings"
+msgstr "تنظیمات کاربر"
+
+#: pretalx/orga/templates/orga/user.html:22
+msgid "Login settings"
+msgstr "تنظیمات ورود"
+
+#: pretalx/orga/templates/orga/widgets/multi_languages_widget.html:8
+#, python-format
+msgid "%(percentage)s %% translated"
+msgstr "%(percentage)s %% ترجمه شده"
+
+#: pretalx/orga/views/admin.py:177
+msgid "The user has been deleted."
+msgstr "کاربر حذف شده است."
+
+#: pretalx/orga/views/cards.py:99
+msgid "{} minutes, #{}, {}, {}"
+msgstr "{} دقیقه، #{}, {}, {}"
+
+#: pretalx/orga/views/cfp.py:71 pretalx/orga/views/event.py:112 pretalx/orga/views/event.py:272
+msgid "General information"
+msgstr "اطلاعات عمومی"
+
+#: pretalx/orga/views/cfp.py:72
+msgid "Fields"
+msgstr "فیلدها"
+
+#: pretalx/orga/views/cfp.py:313
+msgid "You cannot change the question options and upload a question option file at the same time."
+msgstr "شما نمی‌توانید هم گزینه‌های سوال را تغییر دهید و هم یک پرونده گزینه سوال بارگذاری کنید."
+
+#: pretalx/orga/views/cfp.py:374
+msgid "The question has been deleted."
+msgstr "سوال حذف شده است."
+
+#: pretalx/orga/views/cfp.py:381
+msgid "You cannot delete a question that has already been answered. We have deactivated the question instead."
+msgstr "شما نمی‌توانید سوالی را که قبلا پاسخ داده شده حذف کنید. در عوض، ما سوال را غیرفعال کردیم."
+
+#: pretalx/orga/views/cfp.py:435
+msgid "Could not send mails, error in configuration."
+msgstr "ارسال رایانامه‌ها ممکن نشد، خطا در پیکربندی."
+
+#: pretalx/orga/views/cfp.py:527
+msgid "The Session Type has been made default."
+msgstr "نوع جلسه به حالت پیش‌فرض تنظیم شد."
+
+#: pretalx/orga/views/cfp.py:553
+msgid "You cannot delete the only session type. Try creating another one first!"
+msgstr "شما نمی‌توانید تنها نوع جلسه را حذف کنید. ابتدا یک نوع دیگر ایجاد کنید!"
+
+#: pretalx/orga/views/cfp.py:560
+msgid "You cannot delete the default session type. Make another type default first!"
+msgstr "شما نمی‌توانید نوع جلسه پیش‌فرض را حذف کنید. ابتدا یک نوع دیگر را به عنوان پیش‌فرض تنظیم کنید!"
+
+#: pretalx/orga/views/cfp.py:571
+msgid "The Session Type has been deleted."
+msgstr "نوع جلسه حذف شده است."
+
+#: pretalx/orga/views/cfp.py:576
+msgid "This Session Type is in use in a proposal and cannot be deleted."
+msgstr "این نوع جلسه در یک پیشنهاد استفاده شده است و نمی‌توان آن را حذف کرد."
+
+#: pretalx/orga/views/cfp.py:653
+msgid "The track has been deleted."
+msgstr "مسیر حذف شده است."
+
+#: pretalx/orga/views/cfp.py:657
+msgid "This track is in use in a proposal and cannot be deleted."
+msgstr "این مسیر در یک پیشنهاد استفاده شده است و نمی‌توان آن را حذف کرد."
+
+#: pretalx/orga/views/cfp.py:735
+msgid "The access code has been sent."
+msgstr "کد دسترسی ارسال شده است."
+
+#: pretalx/orga/views/cfp.py:756 pretalx/submission/models/access_code.py:20
+msgid "Access code"
+msgstr "کد دسترسی"
+
+#: pretalx/orga/views/cfp.py:770
+msgid "The access code has been deleted."
+msgstr "کد دسترسی حذف شده است."
+
+#: pretalx/orga/views/cfp.py:775
+msgid "This access code has been used for a proposal and cannot be deleted. To disable it, you can set its validity date to the past."
+msgstr "این کد دسترسی در یک پیشنهاد استفاده شده است و نمی‌توان آن را حذف کرد. برای غیرفعال کردن آن، می‌توانید تاریخ اعتبار آن را به گذشته تنظیم کنید."
+
+#: pretalx/orga/views/dashboard.py:148
+msgid "until the CfP ends"
+msgstr "تا زمانی که فراخوان به پایان برسد"
+
+#: pretalx/orga/views/dashboard.py:160
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "پیش‌نویس پیشنهاد ارسال‌نشده"
+msgstr[1] "پیش‌نویس‌های پیشنهاد ارسال‌نشده"
+
+#: pretalx/orga/views/dashboard.py:167
+msgid "Send reminder"
+msgstr "ارسال یادآوری"
+
+#: pretalx/orga/views/dashboard.py:194
+msgid "Active reviewers"
+msgstr "بازبین‌های فعال"
+
+#: pretalx/orga/views/dashboard.py:215
+msgid "proposal is waiting for your review."
+msgid_plural "proposals are waiting for your review."
+msgstr[0] "پیشنهاد در انتظار بازبینی شما است."
+msgstr[1] "پیشنهادها در انتظار بازبینی شما هستند."
+
+#: pretalx/orga/views/dashboard.py:254
+msgid "day until event start"
+msgid_plural "days until event start"
+msgstr[0] "روز تا شروع رویداد"
+msgstr[1] "روزها تا شروع رویداد"
+
+#: pretalx/orga/views/dashboard.py:265
+msgid "day since event end"
+msgid_plural "days since event end"
+msgstr[0] "روز از پایان رویداد گذشته"
+msgstr[1] "روزها از پایان رویداد گذشته"
+
+#: pretalx/orga/views/dashboard.py:274
+#, python-brace-format
+msgid "Day {number}"
+msgstr "روز {number}"
+
+#: pretalx/orga/views/dashboard.py:275
+#, python-brace-format
+msgid "of {total_days} days"
+msgstr "از {total_days} روز"
+
+#: pretalx/orga/views/dashboard.py:286
+msgid "current schedule"
+msgstr "برنامه فعلی"
+
+#: pretalx/orga/views/dashboard.py:306
+msgid "unconfirmed"
+msgstr "تأیید نشده"
+
+#: pretalx/orga/views/dashboard.py:344 pretalx/submission/models/submission.py:57
+msgid "rejected"
+msgstr "رد شده"
+
+#: pretalx/orga/views/dashboard.py:368
+msgid "sent email"
+msgid_plural "sent emails"
+msgstr[0] "رایانامه ارسال شده"
+msgstr[1] "ایمیل‌های ارسال شده"
+
+#: pretalx/orga/views/event.py:113
+msgid "Localisation"
+msgstr "بومی‌سازی"
+
+#: pretalx/orga/views/event.py:114
+msgid "Display settings"
+msgstr "تنظیمات نمایش"
+
+#: pretalx/orga/views/event.py:115
+msgid "Texts"
+msgstr "متن‌ها"
+
+#: pretalx/orga/views/event.py:156
+msgid "The CfP doesn’t have a full text yet."
+msgstr "فراخوان هنوز متن کامل ندارد."
+
+#: pretalx/orga/views/event.py:166
+msgid "The event doesn’t have a landing page text yet."
+msgstr "رویداد هنوز متن صفحه اصلی ندارد."
+
+#: pretalx/orga/views/event.py:179
+msgid "You want submitters to choose the tracks for their proposals, but you do not offer tracks for selection. Add at least one track!"
+msgstr "شما می‌خواهید ارسال‌کنندگان مسیرهای طرح‌های پیشنهادی خود را انتخاب کنند، اما مسیرهایی برای انتخاب ارائه نمی‌دهید. حداقل یک مسیر اضافه کنید!"
+
+#: pretalx/orga/views/event.py:187
+msgid "You have configured only one session type so far."
+msgstr "شما تا کنون فقط یک نوع جلسه تنظیم کرده‌اید."
+
+#: pretalx/orga/views/event.py:207
+msgid "This event was already live."
+msgstr "این رویداد قبلاً فعال شده بود."
+
+#: pretalx/orga/views/event.py:231
+msgid "This event is now public."
+msgstr "این رویداد اکنون عمومی است."
+
+#: pretalx/orga/views/event.py:237
+msgid "This event was already hidden."
+msgstr "این رویداد قبلاً پنهان شده بود."
+
+#: pretalx/orga/views/event.py:247
+msgid "This event is now hidden."
+msgstr "این رویداد اکنون پنهان شده است."
+
+#: pretalx/orga/views/event.py:273
+msgid "Review scoring"
+msgstr "امتیازدهی بازبینی"
+
+#: pretalx/orga/views/event.py:274
+msgid "Review phases"
+msgstr "فازهای بازبینی"
+
+#: pretalx/orga/views/event.py:356
+msgid "Only the last review phase may be open-ended."
+msgstr "فقط فاز آخر بازبینی می‌تواند باز باشد."
+
+#: pretalx/orga/views/event.py:361
+#, python-brace-format
+msgid "The review phases '{phase1}' and '{phase2}' overlap. Please make sure that review phases do not overlap, then save again."
+msgstr "فازهای بازبینی '{phase1}' و '{phase2}' با هم تداخل دارند. لطفا مطمئن شوید که فازهای بازبینی تداخلی ندارند، سپس دوباره ذخیره کنید."
+
+#: pretalx/orga/views/event.py:458
+#, python-format
+msgid "An error occurred while contacting the SMTP server: %s"
+msgstr "هنگام ارتباط با سرور SMTP خطایی رخ داد: %s"
+
+#: pretalx/orga/views/event.py:466
+msgid "Yay, your changes have been saved and the connection attempt to your SMTP server was successful."
+msgstr "تغییرات شما ذخیره شده‌اند و تلاش برای اتصال به سرور SMTP شما موفقیت‌آمیز بود."
+
+#: pretalx/orga/views/event.py:474
+msgid "We’ve been able to contact the SMTP server you configured. Remember to check the “use custom SMTP server” checkbox, otherwise your SMTP server will not be used."
+msgstr "ما توانستیم با سرور SMTP پیکربندی‌شده شما ارتباط برقرار کنیم. به یاد داشته باشید که کادر «استفاده از سرور SMTP سفارشی» را علامت بزنید، در غیر این صورت سرور SMTP شما استفاده نخواهد شد."
+
+#: pretalx/orga/views/event.py:511
+msgid "There was a problem with your authentication. Please contact the organiser for further help."
+msgstr "مشکلی در احراز هویت شما وجود داشت. لطفا برای دریافت کمک بیشتر با سازمان‌دهنده تماس بگیرید."
+
+#: pretalx/orga/views/event.py:528
+msgid "You are now part of the team!"
+msgstr "شما اکنون بخشی از تیم هستید!"
+
+#: pretalx/orga/views/event.py:631
+#, python-brace-format
+msgid "Please consider including your event’s year in the slug, e.g. myevent{number}."
+msgstr "لطفا در نظر بگیرید که سال رویداد خود را در نام نامک اضافه کنید، برای مثال myevent{number}."
+
+#: pretalx/orga/views/event.py:640
+msgid "Did you really mean to make your event take place in the past?"
+msgstr "آیا واقعا قصد داشتید که رویداد شما در گذشته برگزار شود؟"
+
+#: pretalx/orga/views/event.py:696
+#, python-brace-format
+msgid "Team {event.name}"
+msgstr "تیم {event.name}"
+
+#: pretalx/orga/views/event.py:735
+msgid "ALL related data, such as proposals, and speaker profiles, and uploads, will also be deleted and cannot be restored."
+msgstr "تمام داده‌های مرتبط، مانند طرح‌های پیشنهادی، نمایه‌های سخنران، و بارگذاری‌ها، نیز حذف خواهند شد و قابل بازیابی نیستند."
+
+#: pretalx/orga/views/mails.py:136
+#, python-brace-format
+msgid "Do you really want to send {count} mails?"
+msgstr "آیا واقعا می‌خواهید {count} رایانامه ارسال کنید؟"
+
+#: pretalx/orga/views/mails.py:158
+msgid "This mail either does not exist or cannot be sent because it was sent already."
+msgstr "این رایانامه وجود ندارد یا نمی‌توان آن را ارسال کرد زیرا قبلا ارسال شده است."
+
+#: pretalx/orga/views/mails.py:163
+msgid "This mail had been sent already."
+msgstr "این رایانامه قبلا ارسال شده بود."
+
+#: pretalx/orga/views/mails.py:166
+msgid "The mail has been sent."
+msgstr "رایانامه ارسال شده است."
+
+#: pretalx/orga/views/mails.py:185
+#, python-brace-format
+msgid "{count} mails have been sent."
+msgstr "{count} رایانامه ارسال شده است."
+
+#: pretalx/orga/views/mails.py:220
+#, python-brace-format
+msgid "Do you really want to delete this mail?"
+msgid_plural "Do you really want to purge {count} mails?"
+msgstr[0] "آیا واقعا می‌خواهید این رایانامه را حذف کنید؟"
+msgstr[1] "آیا واقعا می‌خواهید {count} رایانامه را پاک کنید؟"
+
+#: pretalx/orga/views/mails.py:233
+msgid "This mail either does not exist or cannot be discarded because it was sent already."
+msgstr "این رایانامه وجود ندارد یا نمی‌توان آن را حذف کرد زیرا قبلا ارسال شده است."
+
+#: pretalx/orga/views/mails.py:245
+#, python-brace-format
+msgid "The mail has been discarded."
+msgid_plural "{count} mails have been discarded."
+msgstr[0] "رایانامه حذف شده است."
+msgstr[1] "{count} رایانامه حذف شده است."
+
+#: pretalx/orga/views/mails.py:261
+#, python-brace-format
+msgid "Do you really want to purge {count} mails?"
+msgstr "آیا واقعا می‌خواهید {count} رایانامه را پاک کنید؟"
+
+#: pretalx/orga/views/mails.py:281
+#, python-brace-format
+msgid "{count} mails have been purged."
+msgstr "{count} رایانامه پاک شده است."
+
+#: pretalx/orga/views/mails.py:308
+msgid "The email has been sent."
+msgstr "رایانامه ارسال شده است."
+
+#: pretalx/orga/views/mails.py:313
+msgid "The email has been saved. When you send it, the updated text will be used."
+msgstr "رایانامه ذخیره شده است. زمانی که آن را ارسال کنید، متن به‌روز شده استفاده خواهد شد."
+
+#: pretalx/orga/views/mails.py:330
+msgid "The mail has been copied, you can edit it now."
+msgstr "رایانامه کپی شده است، اکنون می‌توانید آن را ویرایش کنید."
+
+#: pretalx/orga/views/mails.py:393
+msgid "There are no recipients matching this selection."
+msgstr "هیچ گیرنده‌ای مطابق با این انتخاب وجود ندارد."
+
+#: pretalx/orga/views/mails.py:405
+msgid "This value will be replaced based on dynamic parameters."
+msgstr "این مقدار بر اساس پارامترهای پویا جایگزین خواهد شد."
+
+#: pretalx/orga/views/mails.py:422
+#, python-brace-format
+msgid "Subject: {subject}"
+msgstr "موضوع: {subject}"
+
+#: pretalx/orga/views/mails.py:436 pretalx/orga/views/mails.py:494
+#, python-brace-format
+msgid "{count} emails have been sent."
+msgstr "{count} رایانامه ارسال شده است."
+
+#: pretalx/orga/views/organiser.py:101
+msgid "The invitation has been sent."
+msgstr "دعوت‌نامه ارسال شده است."
+
+#: pretalx/orga/views/organiser.py:103
+msgid "The invitations have been sent."
+msgstr "دعوت‌نامه‌ها ارسال شده‌اند."
+
+#: pretalx/orga/views/organiser.py:127
+msgid "The team has been created."
+msgstr "تیم ایجاد شده است."
+
+#: pretalx/orga/views/organiser.py:152
+msgid "Team member"
+msgstr "عضو تیم"
+
+#: pretalx/orga/views/organiser.py:173
+msgid "The member was removed from the team."
+msgstr "عضو از تیم حذف شد."
+
+#: pretalx/orga/views/organiser.py:178
+msgid "The team was removed."
+msgstr "تیم حذف شد."
+
+#: pretalx/orga/views/organiser.py:210
+msgid "Retract invitation"
+msgstr "پس گرفتن دعوت‌نامه"
+
+#: pretalx/orga/views/organiser.py:211
+msgid "Are you sure you want to retract the invitation to this user?"
+msgstr "آیا مطمئن هستید که می‌خواهید دعوت‌نامه این کاربر را پس بگیرید؟"
+
+#: pretalx/orga/views/organiser.py:222
+msgid "The team invitation was retracted."
+msgstr "دعوت‌نامه تیم پس گرفته شد."
+
+#: pretalx/orga/views/organiser.py:229
+msgid "Resend invitation"
+msgstr "ارسال مجدد دعوت‌نامه"
+
+#: pretalx/orga/views/organiser.py:230
+msgid "Are you sure you want to resend the invitation to this user?"
+msgstr "آیا مطمئن هستید که می‌خواهید دعوت‌نامه را به این کاربر مجدداً ارسال کنید؟"
+
+#: pretalx/orga/views/organiser.py:244
+msgid "The team invitation was sent again."
+msgstr "دعوت‌نامه تیم دوباره ارسال شد."
+
+#: pretalx/orga/views/organiser.py:255 pretalx/orga/views/speaker.py:226
+msgid "Do your really want to reset this user’s password? They won’t be able to log in until they set a new password."
+msgstr "آیا واقعا می‌خواهید گذرواژه این کاربر را بازنشانی کنید؟ آن‌ها تا زمانی که گذرواژه جدیدی تنظیم نکنند، نمی‌توانند وارد شوند."
+
+#: pretalx/orga/views/organiser.py:325
+msgid "ALL related data for ALL events, such as proposals, and speaker profiles, and uploads, will also be deleted and cannot be restored."
+msgstr "تمام داده‌های مرتبط برای تمام رویدادها، مانند طرح‌های پیشنهادی، نمایه‌های سخنران، و بارگذاری‌ها، نیز حذف خواهند شد و قابل بازیابی نیستند."
+
+#: pretalx/orga/views/person.py:17
+msgid "You are now an administrator instead of a superuser."
+msgstr "شما اکنون مدیریت هستید، به جای superuser."
+
+#: pretalx/orga/views/review.py:313
+#, python-brace-format
+msgid "Success! {accepted} proposals were accepted, {rejected} proposals were rejected."
+msgstr "موفقیت! {accepted} طرح پیشنهادی پذیرفته شد، {rejected} طرح پیشنهادی رد شد."
+
+#: pretalx/orga/views/review.py:318
+#, python-brace-format
+msgid "We were unable to change the state of {count} proposals."
+msgstr "ما نتوانستیم وضعیت {count} طرح پیشنهادی را تغییر دهیم."
+
+#: pretalx/orga/views/review.py:325
+#, python-brace-format
+msgid "We were unable to change the state of all {count} proposals."
+msgstr "ما نتوانستیم وضعیت تمام {count} طرح پیشنهادی را تغییر دهیم."
+
+#: pretalx/orga/views/review.py:664
+msgid "Nice, you have no proposals left to review!"
+msgstr "عالی، شما هیچ طرح پیشنهادی برای بازبینی باقی ندارید!"
+
+#: pretalx/orga/views/review.py:678
+msgid "Your review"
+msgstr "بازبینی شما"
+
+#: pretalx/orga/views/review.py:687
+msgid "The review has been deleted."
+msgstr "بازبینی حذف شده است."
+
+#: pretalx/orga/views/review.py:718
+#, python-format
+msgid "Do you really want to regenerate %(count)s acceptance and rejection emails? They will be placed in the outbox and not sent out directly."
+msgstr "آیا واقعا می‌خواهید %(count)s رایانامه پذیرش و رد را دوباره ایجاد کنید؟ آن‌ها در صندوق خروجی قرار می‌گیرند و مستقیماً ارسال نمی‌شوند."
+
+#: pretalx/orga/views/review.py:731
+#, python-brace-format
+msgid "{count} emails were generated and placed in the outbox."
+msgstr "{count} رایانامه تولید شد و در صندوق خروجی قرار گرفت."
+
+#: pretalx/orga/views/review.py:762
+msgid "Assign reviewer teams"
+msgstr "اختصاص تیم‌های بازبینی"
+
+#: pretalx/orga/views/review.py:763
+msgid "Assign reviewers individually"
+msgstr "اختصاص بازبین‌ها به صورت فردی"
+
+#: pretalx/orga/views/review.py:797
+msgid "The reviewers were assigned successfully."
+msgstr "بازبین‌ها با موفقیت اختصاص داده شدند."
+
+#: pretalx/orga/views/review.py:809 pretalx/orga/views/schedule.py:101 pretalx/orga/views/speaker.py:351
+msgid "CSV/JSON exports"
+msgstr "خروجی‌های CSV/JSON"
+
+#: pretalx/orga/views/review.py:822 pretalx/orga/views/schedule.py:109 pretalx/orga/views/speaker.py:359
+msgid "No data to be exported"
+msgstr "هیچ داده‌ای برای خروجی وجود ندارد."
+
+#: pretalx/orga/views/schedule.py:102 pretalx/orga/views/speaker.py:352
+msgid "More exports"
+msgstr "خروجی‌های بیشتر"
+
+#: pretalx/orga/views/schedule.py:124
+msgid "A new export is being generated and will be available soon."
+msgstr "یک خروجی جدید در حال تولید است و به زودی در دسترس خواهد بود."
+
+#: pretalx/orga/views/schedule.py:131
+msgid "A new export will be generated on the next scheduled opportunity – please contact your administrator for details."
+msgstr "یک خروجی جدید در فرصت زمان‌بندی‌شده بعدی تولید خواهد شد – لطفا برای جزئیات با مدیریت خود تماس بگیرید."
+
+#: pretalx/orga/views/schedule.py:149
+#, python-brace-format
+msgid "Could not find the current export, please try to regenerate it. ({error})"
+msgstr "خروجی فعلی پیدا نشد، لطفا دوباره آن را تولید کنید. ({error})"
+
+#: pretalx/orga/views/schedule.py:184
+msgid "You have to provide a new, unique schedule version!"
+msgstr "شما باید نسخه جدید و منحصربه‌فردی از برنامه زمان‌بندی را ارائه دهید!"
+
+#: pretalx/orga/views/schedule.py:195
+msgid "Nice, your schedule has been released!"
+msgstr "عالی، برنامه زمان‌بندی شما منتشر شده است!"
+
+#: pretalx/orga/views/schedule.py:211
+msgid "Reset successful – start editing the schedule from your selected version!"
+msgstr "بازنشانی موفقیت‌آمیز – ویرایش برنامه زمان‌بندی را از نسخه انتخابی خود شروع کنید!"
+
+#: pretalx/orga/views/schedule.py:216
+msgid "Error retrieving the schedule version to reset to."
+msgstr "خطا در بازیابی نسخه برنامه زمان‌بندی برای بازنشانی."
+
+#: pretalx/orga/views/schedule.py:273
+msgid "You can only regenerate mails after the first schedule was released."
+msgstr "شما فقط می‌توانید رایانامه‌ها را پس از انتشار اولین برنامه زمان‌بندی دوباره تولید کنید."
+
+#: pretalx/orga/views/schedule.py:552
+msgid "The session has been scheduled."
+msgstr "جلسه برنامه‌ریزی شده است."
+
+#: pretalx/orga/views/schedule.py:585
+msgid "Room deleted. Hopefully nobody was still in there …"
+msgstr "اتاق حذف شد. امیدواریم هنوز کسی در آنجا نباشد …"
+
+#: pretalx/orga/views/schedule.py:591
+msgid "There is or was a session scheduled in this room. It cannot be deleted."
+msgstr "جلسه‌ای در این اتاق برنامه‌ریزی شده یا شده بود. نمی‌توان آن را حذف کرد."
+
+#: pretalx/orga/views/schedule.py:631
+msgid "Saved!"
+msgstr "ذخیره شد!"
+
+#: pretalx/orga/views/speaker.py:315
+msgid "Speaker information note"
+msgstr "یادداشت اطلاعات سخنران"
+
+#: pretalx/orga/views/speaker.py:326
+msgid "The information has been deleted."
+msgstr "اطلاعات حذف شده است."
+
+#: pretalx/orga/views/submission.py:182
+msgid "Somebody else was faster than you: this proposal was already in the state you wanted to change it to."
+msgstr "کسی دیگری از شما سریع‌تر بود: این طرح پیشنهادی قبلا در حالتی بود که شما می‌خواستید آن را تغییر دهید."
+
+#: pretalx/orga/views/submission.py:221
+msgid "There may be pending emails for this proposal that are now incorrect or outdated."
+msgstr "ممکن است رایانامه‌های در انتظار برای این طرح پیشنهادی وجود داشته باشد که اکنون نادرست یا قدیمی هستند."
+
+#: pretalx/orga/views/submission.py:255
+msgid "The speaker has been removed from the proposal."
+msgstr "سخنران از طرح پیشنهادی حذف شده است."
+
+#: pretalx/orga/views/submission.py:258
+msgid "The speaker was not part of this proposal."
+msgstr "سخنران بخشی از این طرح پیشنهادی نبود."
+
+#: pretalx/orga/views/submission.py:291
+msgid "The speaker has been added to the proposal."
+msgstr "سخنران به طرح پیشنهادی اضافه شده است."
+
+#: pretalx/orga/views/submission.py:477
+msgid "The proposal has been updated!"
+msgstr "طرح پیشنهادی به‌روزرسانی شده است!"
+
+#: pretalx/orga/views/submission.py:626
+msgid "The anonymisation has been updated."
+msgstr "ناشناس‌سازی به‌روزرسانی شده است."
+
+#: pretalx/orga/views/submission.py:628
+msgid "This proposal is now marked as anonymised."
+msgstr "این طرح پیشنهادی اکنون به‌عنوان ناشناس‌شده علامت‌گذاری شده است."
+
+#: pretalx/orga/views/submission.py:644
+#, python-brace-format
+msgid "{name} proposal feed"
+msgstr "خوراک طرح پیشنهادی {name}"
+
+#: pretalx/orga/views/submission.py:656
+#, python-brace-format
+msgid "Updates to the {name} schedule."
+msgstr "به‌روزرسانی‌ها به برنامه زمان‌بندی {name}."
+
+#: pretalx/orga/views/submission.py:662
+#, python-brace-format
+msgid "New {event} proposal: {title}"
+msgstr "پیشنهاد طرح پیشنهادی جدید {event}: {title}"
+
+#: pretalx/orga/views/submission.py:717 pretalx/orga/views/submission.py:729 pretalx/submission/models/cfp.py:108 pretalx/submission/models/question.py:133 pretalx/submission/models/type.py:38
+msgid "Deadline"
+msgstr "مهلت"
+
+#: pretalx/orga/views/submission.py:979
+msgid "The tag has been deleted."
+msgstr "برچسب حذف شده است."
+
+#: pretalx/orga/views/submission.py:1004
+#, python-brace-format
+msgid "Changed {count} proposal states."
+msgstr "{count} وضعیت طرح پیشنهادی تغییر داده شد."
+
+#: pretalx/person/exporters.py:16
+msgid "Speaker CSV"
+msgstr "CSV سخنران"
+
+#: pretalx/person/forms.py:38
+msgid "Please choose a different email address."
+msgstr "لطفاً یک نشانی رایانامه دیگر انتخاب کنید."
+
+#: pretalx/person/forms.py:70
+msgid "Password (again)"
+msgstr "گذرواژه (دوباره)"
+
+#: pretalx/person/forms.py:77
+msgid "Please fill all fields of either the login or the registration form."
+msgstr "لطفاً تمام فیلدهای فرم ورود یا فرم نام‌نویسی را پر کنید."
+
+#: pretalx/person/forms.py:98
+msgid "No user account matches the entered credentials. Are you sure that you typed your password correctly?"
+msgstr "هیچ حساب کاربری با اطلاعات وارد شده مطابقت ندارد. آیا مطمئن هستید که گذرواژه خود را به‌درستی وارد کرده‌اید؟"
+
+#: pretalx/person/forms.py:104
+msgid "Sorry, your account is currently disabled."
+msgstr "متأسفیم، حساب شما در حال حاضر غیرفعال است."
+
+#: pretalx/person/forms.py:120
+msgid "We already have a user with that email address. Did you already register before and just need to log in?"
+msgstr "ما قبلا یک کاربر با این نشانی رایانامه داریم. آیا قبلا نام‌نویسی کرده‌اید و فقط نیاز به ورود دارید؟"
+
+#: pretalx/person/forms.py:265
+msgid "Please provide a profile picture or allow us to load your picture from gravatar!"
+msgstr "لطفاً یک تصویر نمایه ارائه دهید یا به ما اجازه دهید تصویر شما را از gravatar بارگذاری کنیم!"
+
+#: pretalx/person/forms.py:316
+msgid "The current password you entered was not correct."
+msgstr "گذرواژه فعلی که وارد کردید صحیح نیست."
+
+#: pretalx/person/forms.py:320
+msgid "Password (current)"
+msgstr "گذرواژه (فعلی)"
+
+#: pretalx/person/forms.py:408 pretalx/person/forms.py:444
+msgid "Non-accepted submitters"
+msgstr "ارسال‌کنندگان غیرپذیرفته‌شده"
+
+#: pretalx/person/models/information.py:28
+msgid "All accepted speakers"
+msgstr "تمام سخنرانان پذیرفته‌شده"
+
+#: pretalx/person/models/information.py:29
+msgid "Only confirmed speakers"
+msgstr "فقط سخنرانان تأییدشده"
+
+#: pretalx/person/models/information.py:38
+msgid "Leave empty to show this information to all tracks."
+msgstr "برای نمایش این اطلاعات به تمام مسیرها، این قسمت را خالی بگذارید."
+
+#: pretalx/person/models/information.py:42
+msgid "Limit to proposal types"
+msgstr "محدود کردن به انواع پیشنهادات"
+
+#: pretalx/person/models/information.py:44
+msgid "Leave empty to show this information for all proposal types."
+msgstr "برای نمایش این اطلاعات برای تمام انواع طرح‌های پیشنهادی، این قسمت را خالی بگذارید."
+
+#: pretalx/person/models/information.py:54
+msgid "Please try to keep your upload small, preferably below 16 MB."
+msgstr "لطفا سعی کنید حجم بارگذاری خود را کوچک نگه دارید، ترجیحاً کمتر از ۱۶ مگابایت."
+
+#: pretalx/person/models/profile.py:37
+msgid "The speaker has arrived"
+msgstr "سخنران رسیده است."
+
+#: pretalx/person/models/user.py:86
+msgid "Please enter the name you wish to be displayed publicly. This name will be used for all events you are participating in on this server."
+msgstr "لطفا نامی را وارد کنید که می‌خواهید به‌صورت عمومی نمایش داده شود. این نام برای تمام رویدادهایی که در این سرور شرکت می‌کنید استفاده خواهد شد."
+
+#: pretalx/person/models/user.py:93
+msgid "Your email address will be used for password resets and notification about your event/proposals."
+msgstr "نشانی رایانامه شما برای بازنشانی گذرواژه و اطلاع‌رسانی درباره رویدادها/طرح‌های پیشنهادی شما استفاده خواهد شد."
+
+#: pretalx/person/models/user.py:114
+msgid "Preferred language"
+msgstr "زبان ترجیحی"
+
+#: pretalx/person/models/user.py:126
+msgid "We recommend uploading an image at least 400px wide. A square image works best, as we display it in a circle in several places."
+msgstr "ما توصیه می‌کنیم تصویری با عرض حداقل ۴۰۰ پیکسل بارگذاری کنید. یک تصویر مربعی بهترین کارایی را دارد، زیرا در چندین مکان به شکل دایره نمایش داده می‌شود."
+
+#: pretalx/person/models/user.py:137
+msgid "Retrieve profile picture via gravatar"
+msgstr "بازیابی تصویر نمایه از طریق gravatar"
+
+#: pretalx/person/models/user.py:139
+msgid "If you have registered with an email address that has a gravatar account, we can retrieve your profile picture from there."
+msgstr "اگر با نشانی رایانامه که حساب gravatar دارد نام‌نویسی کرده باشید، می‌توانیم تصویر نمایه شما را از آنجا بازیابی کنیم."
+
+#: pretalx/person/models/user.py:145
+msgid "Profile Picture Source"
+msgstr "منبع تصویر نمایه"
+
+#: pretalx/person/models/user.py:147
+msgid "Please enter the name of the author or source of image and a link if applicable."
+msgstr "لطفا نام نویسنده یا منبع تصویر و در صورت امکان پیوند آن را وارد کنید."
+
+#: pretalx/person/models/user.py:153
+msgid "Profile Picture License"
+msgstr "مجوز تصویر نمایه"
+
+#: pretalx/person/models/user.py:155
+msgid "Please enter the name of the license of the photo and link to it if applicable."
+msgstr "لطفا نام مجوز عکس و در صورت امکان پیوند آن را وارد کنید."
+
+#: pretalx/person/models/user.py:166
+msgid "Unnamed user"
+msgstr "کاربر بدون نام"
+
+#: pretalx/person/models/user.py:454
+#, python-brace-format
+msgid ""
+"Hi {name},\n"
+"\n"
+"you have requested a new password for your pretalx account.\n"
+"To reset your password, click on the following link:\n"
+"\n"
+"  {url}\n"
+"\n"
+"If this wasn’t you, you can just ignore this email.\n"
+"\n"
+"All the best,\n"
+"the pretalx robot"
+msgstr ""
+"سلام {name},\n"
+"\n"
+"شما درخواست یک گذرواژه جدید برای حساب pretalx خود داده‌اید.\n"
+"برای بازنشانی گذرواژه خود، روی پیوند زیر کلیک کنید:\n"
+"\n"
+"  {url}\n"
+"\n"
+"اگر شما نبودید، می‌توانید این رایانامه را نادیده بگیرید.\n"
+"\n"
+"با آرزوی بهترین‌ها،\n"
+"ربات pretalx"
+
+#: pretalx/person/models/user.py:469
+msgid "Password recovery"
+msgstr "بازیابی گذرواژه"
+
+#: pretalx/person/models/user.py:493
+#, python-brace-format
+msgid ""
+"Hi {name},\n"
+"\n"
+"Your pretalx account password was just changed.\n"
+"\n"
+"If you did not change your password, please contact the site administration immediately.\n"
+"\n"
+"All the best,\n"
+"the pretalx team"
+msgstr ""
+"سلام {name},\n"
+"\n"
+"گذرواژه حساب pretalx شما به‌تازگی تغییر کرده است.\n"
+"\n"
+"اگر شما گذرواژه خود را تغییر نداده‌اید، لطفا فوراً با مدیریت سایت تماس بگیرید.\n"
+"\n"
+"با آرزوی بهترین‌ها،\n"
+"تیم pretalx"
+
+#: pretalx/person/models/user.py:505
+msgid "[pretalx] Password changed"
+msgstr "[pretalx] تغییر گذرواژه"
+
+#: pretalx/schedule/ascii.py:24
+msgid "No speakers"
+msgstr "هیچ سخنرانی وجود ندارد"
+
+#: pretalx/schedule/exporters.py:373
+msgid "iCal (full event)"
+msgstr "iCal (کل رویداد)"
+
+#: pretalx/schedule/exporters.py:414
+msgid "iCal (your starred sessions)"
+msgstr "iCal (جلسات نشانه‌دار شما)"
+
+#: pretalx/schedule/forms.py:21
+msgid "Please click and drag to mark your availability during the conference with green blocks. We will try to schedule your slot during these times. You can click a block twice to remove it."
+msgstr "لطفاً کلیک کنید و بکشید تا دسترسی خود را در طول کنفرانس با بلوک‌های سبز مشخص کنید. ما سعی خواهیم کرد که فاصله شما را در این زمان‌ها برنامه‌ریزی کنیم. می‌توانید یک بلوک را دوبار کلیک کنید تا آن را حذف کنید."
+
+#: pretalx/schedule/forms.py:80
+#, python-brace-format
+msgid "Please note that all times are in the event timezone, {tz}."
+msgstr "لطفاً توجه داشته باشید که تمام زمان‌ها در منطقه زمانی رویداد، {tz} است."
+
+#: pretalx/schedule/forms.py:85
+msgid "If you set room availabilities, speakers will only be able to set their availability for when any room is available."
+msgstr "اگر دسترسی‌های اتاق‌ها را تنظیم کنید، سخنرانان فقط می‌توانند دسترسی خود را برای زمان‌هایی که هر اتاقی موجود است تنظیم کنند."
+
+#: pretalx/schedule/forms.py:118
+msgid "The submitted availability does not comply with the required format."
+msgstr "دسترسی ارسالی با فرمت مورد نیاز مطابقت ندارد."
+
+#: pretalx/schedule/forms.py:134
+msgid "The submitted availability contains an invalid date."
+msgstr "دسترسی ارسالی شامل یک تاریخ نامعتبر است."
+
+#: pretalx/schedule/forms.py:156
+msgid "Please fill in your availability!"
+msgstr "لطفاً دسترسی خود را پر کنید!"
+
+#: pretalx/schedule/forms.py:212
+msgid "Room I"
+msgstr "اتاق I"
+
+#: pretalx/schedule/forms.py:214
+msgid "Description, e.g.: Our main meeting place, Room I, enter from the right."
+msgstr "توضیحات، مثلاً: محل اصلی جلسه ما، اتاق I، ورود از سمت راست."
+
+#: pretalx/schedule/forms.py:217
+msgid "Information for speakers, e.g.: Projector has only HDMI input."
+msgstr "اطلاعات برای سخنرانان، مثلاً: پروژکتور فقط ورودی HDMI دارد."
+
+#: pretalx/schedule/forms.py:222
+#, python-brace-format
+msgid "The current, automatically generated GUID is: {guid}."
+msgstr "GUID فعلی که به‌صورت خودکار ایجاد شده است: {guid}."
+
+#: pretalx/schedule/models/room.py:28
+msgid "GUID"
+msgstr "شناسه GUID"
+
+#: pretalx/schedule/models/room.py:30
+msgid "Unique identifier (UUID) to help external tools identify the room."
+msgstr "شناسه منحصربه‌فرد (UUID) برای کمک به ابزارهای خارجی در شناسایی اتاق."
+
+#: pretalx/schedule/models/room.py:38
+msgid "A description for attendees, for example directions."
+msgstr "توضیحی برای شرکت‌کنندگان، به‌عنوان مثال مسیرها."
+
+#: pretalx/schedule/models/room.py:46
+msgid "Information relevant for speakers scheduled in this room, for example room size, special directions, available adaptors for video input …"
+msgstr "اطلاعات مرتبط برای سخنرانانی که در این اتاق برنامه‌ریزی شده‌اند، مثلاً اندازه اتاق، مسیرهای خاص، آداپتورهای موجود برای ورودی ویدئو …"
+
+#: pretalx/schedule/models/room.py:53
+msgid "How many people can fit in the room?"
+msgstr "چند نفر در این اتاق جا می‌شوند؟"
+
+#: pretalx/schedule/models/schedule.py:40 pretalx/schedule/phrases.py:8
+msgctxt "Version of the conference schedule"
+msgid "Version"
+msgstr "نسخه"
+
+#: pretalx/schedule/models/schedule.py:46
+msgid "This text will be shown in the public changelog and the RSS feed."
+msgstr "این متن در فهرست تغییرات عمومی و خوراک RSS نمایش داده خواهد شد."
+
+#: pretalx/schedule/models/schedule.py:375
+#, python-brace-format
+msgid "Room {room_name} is not available at the scheduled time."
+msgstr "اتاق {room_name} در زمان برنامه‌ریزی‌شده موجود نیست."
+
+#: pretalx/schedule/models/schedule.py:399
+msgid "Another session in the same room overlaps with this one."
+msgstr "جلسه دیگری در همان اتاق با این جلسه هم‌پوشانی دارد."
+
+#: pretalx/schedule/models/schedule.py:431
+#, python-brace-format
+msgid "{speaker} is not available at the scheduled time."
+msgstr "{speaker} در زمان برنامه‌ریزی‌شده در دسترس نیست."
+
+#: pretalx/schedule/models/schedule.py:459
+#, python-brace-format
+msgid "{speaker} is scheduled for another session at the same time."
+msgstr "{speaker} برای جلسه دیگری در همان زمان برنامه‌ریزی شده است."
+
+#: pretalx/schedule/models/slot.py:45
+msgid "The room this talk is scheduled in, if any"
+msgstr "اتاقی که این صحبت در آن برنامه‌ریزی شده است، در صورت وجود"
+
+#: pretalx/schedule/models/slot.py:55
+msgid "Start"
+msgstr "شروع"
+
+#: pretalx/schedule/models/slot.py:56
+msgid "When the talk starts, if it is currently scheduled"
+msgstr "زمان شروع صحبت، اگر در حال حاضر برنامه‌ریزی شده باشد"
+
+#: pretalx/schedule/models/slot.py:60
+msgid "End"
+msgstr "پایان"
+
+#: pretalx/schedule/models/slot.py:61
+msgid "When the talk ends, if it is currently scheduled"
+msgstr "زمان پایان صحبت، اگر در حال حاضر برنامه‌ریزی شده باشد"
+
+#: pretalx/schedule/phrases.py:9
+msgctxt "Schedule/program of the conference"
+msgid "Schedule"
+msgstr "برنامه زمان‌بندی"
+
+#: pretalx/schedule/phrases.py:13
+msgid "Sessions"
+msgstr "جلسات"
+
+#: pretalx/schedule/phrases.py:20
+msgid "We released our first schedule!"
+msgstr "ما اولین برنامه خود را منتشر کردیم!"
+
+#: pretalx/schedule/phrases.py:22
+msgid "You are currently viewing the editable schedule version, which is unreleased and may change at any time."
+msgstr "شما در حال مشاهده نسخه قابل ویرایش برنامه زمان‌بندی هستید که هنوز منتشر نشده و ممکن است در هر زمانی تغییر کند."
+
+#: pretalx/schedule/phrases.py:24
+msgid "You are currently viewing an older schedule version."
+msgstr "شما در حال مشاهده نسخه قدیمی‌تری از برنامه زمان‌بندی هستید."
+
+#: pretalx/schedule/phrases.py:26
+#, python-format
+msgid "You can find the current version <a href=\"%(current_url)s\">here</a>."
+msgstr "شما می‌توانید نسخه فعلی را <a href=\"%(current_url)s\">اینجا</a> پیدا کنید."
+
+#: pretalx/schedule/phrases.py:30
+#, python-format
+msgid "All times in %(tz)s"
+msgstr "تمام زمان‌ها در منطقه زمانی %(tz)s است."
+
+#: pretalx/schedule/phrases.py:32
+msgid "There has been no feedback for this session yet."
+msgstr "هنوز هیچ بازخوردی برای این جلسه وجود ندارد."
+
+#: pretalx/schedule/templates/schedule/speaker_notification.txt:2
+#, python-format
+msgid "- Your session “%(title)s” will take place at %(start)s in %(location)s"
+msgstr "- جلسه شما «%(title)s» در %(start)s در %(location)s برگزار خواهد شد."
+
+#: pretalx/schedule/templates/schedule/speaker_notification.txt:3
+#, python-format
+msgid "- Your session “%(title)s” has been moved to %(start)s in %(location)s"
+msgstr "- جلسه شما «%(title)s» به %(start)s در %(location)s منتقل شده است."
+
+#: pretalx/settings.py:358
+msgid "English"
+msgstr "انگلیسی"
+
+#: pretalx/settings.py:364
+msgid "German"
+msgstr "آلمانی"
+
+#: pretalx/settings.py:371
+msgid "German (formal)"
+msgstr "آلمانی (رسمی)"
+
+#: pretalx/settings.py:379
+msgid "Arabic"
+msgstr "عربی"
+
+#: pretalx/settings.py:385
+msgid "Czech"
+msgstr "چکی"
+
+#: pretalx/settings.py:391
+msgid "Greek"
+msgstr "یونانی"
+
+#: pretalx/settings.py:397
+msgid "Spanish"
+msgstr "اسپانیایی"
+
+#: pretalx/settings.py:403
+msgid "French"
+msgstr "فرانسوی"
+
+#: pretalx/settings.py:410
+msgid "Italian"
+msgstr "ایتالیایی"
+
+#: pretalx/settings.py:416
+msgid "Japanese"
+msgstr "ژاپنی"
+
+#: pretalx/settings.py:423
+msgid "Dutch"
+msgstr "هلندی"
+
+#: pretalx/settings.py:429
+msgid "Brasilian Portuguese"
+msgstr "پرتغالی برزیلی"
+
+#: pretalx/settings.py:436
+msgid "Portuguese"
+msgstr "پرتغالی"
+
+#: pretalx/settings.py:443
+msgid "Russian"
+msgstr "روسی"
+
+#: pretalx/settings.py:449
+msgid "Swahili"
+msgstr "سواحیلی"
+
+#: pretalx/settings.py:455
+msgid "Ukrainian"
+msgstr "اوکراینی"
+
+#: pretalx/settings.py:461
+msgid "Traditional Chinese (Taiwan)"
+msgstr "چینی سنتی (تایوان)"
+
+#: pretalx/settings.py:468
+msgid "Simplified Chinese"
+msgstr "چینی ساده‌شده"
+
+#: pretalx/submission/exporters.py:18
+msgid "Answered speaker questions"
+msgstr "سوالات پاسخ‌داده‌شده سخنران"
+
+#: pretalx/submission/exporters.py:63
+msgid "Answered session questions"
+msgstr "سوالات پاسخ‌داده‌شده جلسه"
+
+#: pretalx/submission/forms/feedback.py:17
+msgid "All speakers"
+msgstr "تمام سخنرانان"
+
+#: pretalx/submission/forms/resource.py:29
+msgid "Please either provide a link or upload a file, you cannot do both!"
+msgstr "لطفا یا یک پیوند ارائه دهید یا یک پرونده بارگذاری کنید، نمی‌توانید هر دو را انجام دهید!"
+
+#: pretalx/submission/forms/resource.py:32
+msgid "Please provide a link or upload a file!"
+msgstr "لطفا یک پیوند ارائه دهید یا یک پرونده بارگذاری کنید!"
+
+#: pretalx/submission/forms/submission.py:31
+msgid "Additional Speaker"
+msgstr "سخنران اضافی"
+
+#: pretalx/submission/forms/submission.py:33
+msgid "If you have a co-speaker, please add their email address here, and we will invite them to create an account. If you have more than one co-speaker, you can add more speakers after finishing the proposal process."
+msgstr "اگر هم‌ سخنرانی دارید، لطفا نشانی رایانامه آن‌ها را اینجا وارد کنید، و ما آن‌ها را دعوت می‌کنیم تا یک حساب کاربری ایجاد کنند. اگر بیش از یک هم‌سخنران دارید، می‌توانید بعد از تکمیل فرآیند پیشنهاد، سخنرانان بیشتری اضافه کنید."
+
+#: pretalx/submission/forms/submission.py:40 pretalx/submission/models/submission.py:236
+msgid "Use this if you want an illustration to go with your proposal."
+msgstr "اگر می‌خواهید یک تصویر همراه با پیشنهادتان باشد، از این استفاده کنید."
+
+#: pretalx/submission/forms/submission.py:173
+msgid "Please contact the organisers if you want to change how often you’re presenting this proposal."
+msgstr "لطفاً اگر می‌خواهید تغییر دهید که چند بار این پیشنهاد را ارائه می‌دهید، با برگزارکنندگان تماس بگیرید."
+
+#: pretalx/submission/forms/submission.py:245
+msgid "Proposal states"
+msgstr "وضعیت‌های پیشنهاد"
+
+#: pretalx/submission/forms/submission.py:255
+msgid "exclude pending"
+msgstr "منتظر را مستثنی کنید"
+
+#: pretalx/submission/forms/submission.py:381
+#, python-brace-format
+msgid "Pending {state}"
+msgstr "در انتظار {state}"
+
+#: pretalx/submission/forms/tag.py:21
+msgid "You already have a tag by this name!"
+msgstr "شما قبلاً یک برچسب با این نام دارید!"
+
+#: pretalx/submission/models/access_code.py:30
+msgid "You can restrict the access code to a single track, or leave it open for all tracks."
+msgstr "می‌توانید کد دسترسی را به یک مسیر محدود کنید، یا آن را برای تمام مسیرها باز بگذارید."
+
+#: pretalx/submission/models/access_code.py:39
+msgid "Session Type"
+msgstr "نوع جلسه"
+
+#: pretalx/submission/models/access_code.py:41
+msgid "You can restrict the access code to a single session type, or leave it open for all session types."
+msgstr "می‌توانید کد دسترسی را به یک نوع جلسه محدود کنید، یا آن را برای تمام انواع جلسات باز بگذارید."
+
+#: pretalx/submission/models/access_code.py:48
+msgid "Valid until"
+msgstr "معتبر تا"
+
+#: pretalx/submission/models/access_code.py:50
+msgid "You can set or change this date later to invalidate the access code."
+msgstr "می‌توانید این تاریخ را بعداً تنظیم یا تغییر دهید تا کد دسترسی را نامعتبر کنید."
+
+#: pretalx/submission/models/access_code.py:56
+msgid "Maximum uses"
+msgstr "حداکثر استفاده‌ها"
+
+#: pretalx/submission/models/access_code.py:58
+msgid "Numbers of times this access code can be used to submit a proposal. Leave empty for no limit."
+msgstr "تعداد دفعاتی که این کد دسترسی می‌تواند برای ارسال یک طرح پیشنهادی استفاده شود. برای بدون محدودیت، خالی بگذارید."
+
+#: pretalx/submission/models/cfp.py:91
+msgid "headline"
+msgstr "تیتر"
+
+#: pretalx/submission/models/cfp.py:96
+msgid "text"
+msgstr "متن"
+
+#: pretalx/submission/models/cfp.py:103
+msgid "Default session type"
+msgstr "نوع جلسه پیش‌فرض"
+
+#: pretalx/submission/models/cfp.py:110
+msgid "Please put in the last date you want to accept proposals from users."
+msgstr "لطفاً آخرین تاریخی را که می‌خواهید طرح‌های پیشنهادی را از کاربران بپذیرید وارد کنید."
+
+#: pretalx/submission/models/feedback.py:34
+msgid "Rating"
+msgstr "امتیازدهی"
+
+#: pretalx/submission/models/question.py:48
+msgid "Number"
+msgstr "عدد"
+
+#: pretalx/submission/models/question.py:49
+msgid "Text (one-line)"
+msgstr "متن (تک خطی)"
+
+#: pretalx/submission/models/question.py:50
+msgid "Multi-line text"
+msgstr "متن چندخطی"
+
+#: pretalx/submission/models/question.py:51 pretalx/submission/models/resource.py:31
+msgid "URL"
+msgstr "نشانی اینترنتی"
+
+#: pretalx/submission/models/question.py:52
+msgid "Date"
+msgstr "تاریخ"
+
+#: pretalx/submission/models/question.py:53
+msgid "Date and time"
+msgstr "تاریخ و زمان"
+
+#: pretalx/submission/models/question.py:54
+msgid "Yes/No"
+msgstr "بله/خیر"
+
+#: pretalx/submission/models/question.py:55
+msgid "File upload"
+msgstr "بارگذاری پرونده"
+
+#: pretalx/submission/models/question.py:56
+msgid "Choose one from a list"
+msgstr "انتخاب یکی از فهرست"
+
+#: pretalx/submission/models/question.py:57
+msgid "Choose multiple from a list"
+msgstr "انتخاب چند گزینه از فهرست"
+
+#: pretalx/submission/models/question.py:67
+msgid "per proposal"
+msgstr "برای هر طرح پیشنهادی"
+
+#: pretalx/submission/models/question.py:68
+msgid "per speaker"
+msgstr "برای هر سخنران"
+
+#: pretalx/submission/models/question.py:69
+msgid "for reviewers"
+msgstr "برای بازبین‌ها"
+
+#: pretalx/submission/models/question.py:79
+msgid "always optional"
+msgstr "همیشه اختیاری"
+
+#: pretalx/submission/models/question.py:80
+msgid "always required"
+msgstr "همیشه اجباری"
+
+#: pretalx/submission/models/question.py:81
+msgid "required after a deadline"
+msgstr "اجباری پس از یک مهلت مقرر"
+
+#: pretalx/submission/models/question.py:125
+msgid "question type"
+msgstr "نوع سوال"
+
+#: pretalx/submission/models/question.py:127
+msgid "Do you require an answer from every speaker or for every session?"
+msgstr "آیا به پاسخ از هر سخنران یا برای هر جلسه نیاز دارید؟"
+
+#: pretalx/submission/models/question.py:135
+msgid "Set a deadline to make this question required after the given date."
+msgstr "مهلتی تنظیم کنید تا این سوال پس از تاریخ معین الزامی شود."
+
+#: pretalx/submission/models/question.py:141
+msgid "freeze after"
+msgstr "قفل پس از"
+
+#: pretalx/submission/models/question.py:142
+msgid "Set a deadline to stop changes to answers after the given date."
+msgstr "مهلتی تنظیم کنید تا پس از تاریخ معین تغییرات به پاسخ‌ها متوقف شود."
+
+#: pretalx/submission/models/question.py:148
+msgid "question required"
+msgstr "سوال الزامی"
+
+#: pretalx/submission/models/question.py:154
+msgid "You can limit this question to some tracks. Leave this field empty to apply to all tracks."
+msgstr "می‌توانید این سوال را به برخی مسیرها محدود کنید. برای اعمال به تمام مسیرها این فیلد را خالی بگذارید."
+
+#: pretalx/submission/models/question.py:163
+msgid "You can limit this question to some session types. Leave this field empty to apply to all session types."
+msgstr "می‌توانید این سوال را به برخی انواع جلسات محدود کنید. برای اعمال به تمام انواع جلسات این فیلد را خالی بگذارید."
+
+#: pretalx/submission/models/question.py:165
+msgid "Session Types"
+msgstr "انواع جلسات"
+
+#: pretalx/submission/models/question.py:168
+msgid "question"
+msgstr "سوال"
+
+#: pretalx/submission/models/question.py:173
+msgid "help text"
+msgstr "متن راهنما"
+
+#: pretalx/submission/models/question.py:174
+msgid "Will appear just like this text below the question input field."
+msgstr "این متن دقیقاً زیر فیلد ورودی سوال ظاهر خواهد شد."
+
+#: pretalx/submission/models/question.py:179
+msgid "default answer"
+msgstr "پاسخ پیش‌فرض"
+
+#: pretalx/submission/models/question.py:185
+msgid "Inactive questions will no longer be asked."
+msgstr "سوالات غیرفعال دیگر پرسیده نخواهند شد."
+
+#: pretalx/submission/models/question.py:189
+msgid "Answers contain personal data"
+msgstr "پاسخ‌ها شامل داده‌های شخصی هستند."
+
+#: pretalx/submission/models/question.py:191
+msgid "If a user deletes their account, answers of questions for personal data will be removed, too."
+msgstr "اگر کاربری حساب خود را حذف کند، پاسخ‌های سوالات مربوط به داده‌های شخصی نیز حذف خواهند شد."
+
+#: pretalx/submission/models/question.py:197
+msgid "Minimum text length"
+msgstr "حداقل طول متن"
+
+#: pretalx/submission/models/question.py:199
+msgid "Minimum allowed text in characters or words (set in CfP settings)."
+msgstr "حداقل متن مجاز به نویسه‌ها یا کلمات (در تنظیمات فراخوان برای طرح پیشنهادی تنظیم شده است)."
+
+#: pretalx/submission/models/question.py:205
+msgid "Maximum text length"
+msgstr "حداکثر طول متن"
+
+#: pretalx/submission/models/question.py:207
+msgid "Maximum allowed text length in characters or words (set in CfP settings)."
+msgstr "حداکثر طول متن مجاز به نویسه‌ها یا کلمات (در تنظیمات فراخوان برای طرح پیشنهادی تنظیم شده است)."
+
+#: pretalx/submission/models/question.py:215 pretalx/submission/models/question.py:227 pretalx/submission/models/question.py:237
+msgid "Minimum value"
+msgstr "حداقل مقدار"
+
+#: pretalx/submission/models/question.py:222 pretalx/submission/models/question.py:232 pretalx/submission/models/question.py:240
+msgid "Maximum value"
+msgstr "حداکثر مقدار"
+
+#: pretalx/submission/models/question.py:244
+msgid "Publish answers"
+msgstr "انتشار پاسخ‌ها"
+
+#: pretalx/submission/models/question.py:246
+msgid "Answers will be shown on session or speaker pages as appropriate. Please note that you cannot make a question public after the first answers have been given, to allow speakers explicit consent before publishing information."
+msgstr "پاسخ‌ها در صفحات جلسه یا سخنران به‌طور مناسب نمایش داده خواهند شد. لطفاً توجه داشته باشید که نمی‌توانید پس از ارائه پاسخ‌های اولیه، سوالی را عمومی کنید تا رضایت صریح سخنرانان برای انتشار اطلاعات داده شود."
+
+#: pretalx/submission/models/question.py:251
+msgid "Show answers to reviewers"
+msgstr "نمایش پاسخ‌ها به بازبین‌ها"
+
+#: pretalx/submission/models/question.py:253
+msgid "Should answers to this question be shown to reviewers? This is helpful if you want to collect personal information, but use anonymous reviews."
+msgstr "آیا پاسخ‌های این سوال باید به بازبین‌ها نمایش داده شود؟ این مورد مفید است اگر می‌خواهید اطلاعات شخصی جمع‌آوری کنید اما از بازبینی ناشناس استفاده کنید."
+
+#: pretalx/submission/models/review.py:24
+msgid "Leave empty to use this category for all tracks."
+msgstr "این قسمت را خالی بگذارید تا از این دسته برای تمام مسیرها استفاده شود."
+
+#: pretalx/submission/models/review.py:28
+msgid "Independent score"
+msgstr "امتیاز مستقل"
+
+#: pretalx/submission/models/review.py:30
+msgid "Independent scores are not part of the total score. Instead they are shown in a separate column in the review dashboard."
+msgstr "امتیازات مستقل بخشی از امتیاز کلی نیستند. در عوض، در یک ستون جداگانه در پیشخوان بازبینی نمایش داده می‌شوند."
+
+#: pretalx/submission/models/review.py:50
+msgid "You need to keep at least one non-independent score category!"
+msgstr "شما باید حداقل یک دسته امتیاز غیرمستقل را نگه دارید!"
+
+#: pretalx/submission/models/review.py:131
+msgid "What do you think?"
+msgstr "نظر شما چیست؟"
+
+#: pretalx/submission/models/review.py:265
+msgid "Phase start"
+msgstr "شروع فاز"
+
+#: pretalx/submission/models/review.py:266
+msgid "Phase end"
+msgstr "پایان فاز"
+
+#: pretalx/submission/models/review.py:271
+msgid "Reviewers can write and edit reviews"
+msgstr "بازبین‌ها می‌توانند بازبینی‌ها را بنویسند و ویرایش کنند"
+
+#: pretalx/submission/models/review.py:275
+msgid "Reviewers may see these proposals"
+msgstr "بازبین‌ها ممکن است این طرح‌های پیشنهادی را مشاهده کنند"
+
+#: pretalx/submission/models/review.py:277
+msgid "All"
+msgstr "همه"
+
+#: pretalx/submission/models/review.py:278
+msgid "Only assigned proposals"
+msgstr "فقط طرح‌های پیشنهادی تخصیص داده شده"
+
+#: pretalx/submission/models/review.py:283
+msgid "If you select “all”, reviewers can review all proposals that their teams have access to (so either all, or specific tracks). In this mode, assigned proposals will be highlighted and will be shown first in the review workflow."
+msgstr "اگر «همه» را انتخاب کنید، بازبین‌ها می‌توانند تمام طرح‌های پیشنهادی را که تیم‌هایشان به آن‌ها دسترسی دارند (بنابراین یا همه یا مسیرهای خاص) بازبینی کنند. در این حالت، طرح‌های پیشنهادی تخصیص داده‌شده برجسته خواهند شد و ابتدا در جریان کار بازبینی نمایش داده می‌شوند."
+
+#: pretalx/submission/models/review.py:288
+msgid "Reviewers can see other reviews"
+msgstr "بازبین‌ها می‌توانند بازبینی‌های دیگر را مشاهده کنند"
+
+#: pretalx/submission/models/review.py:293
+msgid "After reviewing the proposal"
+msgstr "پس از بازبینی طرح پیشنهادی"
+
+#: pretalx/submission/models/review.py:298
+msgid "Reviewers can see speaker names"
+msgstr "بازبین‌ها می‌توانند نام سخنرانان را مشاهده کنند"
+
+#: pretalx/submission/models/review.py:302
+msgid "Reviewers can see the names of other reviewers"
+msgstr "بازبین‌ها می‌توانند نام بازبین‌های دیگر را مشاهده کنند"
+
+#: pretalx/submission/models/review.py:306
+msgid "Reviewers can accept and reject proposals"
+msgstr "بازبین‌ها می‌توانند طرح‌های پیشنهادی را بپذیرند و رد کنند"
+
+#: pretalx/submission/models/review.py:310
+msgid "Reviewers can tag proposals"
+msgstr "بازبین‌ها می‌توانند طرح‌های پیشنهادی را برچسب‌گذاری کنند"
+
+#: pretalx/submission/models/review.py:314
+msgid "Add and remove existing tags"
+msgstr "افزودن و حذف برچسب‌های موجود"
+
+#: pretalx/submission/models/review.py:315
+msgid "Add, remove and create tags"
+msgstr "افزودن، حذف و ایجاد برچسب‌ها"
+
+#: pretalx/submission/models/review.py:320
+msgid "Speakers can modify their proposals before acceptance"
+msgstr "سخنرانان می‌توانند طرح‌های پیشنهادی خود را قبل از پذیرش تغییر دهند"
+
+#: pretalx/submission/models/review.py:322
+msgid "By default, modification of proposals is locked after the CfP ends, and is re-enabled once the proposal was accepted."
+msgstr "به‌طور پیش‌فرض، تغییر طرح‌های پیشنهادی پس از پایان فراخوان برای طرح پیشنهادی قفل شده و پس از پذیرش طرح پیشنهادی مجدداً فعال می‌شود."
+
+#: pretalx/submission/models/submission.py:54 pretalx/submission/phrases.py:13
+msgctxt "proposal status"
+msgid "submitted"
+msgstr "ارسال شده"
+
+#. Translators: This string is used to mark anything that has been formally deleted,
+#. and can only be shown to organisers with extended access. It's usually placed
+#. after the title/object like [this].
+#: pretalx/submission/models/submission.py:60 pretalx/submission/phrases.py:11
+msgid "deleted"
+msgstr "حذف شده"
+
+#: pretalx/submission/models/submission.py:61
+msgid "draft"
+msgstr "پیش‌نویس"
+
+#: pretalx/submission/models/submission.py:145
+msgid "Proposal title"
+msgstr "عنوان طرح پیشنهادی"
+
+#: pretalx/submission/models/submission.py:177
+msgid "Pending proposal state"
+msgstr "وضعیت طرح پیشنهادی در انتظار"
+
+#: pretalx/submission/models/submission.py:196
+msgid "These notes are meant for the organiser and won’t be made public."
+msgstr "این یادداشت‌ها برای برگزارکننده‌گان هستند و عمومی نمی‌شوند."
+
+#: pretalx/submission/models/submission.py:202
+msgid "Internal notes"
+msgstr "یادداشت‌های داخلی"
+
+#: pretalx/submission/models/submission.py:204
+msgid "Internal notes for other organisers/reviewers. Not visible to the speakers or the public."
+msgstr "یادداشت‌های داخلی برای دیگر برگزارکننده‌گان/بازبین‌ها. برای سخنرانان یا عموم قابل مشاهده نیست."
+
+#: pretalx/submission/models/submission.py:211
+msgid "The duration in minutes."
+msgstr "مدت زمان به دقیقه."
+
+#: pretalx/submission/models/submission.py:216
+msgid "How many times this session will take place."
+msgstr "چند بار این جلسه برگزار خواهد شد."
+
+#: pretalx/submission/models/submission.py:226
+msgid "Show this session in public list of featured sessions."
+msgstr "این جلسه را در فهرست عمومی جلسات ویژه نمایش دهید."
+
+#: pretalx/submission/models/submission.py:229
+msgid "Don’t record this session."
+msgstr "این جلسه ضبط نشود."
+
+#: pretalx/submission/models/submission.py:251
+msgid "Assigned reviewers"
+msgstr "بازبین‌های اختصاص داده‌شده"
+
+#: pretalx/submission/models/submission.py:433
+msgctxt "used in talk confirm/accept/reject/...-errors, like \"... must be accepted OR foo OR bar ...\""
+msgid " or "
+msgstr " یا "
+
+#: pretalx/submission/models/submission.py:441
+#, python-brace-format
+msgid "Proposal must be {src_states} not {state} to be {new_state}."
+msgstr "طرح پیشنهادی باید {src_states} باشد و نه {state} تا {new_state} شود."
+
+#: pretalx/submission/models/submission.py:510
+msgid ""
+"Full proposal content:\n"
+"\n"
+msgstr ""
+"محتوای کامل طرح پیشنهادی:\n"
+"\n"
+
+#: pretalx/submission/models/submission.py:824
+#, python-brace-format
+msgid "{title_in_quotes} by {list_of_speakers}"
+msgstr "{title_in_quotes} توسط {list_of_speakers}"
+
+#: pretalx/submission/models/submission.py:1036
+msgid "List favourite talk"
+msgstr "فهرست صحبت موردعلاقه"
+
+#: pretalx/submission/models/tag.py:29
+msgid "Show tag publicly"
+msgstr "برچسب را به‌صورت عمومی نمایش دهید"
+
+#: pretalx/submission/models/tag.py:31
+msgid "Tags are currently only in use for organisers and reviewers. They will be visible publicly in a future release of pretalx."
+msgstr "برچسب‌ها در حال حاضر فقط برای برگزارکننده‌گان و بازبین‌ها قابل استفاده هستند. آن‌ها در نسخه آینده pretalx به‌صورت عمومی قابل مشاهده خواهند بود."
+
+#: pretalx/submission/models/track.py:41
+msgid "This track will only be shown to submitters with a matching access code."
+msgstr "این مسیر فقط به ارسال‌کنندگان با یک کد دسترسی منطبق نمایش داده خواهد شد."
+
+#: pretalx/submission/models/type.py:29
+msgid "name"
+msgstr "نام"
+
+#: pretalx/submission/models/type.py:32
+msgid "default duration"
+msgstr "مدت زمان پیش‌فرض"
+
+#: pretalx/submission/models/type.py:33
+msgid "Default duration in minutes"
+msgstr "مدت زمان پیش‌فرض به دقیقه"
+
+#: pretalx/submission/models/type.py:40
+msgid "If you want a different deadline than the global deadline for this session type, enter it here."
+msgstr "اگر می‌خواهید مهلتی متفاوت از مهلت جهانی برای این نوع جلسه داشته باشید، آن را اینجا وارد کنید."
+
+#: pretalx/submission/models/type.py:46
+msgid "This session type will only be shown to submitters with a matching access code."
+msgstr "این نوع جلسه فقط به ارسال‌کنندگان با یک کد دسترسی منطبق نمایش داده خواهد شد."
+
+#: pretalx/submission/models/type.py:62
+#, python-brace-format
+msgid "{name} ({duration} days)"
+msgstr "{name} ({duration} روز)"
+
+#: pretalx/submission/models/type.py:67
+#, python-brace-format
+msgid "{name} ({duration} hours)"
+msgstr "{name} ({duration} ساعت)"
+
+#: pretalx/submission/models/type.py:71
+#, python-brace-format
+msgid "{name} ({duration} minutes)"
+msgstr "{name} ({duration} دقیقه)"
+
+#: pretalx/submission/phrases.py:14
+msgctxt "proposal status"
+msgid "in review"
+msgstr "در حال بازبینی"
+
+#: pretalx/submission/phrases.py:15
+msgctxt "proposal status"
+msgid "not accepted"
+msgstr "پذیرفته نشده"

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -399,6 +399,14 @@ LANGUAGES_INFORMATION = {
         "official": False,
         "percentage": 80,
     },
+    "fa-ir": {
+        "name": _("Persian"),
+        "natural_name": "قارسی",
+        "official": False,
+        "percentage": 99,
+        "path": "fa_IR",
+        "public_code": "fa_IR",
+    },
     "fr": {
         "name": _("French"),
         "natural_name": "Français",
@@ -474,6 +482,7 @@ LANGUAGES_INFORMATION = {
 }
 LANGUAGES_RTL = {
     "ar",
+    "fa-ir",
 }
 
 for section in config.sections():


### PR DESCRIPTION
- Added comprehensive Persian translations for modules, including:
  - Review settings and feedback forms.
  - Speaker, session, and submission content.
  - Question types, tags, tracks, and session types.
  - Other UI elements and system messages.
- Ensured proper contextual alignment and consistency across all translations.
- Prepared translations for better localization and usability for Persian-speaking users.

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [X] I have added tests to cover my changes.
