### PR TITLE
Separate answers in talk review.

### DIFF
--- a/src/pretalx/agenda/templates/agenda/talk.html
+++ b/src/pretalx/agenda/templates/agenda/talk.html
@@ -126,12 +126,14 @@
                 {% if answers %}
                     <hr />
                     <section class="answers">
+                        <dl>
                         {% for answer in answers %}
-                            <span class="question"><strong>{{ answer.question.question }}:</strong></span>
-                            <span class="answer {% if question.variant != "text" %}answer-strip-paragraph{% endif %}">{% include "common/question_answer.html" with answer=answer %}</span>
+                            <dt class="question mt-2"><strong>{{ answer.question.question|append_colon }}</strong></dt>
+                            <dd class="answer {% if question.variant != "text" %}answer-strip-paragraph{% endif %}">{% include "common/question_answer.html" with answer=answer %}</dd>
                         {% endfor %}
+                        </dl>
+                    </section>
                 {% endif %}
-            </section>
             {% if submission.active_resources %}
                 <section class="resources">
                     {% translate "See also:" %}

--- a/src/pretalx/common/templatetags/rich_text.py
+++ b/src/pretalx/common/templatetags/rich_text.py
@@ -187,6 +187,6 @@ def append_colon(text: LazyI18nString) -> str:
     text = str(text).strip()
     if not text:
         return ""
-    if text[-1] not in [".", "!", "?", ":", ";"]:
-        return f"{text}:"
-    return text
+    if text[-1] in [".", "!", "?", ":", ";"]:
+        return text
+    return f"{text}:"

--- a/src/pretalx/common/templatetags/rich_text.py
+++ b/src/pretalx/common/templatetags/rich_text.py
@@ -7,6 +7,7 @@ from django import template
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.safestring import mark_safe
 from publicsuffixlist import PublicSuffixList
+from i18nfield.strings import LazyI18nString
 
 from pretalx.common.views.redirect import safelink as sl
 
@@ -178,3 +179,14 @@ def rich_text(text: str):
 def rich_text_without_links(text: str):
     """Process markdown and cleans HTML in a text input, but without links."""
     return render_markdown(text, cleaner=NO_LINKS_CLEANER)
+
+
+@register.filter
+def append_colon(text: LazyI18nString) -> str:
+    """Appends a colon to the given text if it doesn't end with a punctuation mark."""
+    text = str(text)
+    if not text:
+        return ""
+    if text[-1] not in [".", "!", "?", ":", ";"]:
+        return f"{text}:"
+    return text

--- a/src/pretalx/common/templatetags/rich_text.py
+++ b/src/pretalx/common/templatetags/rich_text.py
@@ -184,7 +184,7 @@ def rich_text_without_links(text: str):
 @register.filter
 def append_colon(text: LazyI18nString) -> str:
     """Appends a colon to the given text if it doesn't end with a punctuation mark."""
-    text = str(text)
+    text = str(text).strip()
     if not text:
         return ""
     if text[-1] not in [".", "!", "?", ":", ";"]:


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #314 

## How has this been tested?
![image](https://github.com/user-attachments/assets/f638effc-2ca2-4811-9901-159ddf8a6561)

Other than moving the answer to under the question, I also fix the punctuation marks at the end of question, so that, if the question already has some mark, we don't add the `?`.

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Improve the display of talk review answers by restructuring the HTML and adding a colon appending filter

Bug Fixes:
- Prevent duplicate colon addition to questions that already have punctuation marks

Enhancements:
- Modify the talk review template to use a definition list (dl/dt/dd) for better semantic markup of questions and answers
- Add a template filter to conditionally append a colon to questions that don't already end with punctuation