### PR TITLE
Handle case where question is inactive.

### DIFF
--- a/src/pretalx/submission/management/commands/copy-track-from-question-answer.py
+++ b/src/pretalx/submission/management/commands/copy-track-from-question-answer.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
 
         with scope(event=event):
             # Find question with "track" in the label
-            track_question = Question.objects.get(question__icontains="track")
+            track_question = Question.all_objects.get(question__icontains="track")
         logger.info('Found question: %s', track_question)
         # Get available tracks
         with scope(event=event):


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #305 

This is the complement of #306 , because when we about to run the script on prod, the wanted `Question` object was already deactivated and the script couldn't that Question object.

## How has this been tested?

Just a minor update. Didn't test.

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
