### PR TITLE
Reindent Django template files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ close_void_tags = false
 extend_exclude = "static,docs"
 max_blank_lines = 1
 preserve_blank_lines = 1
+indent = 2
 profile = "django"
 
 [tool.uv]

--- a/src/pretalx/agenda/templates/agenda/base.html
+++ b/src/pretalx/agenda/templates/agenda/base.html
@@ -6,58 +6,58 @@
 {% load safelink %}
 
 {% block custom_header %}
-    {% block alternate_link %}
-        <link rel="alternate" type="application/atom+xml" title="{{ request.event.name }} Schedule Versions" href="{{ request.event.urls.feed }}" />
-        <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.base.full }}" />
-    {% endblock alternate_link %}
-    {% block agenda_custom_header %}{% endblock agenda_custom_header %}
+  {% block alternate_link %}
+    <link rel="alternate" type="application/atom+xml" title="{{ request.event.name }} Schedule Versions" href="{{ request.event.urls.feed }}" />
+    <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.base.full }}" />
+  {% endblock alternate_link %}
+  {% block agenda_custom_header %}{% endblock agenda_custom_header %}
 {% endblock custom_header %}
 
 {% block nav_link %}
-    {% has_perm "agenda.view_schedule" request.user request.event as can_view_schedule %}
-    {% if can_view_schedule %}
-        {{ request.event.urls.schedule }}
-    {% else %}
-        {{ request.event.urls.base }}
-    {% endif %}
+  {% has_perm "agenda.view_schedule" request.user request.event as can_view_schedule %}
+  {% if can_view_schedule %}
+    {{ request.event.urls.schedule }}
+  {% else %}
+    {{ request.event.urls.base }}
+  {% endif %}
 {% endblock nav_link %}
 {% block header_tabs %}
-    <a href="{{ request.event.urls.schedule }}" class='header-tab {% if "/schedule/" in request.path_info %}active{% endif %}'>
-        <i class="fa fa-calendar"></i> {{ phrases.schedule.schedule }}
+  <a href="{{ request.event.urls.schedule }}" class='header-tab {% if "/schedule/" in request.path_info %}active{% endif %}'>
+    <i class="fa fa-calendar"></i> {{ phrases.schedule.schedule }}
+  </a>
+  {% if request.event.display_settings.schedule_display != "list" %}
+    <a href="{{ request.event.urls.talks }}" class='header-tab {% if "/talk/" in request.path_info %} active{% endif %}'>
+      <i class="fa fa-comments-o"></i> {{ phrases.schedule.sessions }}
     </a>
-    {% if request.event.display_settings.schedule_display != "list" %}
-        <a href="{{ request.event.urls.talks }}" class='header-tab {% if "/talk/" in request.path_info %} active{% endif %}'>
-            <i class="fa fa-comments-o"></i> {{ phrases.schedule.sessions }}
-        </a>
-    {% endif %}
-    <a href="{{ request.event.urls.speakers }}" class='header-tab {% if "/speaker/" in request.path_info %} active{% endif %}'>
-        <i class="fa fa-group"></i> {{ phrases.schedule.speakers }}
+  {% endif %}
+  <a href="{{ request.event.urls.speakers }}" class='header-tab {% if "/speaker/" in request.path_info %} active{% endif %}'>
+    <i class="fa fa-group"></i> {{ phrases.schedule.speakers }}
+  </a>
+  {% for link in header_links %}
+    <a href="{% safelink link.url %}" target="_blank" rel="noopener" class="header-tab">
+      <i class="fa fa-link"></i> {{ link.label }}
     </a>
-    {% for link in header_links %}
-        <a href="{% safelink link.url %}" target="_blank" rel="noopener" class="header-tab">
-            <i class="fa fa-link"></i> {{ link.label }}
-        </a>
-    {% endfor %}
-    {% if request.event.display_settings.ticket_link %}
-        <a href="{{ request.event.display_settings.ticket_link }}" class="header-tab">
-            <i class="fa fa-ticket"></i> {% translate "Tickets" %}
-        </a>
-    {% endif %}
+  {% endfor %}
+  {% if request.event.display_settings.ticket_link %}
+    <a href="{{ request.event.display_settings.ticket_link }}" class="header-tab">
+      <i class="fa fa-ticket"></i> {% translate "Tickets" %}
+    </a>
+  {% endif %}
 
-    <a id="join-event-link" href='{% url "agenda:event.onlinevideo.join" event=request.event.slug %}' class="header-tab">
-        <i class="fa fa-video-camera"></i> {% translate "Videos" %}
-    </a>
+  <a id="join-event-link" href='{% url "agenda:event.onlinevideo.join" event=request.event.slug %}' class="header-tab">
+    <i class="fa fa-video-camera"></i> {% translate "Videos" %}
+  </a>
 {% endblock header_tabs %}
 
 {% block content %}
-    {% include "agenda/header_row.html" %}
-    {% if not request.event|get_feature_flag:"show_schedule" and not request.user.is_anonymous and not hide_visibility_warning %}
-        <div id="event-nonpublic" class="d-print-none">
-            <i class="fa fa-user-secret"></i>
-            {% blocktranslate trimmed %}
-                This schedule-related page is non-public. Only organisers can see it.
-            {% endblocktranslate %}
-        </div>
-    {% endif %}
-    {% block agenda_content %}{% endblock agenda_content %}
+  {% include "agenda/header_row.html" %}
+  {% if not request.event|get_feature_flag:"show_schedule" and not request.user.is_anonymous and not hide_visibility_warning %}
+    <div id="event-nonpublic" class="d-print-none">
+      <i class="fa fa-user-secret"></i>
+      {% blocktranslate trimmed %}
+        This schedule-related page is non-public. Only organisers can see it.
+      {% endblocktranslate %}
+    </div>
+  {% endif %}
+  {% block agenda_content %}{% endblock agenda_content %}
 {% endblock content %}

--- a/src/pretalx/agenda/templates/agenda/changelog.html
+++ b/src/pretalx/agenda/templates/agenda/changelog.html
@@ -3,21 +3,21 @@
 {% load i18n %}
 
 {% block agenda_content %}
-    <article>
-        {% for schedule in request.event.schedules.all %}
-            {% if schedule.version %}
-                <section>
-                    <h4 id="{{ schedule.version }}">
-                        <a href="{% url "agenda:versioned-schedule" event=request.event.slug version=schedule.version %}">
-                            {{ phrases.schedule.version }} {{ schedule.version }}
-                            <small class="text-muted">{{ schedule.published|date }}</small>
-                        </a>
-                    </h4>
+  <article>
+    {% for schedule in request.event.schedules.all %}
+      {% if schedule.version %}
+        <section>
+          <h4 id="{{ schedule.version }}">
+            <a href="{% url "agenda:versioned-schedule" event=request.event.slug version=schedule.version %}">
+              {{ phrases.schedule.version }} {{ schedule.version }}
+              <small class="text-muted">{{ schedule.published|date }}</small>
+            </a>
+          </h4>
 
-                    {% include "agenda/changelog_block.html" with schedule=schedule %}
+          {% include "agenda/changelog_block.html" with schedule=schedule %}
 
-                </section>
-            {% endif %}
-        {% endfor %}
-    </article>
+        </section>
+      {% endif %}
+    {% endfor %}
+  </article>
 {% endblock agenda_content %}

--- a/src/pretalx/agenda/templates/agenda/changelog_block.html
+++ b/src/pretalx/agenda/templates/agenda/changelog_block.html
@@ -2,82 +2,82 @@
 {% load rich_text %}
 
 {% if schedule.comment %}
-    <p>{{ schedule.comment|rich_text }}</p>
+  <p>{{ schedule.comment|rich_text }}</p>
 {% elif schedule.changes.action == "create" %}
-    <p>{{ phrases.schedule.first_schedule }}</p>
+  <p>{{ phrases.schedule.first_schedule }}</p>
 {% elif not schedule.changes.count %}
-    <p>–</p>
+  <p>–</p>
 {% endif %}
 {% if schedule.changes.count %}
-    {% if schedule.changes.new_talks|length > 0 %}
-        {% if schedule.changes.new_talks|length > 1 %}
-            <p>{% translate "We have new sessions!" %}</p>
-            <ul>
-                {% for talk in schedule.changes.new_talks %}
-                    <li>
-                        <a href="{{ talk.submission.urls.public }}">{{ talk.submission.display_title_with_speakers }}</a>
-                    </li>
-                {% endfor %}
-            </ul>
-        {% else %}
-            <p>
-                {% translate "We have a new session: " %}
-                {% for talk in schedule.changes.new_talks %}
-                    <a href="{{ talk.submission.urls.public }}">{{ talk.submission.display_title_with_speakers }}</a>.
-                {% endfor %}
-        {% endif %}
-        </p>
+  {% if schedule.changes.new_talks|length > 0 %}
+    {% if schedule.changes.new_talks|length > 1 %}
+      <p>{% translate "We have new sessions!" %}</p>
+      <ul>
+        {% for talk in schedule.changes.new_talks %}
+          <li>
+            <a href="{{ talk.submission.urls.public }}">{{ talk.submission.display_title_with_speakers }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>
+        {% translate "We have a new session: " %}
+        {% for talk in schedule.changes.new_talks %}
+          <a href="{{ talk.submission.urls.public }}">{{ talk.submission.display_title_with_speakers }}</a>.
+        {% endfor %}
     {% endif %}
+    </p>
+  {% endif %}
 
-    {% if schedule.changes.canceled_talks|length > 0 %}
-        {% if schedule.changes.canceled_talks|length > 1 %}
-            <p>{% translate "Sadly, we had to cancel sessions:" %}</p>
-            <ul>
-                {% for talk in schedule.changes.canceled_talks %}
-                    <li>{{ talk.submission.display_title_with_speakers }}</li>
-                {% endfor %}
-            </ul>
-        {% else %}
-            <p>
-                {% translate "We sadly had to cancel a session: " %}
-                {% for talk in schedule.changes.canceled_talks %}{{ talk.submission.display_title_with_speakers }}{% endfor %}
-            </p>
-        {% endif %}
+  {% if schedule.changes.canceled_talks|length > 0 %}
+    {% if schedule.changes.canceled_talks|length > 1 %}
+      <p>{% translate "Sadly, we had to cancel sessions:" %}</p>
+      <ul>
+        {% for talk in schedule.changes.canceled_talks %}
+          <li>{{ talk.submission.display_title_with_speakers }}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>
+        {% translate "We sadly had to cancel a session: " %}
+        {% for talk in schedule.changes.canceled_talks %}{{ talk.submission.display_title_with_speakers }}{% endfor %}
+      </p>
     {% endif %}
+  {% endif %}
 
-    {% if schedule.changes.moved_talks|length > 0 %}
-        {% if schedule.changes.moved_talks|length > 1 %}
-            <p>
-                {% translate "We had to move some sessions, so if you were planning on seeing them, check their new dates or locations:" %}
-            </p>
-            <ul>
-                {% for talk in schedule.changes.moved_talks %}
-                    <li>
-                        <a href="{{ talk.submission.urls.public }}">{{ talk.submission.display_title_with_speakers }}</a>
-                        {% if talk.old_room == talk.new_room %}
-                            ({{ talk.old_start }} → {{ talk.new_start }})
-                        {% elif talk.old_start == talk.new_start %}
-                            ({{ talk.old_room }} → {{ talk.new_room }})
-                        {% else %}
-                            ({{ talk.old_start }}, {{ talk.old_room }} → {{ talk.new_start }}, {{ talk.new_room }})
-                        {% endif %}
-                    </li>
-                {% endfor %}
-            </ul>
-        {% else %}
-            <p>
-                {% translate "We have moved a session around: " %}
-                {% for talk in schedule.changes.moved_talks %}
-                    <a href="{{ talk.submission.urls.public }}">{{ talk.submission.display_title_with_speakers }}</a>
-                    {% if talk.old_room == talk.new_room %}
-                        ({{ talk.old_start }} → {{ talk.new_start }})
-                    {% elif talk.old_start == talk.new_start %}
-                        ({{ talk.old_room }} → {{ talk.new_room }})
-                    {% else %}
-                        ({{ talk.old_start }}, {{ talk.old_room }} → {{ talk.new_start }}, {{ talk.new_room }}).
-                    {% endif %}
-                {% endfor %}
-            </p>
-        {% endif %}
+  {% if schedule.changes.moved_talks|length > 0 %}
+    {% if schedule.changes.moved_talks|length > 1 %}
+      <p>
+        {% translate "We had to move some sessions, so if you were planning on seeing them, check their new dates or locations:" %}
+      </p>
+      <ul>
+        {% for talk in schedule.changes.moved_talks %}
+          <li>
+            <a href="{{ talk.submission.urls.public }}">{{ talk.submission.display_title_with_speakers }}</a>
+            {% if talk.old_room == talk.new_room %}
+              ({{ talk.old_start }} → {{ talk.new_start }})
+            {% elif talk.old_start == talk.new_start %}
+              ({{ talk.old_room }} → {{ talk.new_room }})
+            {% else %}
+              ({{ talk.old_start }}, {{ talk.old_room }} → {{ talk.new_start }}, {{ talk.new_room }})
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>
+        {% translate "We have moved a session around: " %}
+        {% for talk in schedule.changes.moved_talks %}
+          <a href="{{ talk.submission.urls.public }}">{{ talk.submission.display_title_with_speakers }}</a>
+          {% if talk.old_room == talk.new_room %}
+            ({{ talk.old_start }} → {{ talk.new_start }})
+          {% elif talk.old_start == talk.new_start %}
+            ({{ talk.old_room }} → {{ talk.new_room }})
+          {% else %}
+            ({{ talk.old_start }}, {{ talk.old_room }} → {{ talk.new_start }}, {{ talk.new_room }}).
+          {% endif %}
+        {% endfor %}
+      </p>
     {% endif %}
+  {% endif %}
 {% endif %}

--- a/src/pretalx/agenda/templates/agenda/featured.html
+++ b/src/pretalx/agenda/templates/agenda/featured.html
@@ -6,41 +6,41 @@
 {% load static %}
 
 {% block agenda_content %}
-    <p>
-        {% if request.event.featured_sessions_text %}
-            {{ request.event.featured_sessions_text|rich_text }}
-        {% else %}
-            {% if talks %}
-                <b>{% translate "Welcome to our list of featured sessions!" %}</b>
-                <br>
-                <br>
-                {% blocktranslate trimmed %}
-                    We prepared a list of exciting sessions, so you can get a feel for our
-                    conference. Please keep in mind that this is not our full schedule.
-                    We will follow up with the full schedule in time, stay tuned!
-                {% endblocktranslate %}
-            {% else %}
-                {% blocktranslate trimmed %}
-                    In the near future you will see a curated list of sessions we’d like
-                    to show off here. Right now we are busy reviewing proposals.<br>
-                    Check back later!
-                {% endblocktranslate %}
-            {% endif %}
-        {% endif %}
-    </p>
-    <article id="featured-talks">
-        {% for talk in talks %}
-            <section>
-                <h3 class="talk-title">
-                    <div>{{ quotation_open }}{{ talk.title }}{{ quotation_close }}</div>
-                    <small class="text-muted">
-                        {% if talk.display_speaker_names %}{{ talk.display_speaker_names }};{% endif %}
-                        <i>{{ talk.submission_type.name }}</i>
-                    </small>
-                </h3>
-                <p>{{ talk.abstract|default:talk.description|default:""|rich_text }}</p>
-                {% if not forloop.last %}<hr>{% endif %}
-            </section>
-        {% endfor %}
-    </article>
+  <p>
+    {% if request.event.featured_sessions_text %}
+      {{ request.event.featured_sessions_text|rich_text }}
+    {% else %}
+      {% if talks %}
+        <b>{% translate "Welcome to our list of featured sessions!" %}</b>
+        <br>
+        <br>
+        {% blocktranslate trimmed %}
+          We prepared a list of exciting sessions, so you can get a feel for our
+          conference. Please keep in mind that this is not our full schedule.
+          We will follow up with the full schedule in time, stay tuned!
+        {% endblocktranslate %}
+      {% else %}
+        {% blocktranslate trimmed %}
+          In the near future you will see a curated list of sessions we’d like
+          to show off here. Right now we are busy reviewing proposals.<br>
+          Check back later!
+        {% endblocktranslate %}
+      {% endif %}
+    {% endif %}
+  </p>
+  <article id="featured-talks">
+    {% for talk in talks %}
+      <section>
+        <h3 class="talk-title">
+          <div>{{ quotation_open }}{{ talk.title }}{{ quotation_close }}</div>
+          <small class="text-muted">
+            {% if talk.display_speaker_names %}{{ talk.display_speaker_names }};{% endif %}
+            <i>{{ talk.submission_type.name }}</i>
+          </small>
+        </h3>
+        <p>{{ talk.abstract|default:talk.description|default:""|rich_text }}</p>
+        {% if not forloop.last %}<hr>{% endif %}
+      </section>
+    {% endfor %}
+  </article>
 {% endblock agenda_content %}

--- a/src/pretalx/agenda/templates/agenda/feed/description.html
+++ b/src/pretalx/agenda/templates/agenda/feed/description.html
@@ -1,15 +1,15 @@
 {% load i18n %}
 
 <p>
-    {% if obj.changes.action == "update" %}
-        {% blocktranslate trimmed with event_name=obj.event.name %}
-            A new {{ event_name }} schedule has been released!
-        {% endblocktranslate %}
-    {% else %}
-        {% blocktranslate trimmed with event_name=obj.event.name %}
-            The first {{ event_name }} schedule has been released!
-        {% endblocktranslate %}
-    {% endif %}
+  {% if obj.changes.action == "update" %}
+    {% blocktranslate trimmed with event_name=obj.event.name %}
+      A new {{ event_name }} schedule has been released!
+    {% endblocktranslate %}
+  {% else %}
+    {% blocktranslate trimmed with event_name=obj.event.name %}
+      The first {{ event_name }} schedule has been released!
+    {% endblocktranslate %}
+  {% endif %}
 </p>
 
 {% include "agenda/changelog_block.html" with schedule=obj %}

--- a/src/pretalx/agenda/templates/agenda/feedback.html
+++ b/src/pretalx/agenda/templates/agenda/feedback.html
@@ -4,28 +4,28 @@
 {% load rich_text %}
 
 {% block content %}
-    <h3 class="talk-title">
-        <a href="{{ talk.urls.public }}">
-            {% translate "Feedback" %}: {{ quotation_open }}{{ talk.title }}{{ quotation_close }}
-        </a>
-        <small class="text-muted">
-            {{ talk.slot.local_start|date:DAY_MONTH_DATE_FORMAT }}, {{ talk.slot.local_start|date:"TIME_FORMAT" }}–{{ talk.slot.end|date:"TIME_FORMAT" }}, {{ talk.slot.room.name }}
-        </small>
-    </h3>
-    <div class="talk feedback-list flex-column">
-        {% for opinion in feedback %}
-            <div class="speakers feedback-box">
-                {% if opinion.speaker and talk.speakers.count > 1 %}
-                    <div>
-                        <em>{% translate "This review is for you personally, not for all speakers in this session." %}</em>
-                    </div>
-                {% endif %}
-                <i class="fa fa-quote-left quote" aria-hidden="true"></i>
-                <div class="feedback-text">{{ opinion.review|rich_text }}</div>
-                <i class="fa fa-quote-right quote float-right" aria-hidden="true"></i>
-            </div>
-        {% empty %}
-            {{ phrases.schedule.no_feedback }}
-        {% endfor %}
-    </div>
+  <h3 class="talk-title">
+    <a href="{{ talk.urls.public }}">
+      {% translate "Feedback" %}: {{ quotation_open }}{{ talk.title }}{{ quotation_close }}
+    </a>
+    <small class="text-muted">
+      {{ talk.slot.local_start|date:DAY_MONTH_DATE_FORMAT }}, {{ talk.slot.local_start|date:"TIME_FORMAT" }}–{{ talk.slot.end|date:"TIME_FORMAT" }}, {{ talk.slot.room.name }}
+    </small>
+  </h3>
+  <div class="talk feedback-list flex-column">
+    {% for opinion in feedback %}
+      <div class="speakers feedback-box">
+        {% if opinion.speaker and talk.speakers.count > 1 %}
+          <div>
+            <em>{% translate "This review is for you personally, not for all speakers in this session." %}</em>
+          </div>
+        {% endif %}
+        <i class="fa fa-quote-left quote" aria-hidden="true"></i>
+        <div class="feedback-text">{{ opinion.review|rich_text }}</div>
+        <i class="fa fa-quote-right quote float-right" aria-hidden="true"></i>
+      </div>
+    {% empty %}
+      {{ phrases.schedule.no_feedback }}
+    {% endfor %}
+  </div>
 {% endblock content %}

--- a/src/pretalx/agenda/templates/agenda/feedback_form.html
+++ b/src/pretalx/agenda/templates/agenda/feedback_form.html
@@ -3,33 +3,33 @@
 {% load i18n %}
 
 {% block agenda_custom_header %}
-    {% include "cfp/includes/forms_header.html" %}
+  {% include "cfp/includes/forms_header.html" %}
 {% endblock %}
 
 {% block content %}
 
-    <h3 class="talk-title">
-        <a href="{{ talk.urls.public }}">{{ quotation_open }}{{ talk.title }}{{ quotation_close }}</a>
-    </h3>
-    <div class="talk row">
-        <div class="talk-content">
-            <div class="description">
-                {% blocktranslate trimmed %}
-                    Reviews are a valuable tool for speakers to improve their content and presentation.
-                    Even a short review can prove valuable to a speaker! Please
-                    take the time and communicate your feedback in a constructive way.
-                {% endblocktranslate %}
-                {{ phrases.agenda.feedback_success }}
-                {% if not talk.does_accept_feedback or not can_give_feedback %}
-                    {% translate "You can’t give feedback for this session at this time." %}
-                {% else %}
-                    <form method="post">
-                        {% csrf_token %}
-                        {{ form }}
-                        <button type="submit" class="btn-success float-right">{{ phrases.base.send }}</button>
-                    </form>
-                {% endif %}
-            </div>
-        </div>
+  <h3 class="talk-title">
+    <a href="{{ talk.urls.public }}">{{ quotation_open }}{{ talk.title }}{{ quotation_close }}</a>
+  </h3>
+  <div class="talk row">
+    <div class="talk-content">
+      <div class="description">
+        {% blocktranslate trimmed %}
+          Reviews are a valuable tool for speakers to improve their content and presentation.
+          Even a short review can prove valuable to a speaker! Please
+          take the time and communicate your feedback in a constructive way.
+        {% endblocktranslate %}
+        {{ phrases.agenda.feedback_success }}
+        {% if not talk.does_accept_feedback or not can_give_feedback %}
+          {% translate "You can’t give feedback for this session at this time." %}
+        {% else %}
+          <form method="post">
+            {% csrf_token %}
+            {{ form }}
+            <button type="submit" class="btn-success float-right">{{ phrases.base.send }}</button>
+          </form>
+        {% endif %}
+      </div>
     </div>
+  </div>
 {% endblock content %}

--- a/src/pretalx/agenda/templates/agenda/header_row.html
+++ b/src/pretalx/agenda/templates/agenda/header_row.html
@@ -3,55 +3,55 @@
 {% load compress %}
 
 {% block agenda_header_row %}
-    {% compress js %}
-        <script src="{% static "jquery/js/jquery-3.7.1.min.js" %}"></script>
-        <script src="{% static "agenda/js/join-online-event.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script src="{% static "jquery/js/jquery-3.7.1.min.js" %}"></script>
+    <script src="{% static "agenda/js/join-online-event.js" %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block agenda_content %}
-<div id="join-video-popupmodal" hidden aria-live="polite">
-  <div class="modal-card">
+  <div id="join-video-popupmodal" hidden aria-live="polite">
+    <div class="modal-card">
       <div class="modal-card-content-join">
-          <div>
-              <h3>
-                  {% trans "This is a ticketed event. If you ordered a ticket as a guest user, you don't have an account but can still access the ticket using the secret link in your ticket confirmation email. On the tickets page there is also a link to join online sessions." %}
-              </h3>
-              <h3>
-                  {% trans "As a ticket holder please also check your email for the unique link to join online sessions." %}
-              </h3>
-              <p class="text">
-                  {% trans "Can't find your ticket?" %}
-                  <a id="resend_link" class="btn-link" href='{{ request.event.display_settings.ticket_link }}resend'>
-                      {% trans "Resend the email" %}
-                  </a>
-                  {% trans "to receive it." %}
-              </p>
-              <p class="text">
-                  {% trans "Want to order a ticket?" %}
-                  <a id="ticket_link" class="btn-link" href='{{ request.event.display_settings.ticket_link }}'>
-                      {% trans "Get a ticket here" %}
-                  </a>
-              </p>
-          </div>
+        <div>
+          <h3>
+            {% trans "This is a ticketed event. If you ordered a ticket as a guest user, you don't have an account but can still access the ticket using the secret link in your ticket confirmation email. On the tickets page there is also a link to join online sessions." %}
+          </h3>
+          <h3>
+            {% trans "As a ticket holder please also check your email for the unique link to join online sessions." %}
+          </h3>
+          <p class="text">
+            {% trans "Can't find your ticket?" %}
+            <a id="resend_link" class="btn-link" href='{{ request.event.display_settings.ticket_link }}resend'>
+              {% trans "Resend the email" %}
+            </a>
+            {% trans "to receive it." %}
+          </p>
+          <p class="text">
+            {% trans "Want to order a ticket?" %}
+            <a id="ticket_link" class="btn-link" href='{{ request.event.display_settings.ticket_link }}'>
+              {% trans "Get a ticket here" %}
+            </a>
+          </p>
+        </div>
       </div>
       <div class="join-online-close">
-          <button id="join-online-close-button" class="btn-link join-online-close-button">Close</button>
+        <button id="join-online-close-button" class="btn-link join-online-close-button">Close</button>
       </div>
+    </div>
   </div>
-</div>
-<div id="join-video-popupmodal-missing-config" hidden aria-live="polite">
-  <div class="modal-card">
+  <div id="join-video-popupmodal-missing-config" hidden aria-live="polite">
+    <div class="modal-card">
       <div class="modal-card-content-join">
-          <div>
-              <h3>
-                  {% trans "Some configurations is missing for video setting, please contact organizer." %}
-              </h3>
-          </div>
+        <div>
+          <h3>
+            {% trans "Some configurations is missing for video setting, please contact organizer." %}
+          </h3>
+        </div>
       </div>
       <div class="join-online-close">
-          <button id="join-online-close-button-missing-config" class="btn btn-default join-online-close-button">Close</button>
+        <button id="join-online-close-button-missing-config" class="btn btn-default join-online-close-button">Close</button>
       </div>
+    </div>
   </div>
-</div>
 {% endblock %}

--- a/src/pretalx/agenda/templates/agenda/includes/submission_resource.html
+++ b/src/pretalx/agenda/templates/agenda/includes/submission_resource.html
@@ -1,7 +1,7 @@
 {% load filesize %}
 
 <a href="{{ resource.url }}">
-    <i class="fa fa-{% if resource.link %}link{% else %}file-o{% endif %}"></i>
-    {{ resource.description }}
-    {% if resource.resource %}({{ resource.resource.size|filesizeformat }}){% endif %}
+  <i class="fa fa-{% if resource.link %}link{% else %}file-o{% endif %}"></i>
+  {{ resource.description }}
+  {% if resource.resource %}({{ resource.resource.size|filesizeformat }}){% endif %}
 </a>

--- a/src/pretalx/agenda/templates/agenda/schedule.html
+++ b/src/pretalx/agenda/templates/agenda/schedule.html
@@ -8,77 +8,77 @@
 {% block container_width %} {% if not show_talk_list %}main-schedule{% else %}list-schedule{% endif %}{% endblock container_width %}
 
 {% block agenda_custom_header %}
-    <script id="pretalx-messages" data-logged-in="{% if request.user.is_anonymous %}false{% else %}true{% endif %}" src="{{ request.event.urls.schedule }}widget/messages.js"></script>
+  <script id="pretalx-messages" data-logged-in="{% if request.user.is_anonymous %}false{% else %}true{% endif %}" src="{{ request.event.urls.schedule }}widget/messages.js"></script>
 {% endblock agenda_custom_header %}
 {% block header_right %}
-    <details class="dropdown mr-2" aria-haspopup="menu" role="menu">
-        <summary>
-            <span>{{ phrases.schedule.version }} {{ schedule.version|default:'-' }}</span>
-            <i class="fa fa-caret-down ml-1"></i>
-        </summary>
-        <div class="dropdown-content dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
-            <a class="dropdown-item" href="{{ request.event.urls.changelog }}" role="menuitem" tabindex="-1">
-                <i class="fa fa-book"></i>
-                {% translate "Changelog" %}
-            </a>
-            <hr>
-            {% for exporter in exporters %}
-                <a class="dropdown-item" href="{{ exporter.urls.base }}" role="menuitem" tabindex="-1">
-                    {% if exporter.icon|slice:":3" == "fa-" %}
-                        <span class="fa {{ exporter.icon }} export-icon"></span>
-                    {% else %}
-                        <span class="export-icon">{{ exporter.icon }}</span>
-                    {% endif %}
-                    {{ exporter.verbose_name }}
-                    {% if exporter.show_qrcode %}
-                        <span class="export-qrcode">
-                            <i class="fa fa-qrcode"></i>
-                            <div class="export-qrcode-image">{{ exporter.get_qrcode }}</div>
-                        </span>
-                    {% endif %}
-                </a>
-            {% endfor %}
-        </div>
-    </details>
+  <details class="dropdown mr-2" aria-haspopup="menu" role="menu">
+    <summary>
+      <span>{{ phrases.schedule.version }} {{ schedule.version|default:'-' }}</span>
+      <i class="fa fa-caret-down ml-1"></i>
+    </summary>
+    <div class="dropdown-content dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
+      <a class="dropdown-item" href="{{ request.event.urls.changelog }}" role="menuitem" tabindex="-1">
+        <i class="fa fa-book"></i>
+        {% translate "Changelog" %}
+      </a>
+      <hr>
+      {% for exporter in exporters %}
+        <a class="dropdown-item" href="{{ exporter.urls.base }}" role="menuitem" tabindex="-1">
+          {% if exporter.icon|slice:":3" == "fa-" %}
+            <span class="fa {{ exporter.icon }} export-icon"></span>
+          {% else %}
+            <span class="export-icon">{{ exporter.icon }}</span>
+          {% endif %}
+          {{ exporter.verbose_name }}
+          {% if exporter.show_qrcode %}
+            <span class="export-qrcode">
+              <i class="fa fa-qrcode"></i>
+              <div class="export-qrcode-image">{{ exporter.get_qrcode }}</div>
+            </span>
+          {% endif %}
+        </a>
+      {% endfor %}
+    </div>
+  </details>
 {% endblock header_right %}
 
 {% block agenda_content %}
-    <div id="fahrplan" class="{% if show_talk_list %}list{% else %}grid{% endif %}">
-        {% if schedule != schedule.event.current_schedule %}
-            <div class="alert alert-warning m-3">
-                <span>
-                    {% if not schedule.version %}
-                        {{ phrases.schedule.wip_version }}
-                    {% else %}
-                        {{ phrases.schedule.old_version }}
-                    {% endif %}
-                    {% if request.event.current_schedule %}
-                        {% phrase "phrases.schedule.current_version" current_url=schedule.event.urls.schedule %}
-                    {% endif %}
-                </span>
-            </div>
-        {% endif %}
+  <div id="fahrplan" class="{% if show_talk_list %}list{% else %}grid{% endif %}">
+    {% if schedule != schedule.event.current_schedule %}
+      <div class="alert alert-warning m-3">
+        <span>
+          {% if not schedule.version %}
+            {{ phrases.schedule.wip_version }}
+          {% else %}
+            {{ phrases.schedule.old_version }}
+          {% endif %}
+          {% if request.event.current_schedule %}
+            {% phrase "phrases.schedule.current_version" current_url=schedule.event.urls.schedule %}
+          {% endif %}
+        </span>
+      </div>
+    {% endif %}
 
-        <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
+    <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>
 
-        <pretalx-schedule
-            event-url="{{ request.event.urls.base }}"
-            version="{{ schedule.version|default:"wip"|urlencode }}"
-            locale="{{ request.LANGUAGE_CODE }}"
-            timezone="{{ request.event.timezone }}"
-            {% if show_talk_list %}format="list"{% endif %}
-            style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"
-        ></pretalx-schedule>
-        <noscript class="d-block">
-            <div class="alert alert-info m-4">
-                <div></div>
-                <div>
-                    {% blocktranslate trimmed with href=request.event.urls.schedule_nojs %}
-                        To see our schedule, please either enable JavaScript or go <a href="{{ href }}">here</a> for our NoJS schedule.
-                    {% endblocktranslate %}
-                </div>
-            </div>
-        </noscript>
-    </div>
+    <pretalx-schedule
+      event-url="{{ request.event.urls.base }}"
+      version="{{ schedule.version|default:"wip"|urlencode }}"
+      locale="{{ request.LANGUAGE_CODE }}"
+      timezone="{{ request.event.timezone }}"
+      {% if show_talk_list %}format="list"{% endif %}
+      style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"
+    ></pretalx-schedule>
+    <noscript class="d-block">
+      <div class="alert alert-info m-4">
+        <div></div>
+        <div>
+          {% blocktranslate trimmed with href=request.event.urls.schedule_nojs %}
+            To see our schedule, please either enable JavaScript or go <a href="{{ href }}">here</a> for our NoJS schedule.
+          {% endblocktranslate %}
+        </div>
+      </div>
+    </noscript>
+  </div>
 
 {% endblock agenda_content %}

--- a/src/pretalx/agenda/templates/agenda/schedule_nojs.html
+++ b/src/pretalx/agenda/templates/agenda/schedule_nojs.html
@@ -7,81 +7,81 @@
 {% load phrases %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" type="text/css" href="{% static "agenda/css/agenda_nojs.css" %}" />
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static "agenda/css/agenda_nojs.css" %}" />
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block agenda_content %}
-    <div id="fahrplan" class="list">
+  <div id="fahrplan" class="list">
 
-        <div class="alert alert-info">
-            <div></div>
-            <div>
-                {% blocktranslate trimmed with href=request.event.urls.schedule %}
-                    To see our schedule with full functionality, like timezone conversion and personal scheduling, please enable JavaScript and go <a href="{{ href }}">here</a>.
-                {% endblocktranslate %}
-            </div>
-        </div>
-        {% if schedule != schedule.event.current_schedule %}
-            <div class="alert alert-warning m-3">
-                <span>
-                    {% if not schedule.version %}
-                        {{ phrases.schedule.wip_version }}
-                    {% else %}
-                        {{ phrases.schedule.old_version }}
-                    {% endif %}
-                    {% if request.event.current_schedule %}
-                        {% phrase "phrases.schedule.current_version" current_url=schedule.event.urls.schedule %}
-                    {% endif %}
-                </span>
-            </div>
-        {% endif %}
-
-        <div class="pretalx-tabbed">
-            <div class="pretalx-tabbed-content">
-                {% if day_count > 1 %}
-                    <div class="pretalx-tabs">
-                        {% for day in data %}
-                            <div class="pretalx-tab">
-                                <label class="pretalx-tab-label" for="{{ day.start|date:"Y-m-d" }}">
-                                    {{ day.start|date:"l" }}, {{ day.start|date:"DATE_FORMAT" }}
-                                </label>
-                            </div>
-                        {% endfor %}
-                    </div>
-                {% endif %}
-                {% for day in data %}
-                    {% if day_count > 1 %}
-                        <input name="tabs" id="{{ day.start|date:"Y-m-d" }}" type="radio" {% if forloop.first %}checked{% endif %}>
-                    {% endif %}
-                    <div class="pretalx-list-day pretalx-tab-content"
-                         data-start="{{ day.display_start|date:"c" }}">
-                        {% if day.first_start %}
-                            {% for session in day.talks %}
-                                <div class="bucket-time">
-                                    {% ifchanged session.start %}
-                                        {{ session.start|date:"TIME_FORMAT" }}
-                                    {% endifchanged %}
-                                </div>
-                                {% if not schedule.is_archived and session.submission and not session.submission.is_deleted %}
-                                    <a href="{{ session.submission.urls.public }}">
-                                {% endif %}
-
-                                {% include "agenda/session_block.html" %}
-
-                                {% if not schedule.is_archived and session.submission and not session.submission.is_deleted %}</a>{% endif %}
-                            {% endfor %}
-                        {% else %}
-                            <div class="no-session">
-                                {% blocktranslate with current_day=day.start|date:"DATE_FORMAT" weekday=day.start|date:"l" trimmed %}
-                                    No sessions on {{ weekday }}, {{ current_day }}.
-                                {% endblocktranslate %}
-                            </div>
-                        {% endif %}
-                    </div>
-                {% endfor %}
-            </div>
-        </div>
+    <div class="alert alert-info">
+      <div></div>
+      <div>
+        {% blocktranslate trimmed with href=request.event.urls.schedule %}
+          To see our schedule with full functionality, like timezone conversion and personal scheduling, please enable JavaScript and go <a href="{{ href }}">here</a>.
+        {% endblocktranslate %}
+      </div>
     </div>
+    {% if schedule != schedule.event.current_schedule %}
+      <div class="alert alert-warning m-3">
+        <span>
+          {% if not schedule.version %}
+            {{ phrases.schedule.wip_version }}
+          {% else %}
+            {{ phrases.schedule.old_version }}
+          {% endif %}
+          {% if request.event.current_schedule %}
+            {% phrase "phrases.schedule.current_version" current_url=schedule.event.urls.schedule %}
+          {% endif %}
+        </span>
+      </div>
+    {% endif %}
+
+    <div class="pretalx-tabbed">
+      <div class="pretalx-tabbed-content">
+        {% if day_count > 1 %}
+          <div class="pretalx-tabs">
+            {% for day in data %}
+              <div class="pretalx-tab">
+                <label class="pretalx-tab-label" for="{{ day.start|date:"Y-m-d" }}">
+                  {{ day.start|date:"l" }}, {{ day.start|date:"DATE_FORMAT" }}
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+        {% endif %}
+        {% for day in data %}
+          {% if day_count > 1 %}
+            <input name="tabs" id="{{ day.start|date:"Y-m-d" }}" type="radio" {% if forloop.first %}checked{% endif %}>
+          {% endif %}
+          <div class="pretalx-list-day pretalx-tab-content"
+               data-start="{{ day.display_start|date:"c" }}">
+            {% if day.first_start %}
+              {% for session in day.talks %}
+                <div class="bucket-time">
+                  {% ifchanged session.start %}
+                    {{ session.start|date:"TIME_FORMAT" }}
+                  {% endifchanged %}
+                </div>
+                {% if not schedule.is_archived and session.submission and not session.submission.is_deleted %}
+                  <a href="{{ session.submission.urls.public }}">
+                {% endif %}
+
+                {% include "agenda/session_block.html" %}
+
+                {% if not schedule.is_archived and session.submission and not session.submission.is_deleted %}</a>{% endif %}
+              {% endfor %}
+            {% else %}
+              <div class="no-session">
+                {% blocktranslate with current_day=day.start|date:"DATE_FORMAT" weekday=day.start|date:"l" trimmed %}
+                  No sessions on {{ weekday }}, {{ current_day }}.
+                {% endblocktranslate %}
+              </div>
+            {% endif %}
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
 {% endblock agenda_content %}

--- a/src/pretalx/agenda/templates/agenda/session_block.html
+++ b/src/pretalx/agenda/templates/agenda/session_block.html
@@ -5,44 +5,44 @@
 <div class="pretalx-session{% if request.user in session.submission.speakers.all %} session-highlight{% endif %}{% if session.is_active %} active{% endif %}{% if session.submission.state == "accepted" %} accepted{% endif %}{% if not session.submission %} break{% endif %}"
      id="{{ session.submission.code|default:"break" }}"
      style="--track-color:{% if not session.submission %}#ccc{% elif request.event|get_feature_flag:"use_tracks" and session.submission.track and session.submission.track.color %}{{ session.submission.track.color }}{% else %}{{ request.event.visible_primary_color }}{% endif %}">
-    <div class="pretalx-session-time-box">
-        {% if show_date %}<div class="start">{{ session.start|date:DAY_MONTH_DATE_FORMAT }}</div>{% endif %}
-        <div class="start">{{ session.start|date:"TIME_FORMAT" }}</div>
-        <div class="duration">
-            {% blocktranslate trimmed with minutes=session.duration %}
-                {{ minutes }}min
-            {% endblocktranslate %}
-        </div>
+  <div class="pretalx-session-time-box">
+    {% if show_date %}<div class="start">{{ session.start|date:DAY_MONTH_DATE_FORMAT }}</div>{% endif %}
+    <div class="start">{{ session.start|date:"TIME_FORMAT" }}</div>
+    <div class="duration">
+      {% blocktranslate trimmed with minutes=session.duration %}
+        {{ minutes }}min
+      {% endblocktranslate %}
     </div>
-    <div class="pretalx-session-info">
-        <div class="title">
-            {% if not session.submission %}
-                {{ session.description }}
-            {% elif session.submission.is_deleted %}
-                <span class="pretalx-session-title">[{{ phrases.submission.deleted }}]</span>
-            {% else %}
-                {% if session.submission.do_not_record %}
-                    <span class="fa-stack">
-                        <i class="fa fa-video-camera fa-stack-1x"></i>
-                        <i class="fa fa-ban do-not-record fa-stack-2x" aria-hidden="true" title="{{ phrases.agenda.schedule_do_not_record }}"></i>
-                    </span>
-                {% endif %}
-                {{ session.submission.title }}
-            {% endif %}
-        </div>
-        {% if session.submission and session.submission.speakers %}
-            <div class="speakers">{{ session.submission.display_speaker_names }}</div>
+  </div>
+  <div class="pretalx-session-info">
+    <div class="title">
+      {% if not session.submission %}
+        {{ session.description }}
+      {% elif session.submission.is_deleted %}
+        <span class="pretalx-session-title">[{{ phrases.submission.deleted }}]</span>
+      {% else %}
+        {% if session.submission.do_not_record %}
+          <span class="fa-stack">
+            <i class="fa fa-video-camera fa-stack-1x"></i>
+            <i class="fa fa-ban do-not-record fa-stack-2x" aria-hidden="true" title="{{ phrases.agenda.schedule_do_not_record }}"></i>
+          </span>
         {% endif %}
-        {% if session.submission and session.submission.abstract %}
-            <div class="abstract">{{ session.submission.abstract|rich_text_without_links }}</div>
-        {% endif %}
-        <div class="bottom-info">
-            <div class="track">
-                {% if session.submission and session.submission.track %}{{ session.submission.track.name|default:"" }}{% endif %}
-            </div>
-            <div class="room">
-                {% if session.room %}{{ session.room.name|default:"" }}{% endif %}
-            </div>
-        </div>
+        {{ session.submission.title }}
+      {% endif %}
     </div>
+    {% if session.submission and session.submission.speakers %}
+      <div class="speakers">{{ session.submission.display_speaker_names }}</div>
+    {% endif %}
+    {% if session.submission and session.submission.abstract %}
+      <div class="abstract">{{ session.submission.abstract|rich_text_without_links }}</div>
+    {% endif %}
+    <div class="bottom-info">
+      <div class="track">
+        {% if session.submission and session.submission.track %}{{ session.submission.track.name|default:"" }}{% endif %}
+      </div>
+      <div class="room">
+        {% if session.room %}{{ session.room.name|default:"" }}{% endif %}
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/pretalx/agenda/templates/agenda/speaker.html
+++ b/src/pretalx/agenda/templates/agenda/speaker.html
@@ -10,77 +10,77 @@
 {% block meta_title %}{{ profile.user.get_display_name }}{% endblock meta_title %}
 {% block social_title %}{{ profile.user.get_display_name }}{% endblock social_title %}
 {% block meta_image %}
-    {% if profile.user.avatar_url and request.event.cfp.request_avatar %}
-        <meta property="thumbnail" content="{{ profile.urls.social_image.full }}">
-        <meta property="og:image" content="{{ profile.urls.social_image.full }}">
-    {% endif %}
+  {% if profile.user.avatar_url and request.event.cfp.request_avatar %}
+    <meta property="thumbnail" content="{{ profile.urls.social_image.full }}">
+    <meta property="og:image" content="{{ profile.urls.social_image.full }}">
+  {% endif %}
 {% endblock meta_image %}
 {% block alternate_link %}
-    <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.speakers.full }}{{ profile.code }}" />
+  <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.speakers.full }}{{ profile.code }}" />
 {% endblock alternate_link %}
 
 {% block agenda_custom_header %}
-    {% compress js %}
-        <script defer src="{% static "common/js/lightbox.js" %}"></script>
-    {% endcompress %}
-    {% compress css %}
-        <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/lightbox.js" %}"></script>
+  {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock agenda_custom_header %}
 
 {% block agenda_content %}
-    <article>
-        <div class="d-flex mb-2">
-            <h3 class="heading-with-buttons">
-                {{ profile.user.get_display_name }}
-                {% if request.event.current_schedule %}
-                    <div class="buttons ml-auto flip">
-                        <a class="btn btn-outline-primary" href="{{ profile.urls.talks_ical }}">
-                            <i class="fa fa-calendar"></i> .ical
-                        </a>
-                    </div>
-                {% endif %}
-            </h3>
-        </div>
-        <div class="speaker-container">
-            <section class="speaker-info">
-                <div class="speaker-bio">{{ profile.biography|rich_text }}</div>
-                {% if profile.user.avatar_url and request.event.cfp.request_avatar %}
-                    <div class="speaker-avatar">
-                        <a href="{{ profile.user.avatar.url }}" data-lightbox="{{ profile.user.avatar.url }}">
-                            <img loading="lazy" width="100%" src="{{ profile.user.avatar|thumbnail:"default" }}" alt="{% translate "The speaker’s profile picture" %}">
-                        </a>
-                    </div>
-                {% endif %}
-            </section>
-            {% if answers %}
-                <hr />
-                <section class="answers">
-                    {% for answer in answers %}
-                        <span class="question"><strong>{{ answer.question.question }}</strong></span>
-                        <span class="answer">– {% include "common/question_answer.html" with answer=answer %}</span>
-                    {% endfor %}
-                </section>
-            {% endif %}
-            <hr />
-            {% if talks %}
-                <section class="speaker-talks">
-                    <h4>
-                        {% blocktranslate trimmed count count=talks.count %}
-                            Session
-                        {% plural %}
-                            Sessions
-                        {% endblocktranslate %}
-                    </h4>
-                    {% for session in talks %}
-                        <a href="{{ session.submission.urls.public }}">
+  <article>
+    <div class="d-flex mb-2">
+      <h3 class="heading-with-buttons">
+        {{ profile.user.get_display_name }}
+        {% if request.event.current_schedule %}
+          <div class="buttons ml-auto flip">
+            <a class="btn btn-outline-primary" href="{{ profile.urls.talks_ical }}">
+              <i class="fa fa-calendar"></i> .ical
+            </a>
+          </div>
+        {% endif %}
+      </h3>
+    </div>
+    <div class="speaker-container">
+      <section class="speaker-info">
+        <div class="speaker-bio">{{ profile.biography|rich_text }}</div>
+        {% if profile.user.avatar_url and request.event.cfp.request_avatar %}
+          <div class="speaker-avatar">
+            <a href="{{ profile.user.avatar.url }}" data-lightbox="{{ profile.user.avatar.url }}">
+              <img loading="lazy" width="100%" src="{{ profile.user.avatar|thumbnail:"default" }}" alt="{% translate "The speaker’s profile picture" %}">
+            </a>
+          </div>
+        {% endif %}
+      </section>
+      {% if answers %}
+        <hr />
+        <section class="answers">
+          {% for answer in answers %}
+            <span class="question"><strong>{{ answer.question.question }}</strong></span>
+            <span class="answer">– {% include "common/question_answer.html" with answer=answer %}</span>
+          {% endfor %}
+        </section>
+      {% endif %}
+      <hr />
+      {% if talks %}
+        <section class="speaker-talks">
+          <h4>
+            {% blocktranslate trimmed count count=talks.count %}
+              Session
+            {% plural %}
+              Sessions
+            {% endblocktranslate %}
+          </h4>
+          {% for session in talks %}
+            <a href="{{ session.submission.urls.public }}">
 
-                            {% include "agenda/session_block.html" with show_date=True %}
+              {% include "agenda/session_block.html" with show_date=True %}
 
-                        </a>
-                    {% endfor %}
-                </section>
-            {% endif %}
-        </div>
-    </article>
+            </a>
+          {% endfor %}
+        </section>
+      {% endif %}
+    </div>
+  </article>
 {% endblock agenda_content %}

--- a/src/pretalx/agenda/templates/agenda/speakers.html
+++ b/src/pretalx/agenda/templates/agenda/speakers.html
@@ -6,33 +6,33 @@
 {% load thumbnail %}
 
 {% block agenda_content %}
-    <p></p>
-    <article>
-        <section style="--track-color: {{ request.event.visible_primary_color }}" class="pretalx-list-day">
-            {% for speaker in speakers %}
-                <a href="{{ speaker.urls.public }}">
-                    <div class="pretalx-session">
-                        <div class="pretalx-session-time-box avatar">
-                            <div class="avatar-wrapper">
-                                {% if speaker.user.avatar_url and request.event.cfp.request_avatar %}
-                                    <img loading="lazy" src="{{ speaker.user.avatar|thumbnail:"default" }}" alt="{% translate "The speaker’s profile picture" %}">
-                                {% else %}
-                                    <img loading="lazy" src="{{ request.event.urls.speakers }}avatar.svg" alt="{% translate "The speaker’s profile picture" %}">
-                                {% endif %}
-                            </div>
-                        </div>
-                        <div class="pretalx-session-info">
-                            <div class="title">{{ speaker.user.get_display_name }}</div>
-                            <div class="abstract">{{ speaker.biography|default:""|rich_text_without_links }}</div>
-                            <ul>
-                                {% for talk in speaker.talks %}
-                                    <li>{{ talk.title }}</li>
-                                {% endfor %}
-                            </ul>
-                        </div>
-                    </div>
-                </a>
-            {% endfor %}
-        </section>
-    </article>
+  <p></p>
+  <article>
+    <section style="--track-color: {{ request.event.visible_primary_color }}" class="pretalx-list-day">
+      {% for speaker in speakers %}
+        <a href="{{ speaker.urls.public }}">
+          <div class="pretalx-session">
+            <div class="pretalx-session-time-box avatar">
+              <div class="avatar-wrapper">
+                {% if speaker.user.avatar_url and request.event.cfp.request_avatar %}
+                  <img loading="lazy" src="{{ speaker.user.avatar|thumbnail:"default" }}" alt="{% translate "The speaker’s profile picture" %}">
+                {% else %}
+                  <img loading="lazy" src="{{ request.event.urls.speakers }}avatar.svg" alt="{% translate "The speaker’s profile picture" %}">
+                {% endif %}
+              </div>
+            </div>
+            <div class="pretalx-session-info">
+              <div class="title">{{ speaker.user.get_display_name }}</div>
+              <div class="abstract">{{ speaker.biography|default:""|rich_text_without_links }}</div>
+              <ul>
+                {% for talk in speaker.talks %}
+                  <li>{{ talk.title }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+        </a>
+      {% endfor %}
+    </section>
+  </article>
 {% endblock agenda_content %}

--- a/src/pretalx/agenda/templates/agenda/talk.html
+++ b/src/pretalx/agenda/templates/agenda/talk.html
@@ -16,178 +16,178 @@
 {% block meta_description %}{{ submission_description }}{% endblock meta_description %}
 {% block social_description %}{{ submission_description }}{% endblock social_description %}
 {% block meta_image %}
-    <meta property="thumbnail" content="{{ submission.urls.social_image.full }}">
-    <meta property="og:image" content="{{ submission.urls.social_image.full }}">
+  <meta property="thumbnail" content="{{ submission.urls.social_image.full }}">
+  <meta property="og:image" content="{{ submission.urls.social_image.full }}">
 {% endblock meta_image %}
 {% block alternate_link %}
-    <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.talks.full }}{{ submission.code }}" />
+  <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.talks.full }}{{ submission.code }}" />
 {% endblock alternate_link %}
 
 {% block agenda_custom_header %}
-    <script id="pretalx-messages" data-logged-in="{% if request.user.is_anonymous %}false{% else %}true{% endif %}" src="{{ request.event.urls.schedule }}widget/messages.js"></script>
-    {% compress js %}
-        <script defer src="{% static "agenda/js/favourite.js" %}"></script>
-        <script defer src="{% static "common/js/lightbox.js" %}"></script>
-        <script defer src="{% static "vendored/moment-with-locales.js" %}"></script>
-        <script defer src="{% static "vendored/moment-timezone-with-data-10-year-range.js" %}"></script>
-        <script defer src="{% static "agenda/js/datetime-local.js" %}"></script>
-    {% endcompress %}
-    {% compress css %}
-        <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  <script id="pretalx-messages" data-logged-in="{% if request.user.is_anonymous %}false{% else %}true{% endif %}" src="{{ request.event.urls.schedule }}widget/messages.js"></script>
+  {% compress js %}
+    <script defer src="{% static "agenda/js/favourite.js" %}"></script>
+    <script defer src="{% static "common/js/lightbox.js" %}"></script>
+    <script defer src="{% static "vendored/moment-with-locales.js" %}"></script>
+    <script defer src="{% static "vendored/moment-timezone-with-data-10-year-range.js" %}"></script>
+    <script defer src="{% static "agenda/js/datetime-local.js" %}"></script>
+  {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock agenda_custom_header %}
 
 {% block agenda_content %}
-    <article>
-        {% html_signal "pretalx.agenda.signals.html_above_session_pages" sender=request.event request=request submission=submission %}
-        <h3 class="talk-title">
-            <div class="heading-with-buttons">
-                <span>
-                    {{ submission.title }}
-                    <button class="btn btn-xs btn-link d-none" id="fav-button">
-                        <i class="fa fa-star-o d-none" title="{% translate "Favourite this session" %}"></i>
-                        <i class="fa fa-star d-none" title="{% translate "Remove this session from your favourites" %}"></i>
-                    </button>
-                </span>
-                <div class="buttons d-flex justify-content-end" id="talk-buttons">
-                    {% if submission.state == "confirmed" and request.event.current_schedule %}
-                        <a class="btn btn-outline-primary ml-2" href="{{ submission.urls.ical }}">
-                            <i class="fa fa-calendar"></i> .ical
-                        </a>
-                    {% endif %}
-                    {% if submission.does_accept_feedback and request.event|get_feature_flag:"use_feedback" and not is_html_export %}
-                        <a href="{{ submission.urls.feedback }}" class="btn btn-success">
-                            <i class="fa fa-comments"></i> {{ phrases.agenda.feedback }}
-                        </a>
-                    {% endif %}
-                    {% if request.user in submission.speakers.all %}
-                        <a href="{{ submission.urls.user_base }}" class="btn btn-info ml-1">
-                            <i class="fa fa-edit"></i> {{ phrases.base.edit }}
-                        </a>
-                    {% endif %}
-                </div>
-            </div>
-            <small class="text-muted">
-                {% if talk_slots|length == 1 %}
-                    {{ talk_slots.0.start|datetimerange:talk_slots.0.end }}, {{ talk_slots.0.room.name }}
-                    {% if talk_slots.0.room.description %}
-                        <i class="fa fa-question-circle" data-toggle="tooltip" title="{{ talk_slots.0.room.description }}"></i>
-                    {% endif %}
-                {% endif %}
-                {% if request.event.is_multilingual and request.event.cfp.request_content_locale %}
-                    <div class="speakers">
-                        <strong>{{ phrases.base.language }}:</strong> {{ submission.get_content_locale_display }}
-                    </div>
-                {% endif %}
-                {% if submission.do_not_record %}
-                    <span class="fa-stack">
-                        <i class="fa fa-video-camera fa-stack-1x"></i>
-                        <i class="fa fa-ban do-not-record fa-stack-2x" aria-hidden="true" alt="{{ phrases.agenda.schedule_do_not_record }}"></i>
-                    </span>
-                    <em>{{ phrases.agenda.schedule.do_not_record }}</em>
-                {% endif %}
-            </small>
-        </h3>
-        <div class="talk row">
-            <div class="talk-content">
-                {% if recording_iframe %}{{ recording_iframe|safe }}{% endif %}
-                {% if submission.image %}
-                    <div class="talk-image">
-                        <a href="{{ submission.image.url }}"
-                           data-lightbox="{{ submission.image.url }}">
-                            <img loading="lazy"
-                                 src="{{ submission.image.url }}"
-                                 alt="{% translate "This session’s header image" %}">
-                        </a>
-                    </div>
-                {% endif %}
-                {% if talk_slots|length > 1 %}
-                    <ul class="talk-slots">
-                        {% for talk in talk_slots %}
-                            <li class="text-muted">
-                                {{ talk.start|datetimerange:talk.end }}, {{ talk.room.name }}
-                                {% if room.description %}
-                                    <i class="fa fa-question-circle" data-toggle="tooltip" title="{{ room.description }}"></i>
-                                {% endif %}
-                            </li>
-                        {% endfor %}
-                    </ul>
-                    <p>
-                        <i>{% phrase "phrases.schedule.timezone_hint" tz=request.event.timezone %}</i>
-                    </p>
-                {% endif %}
-                <section class="abstract">
-                    {{ submission.abstract|rich_text }}
-                </section>
-                {% if submission.abstract and submission.description %}<hr />{% endif %}
-                <section class="description">
-                    {{ submission.description|rich_text }}
-                </section>
-                {% if answers %}
-                    <hr />
-                    <section class="answers">
-                        {% for answer in answers %}
-                            <span class="question"><strong>{{ answer.question.question }}:</strong></span>
-                            <span class="answer {% if question.variant != "text" %}answer-strip-paragraph{% endif %}">{% include "common/question_answer.html" with answer=answer %}</span>
-                        {% endfor %}
-                {% endif %}
-            </section>
-            {% if submission.active_resources %}
-                <section class="resources">
-                    {% translate "See also:" %}
-                    {% if submission.active_resources.count == 1 %}{% with resource=submission.active_resources.first %}
-                        {% include "agenda/includes/submission_resource.html" %}
-                    {% endwith %}{% else %}
-                        <ul>
-                            {% for resource in submission.active_resources %}
-                                <li>{% include "agenda/includes/submission_resource.html" %}</li>
-                            {% endfor %}
-                        </ul>
-                    {% endif %}
-                </section>
-            {% endif %}
-            <section>
-                {% html_signal "pretalx.agenda.signals.html_below_session_pages" sender=request.event request=request submission=submission %}
-            </section>
-            {% if submission_tags %}
-              {% for tag_item in submission_tags %}
-                  <span class="submission_tag" onclick="#" style="background-color: {{ tag_item.color }}; color: {{ tag_item.contrast_color }};">{{ tag_item.tag }}</span>
-              {% endfor %}
-            {% endif %}
+  <article>
+    {% html_signal "pretalx.agenda.signals.html_above_session_pages" sender=request.event request=request submission=submission %}
+    <h3 class="talk-title">
+      <div class="heading-with-buttons">
+        <span>
+          {{ submission.title }}
+          <button class="btn btn-xs btn-link d-none" id="fav-button">
+            <i class="fa fa-star-o d-none" title="{% translate "Favourite this session" %}"></i>
+            <i class="fa fa-star d-none" title="{% translate "Remove this session from your favourites" %}"></i>
+          </button>
+        </span>
+        <div class="buttons d-flex justify-content-end" id="talk-buttons">
+          {% if submission.state == "confirmed" and request.event.current_schedule %}
+            <a class="btn btn-outline-primary ml-2" href="{{ submission.urls.ical }}">
+              <i class="fa fa-calendar"></i> .ical
+            </a>
+          {% endif %}
+          {% if submission.does_accept_feedback and request.event|get_feature_flag:"use_feedback" and not is_html_export %}
+            <a href="{{ submission.urls.feedback }}" class="btn btn-success">
+              <i class="fa fa-comments"></i> {{ phrases.agenda.feedback }}
+            </a>
+          {% endif %}
+          {% if request.user in submission.speakers.all %}
+            <a href="{{ submission.urls.user_base }}" class="btn btn-info ml-1">
+              <i class="fa fa-edit"></i> {{ phrases.base.edit }}
+            </a>
+          {% endif %}
         </div>
-    </div>
-    {% if not hide_speaker_links %}
-        {% for speaker in speakers %}
-            <div class="pretalx-session">
-                <div class="pretalx-session-time-box avatar">
-                    <a href="{{ speaker.talk_profile.urls.public }}">
-                        <div class="avatar-wrapper">
-                            {% if speaker.avatar_url and request.event.cfp.request_avatar %}
-                                <img loading="lazy" src="{{ speaker.avatar|thumbnail:"default" }}" alt="{% translate "The speaker’s profile picture" %}">
-                            {% else %}
-                                <img loading="lazy" src="{{ request.event.urls.speakers }}avatar.svg" alt="The speaker’s profile picture">
-                            {% endif %}
-                        </div>
-                    </a>
-                </div>
-                <div class="pretalx-session-info">
-                    <div class="title">
-                        <a href="{{ speaker.talk_profile.urls.public }}">{{ speaker.get_display_name }}</a>
-                    </div>
-                    <div class="abstract">{{ speaker.talk_profile.biography|default:""|rich_text }}</div>
-                    {% if speaker.other_submissions %}
-                        {% translate "This speaker also appears in:" %}
-                        <ul>
-                            {% for talk in speaker.other_submissions %}
-                                <li>
-                                    <a href="{{ talk.urls.public }}">{{ talk.title }}</a>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    {% endif %}
-                </div>
-            </div>
+      </div>
+      <small class="text-muted">
+        {% if talk_slots|length == 1 %}
+          {{ talk_slots.0.start|datetimerange:talk_slots.0.end }}, {{ talk_slots.0.room.name }}
+          {% if talk_slots.0.room.description %}
+            <i class="fa fa-question-circle" data-toggle="tooltip" title="{{ talk_slots.0.room.description }}"></i>
+          {% endif %}
+        {% endif %}
+        {% if request.event.is_multilingual and request.event.cfp.request_content_locale %}
+          <div class="speakers">
+            <strong>{{ phrases.base.language }}:</strong> {{ submission.get_content_locale_display }}
+          </div>
+        {% endif %}
+        {% if submission.do_not_record %}
+          <span class="fa-stack">
+            <i class="fa fa-video-camera fa-stack-1x"></i>
+            <i class="fa fa-ban do-not-record fa-stack-2x" aria-hidden="true" alt="{{ phrases.agenda.schedule_do_not_record }}"></i>
+          </span>
+          <em>{{ phrases.agenda.schedule.do_not_record }}</em>
+        {% endif %}
+      </small>
+    </h3>
+    <div class="talk row">
+      <div class="talk-content">
+        {% if recording_iframe %}{{ recording_iframe|safe }}{% endif %}
+        {% if submission.image %}
+          <div class="talk-image">
+            <a href="{{ submission.image.url }}"
+               data-lightbox="{{ submission.image.url }}">
+              <img loading="lazy"
+                   src="{{ submission.image.url }}"
+                   alt="{% translate "This session’s header image" %}">
+            </a>
+          </div>
+        {% endif %}
+        {% if talk_slots|length > 1 %}
+          <ul class="talk-slots">
+            {% for talk in talk_slots %}
+              <li class="text-muted">
+                {{ talk.start|datetimerange:talk.end }}, {{ talk.room.name }}
+                {% if room.description %}
+                  <i class="fa fa-question-circle" data-toggle="tooltip" title="{{ room.description }}"></i>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+          <p>
+            <i>{% phrase "phrases.schedule.timezone_hint" tz=request.event.timezone %}</i>
+          </p>
+        {% endif %}
+        <section class="abstract">
+          {{ submission.abstract|rich_text }}
+        </section>
+        {% if submission.abstract and submission.description %}<hr />{% endif %}
+        <section class="description">
+          {{ submission.description|rich_text }}
+        </section>
+        {% if answers %}
+          <hr />
+          <section class="answers">
+            {% for answer in answers %}
+              <span class="question"><strong>{{ answer.question.question }}:</strong></span>
+              <span class="answer {% if question.variant != "text" %}answer-strip-paragraph{% endif %}">{% include "common/question_answer.html" with answer=answer %}</span>
+            {% endfor %}
+        {% endif %}
+      </section>
+      {% if submission.active_resources %}
+        <section class="resources">
+          {% translate "See also:" %}
+          {% if submission.active_resources.count == 1 %}{% with resource=submission.active_resources.first %}
+            {% include "agenda/includes/submission_resource.html" %}
+          {% endwith %}{% else %}
+            <ul>
+              {% for resource in submission.active_resources %}
+                <li>{% include "agenda/includes/submission_resource.html" %}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </section>
+      {% endif %}
+      <section>
+        {% html_signal "pretalx.agenda.signals.html_below_session_pages" sender=request.event request=request submission=submission %}
+      </section>
+      {% if submission_tags %}
+        {% for tag_item in submission_tags %}
+          <span class="submission_tag" onclick="#" style="background-color: {{ tag_item.color }}; color: {{ tag_item.contrast_color }};">{{ tag_item.tag }}</span>
         {% endfor %}
-    {% endif %}
-    </article>
+      {% endif %}
+    </div>
+  </div>
+  {% if not hide_speaker_links %}
+    {% for speaker in speakers %}
+      <div class="pretalx-session">
+        <div class="pretalx-session-time-box avatar">
+          <a href="{{ speaker.talk_profile.urls.public }}">
+            <div class="avatar-wrapper">
+              {% if speaker.avatar_url and request.event.cfp.request_avatar %}
+                <img loading="lazy" src="{{ speaker.avatar|thumbnail:"default" }}" alt="{% translate "The speaker’s profile picture" %}">
+              {% else %}
+                <img loading="lazy" src="{{ request.event.urls.speakers }}avatar.svg" alt="The speaker’s profile picture">
+              {% endif %}
+            </div>
+          </a>
+        </div>
+        <div class="pretalx-session-info">
+          <div class="title">
+            <a href="{{ speaker.talk_profile.urls.public }}">{{ speaker.get_display_name }}</a>
+          </div>
+          <div class="abstract">{{ speaker.talk_profile.biography|default:""|rich_text }}</div>
+          {% if speaker.other_submissions %}
+            {% translate "This speaker also appears in:" %}
+            <ul>
+              {% for talk in speaker.other_submissions %}
+                <li>
+                  <a href="{{ talk.urls.public }}">{{ talk.title }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+      </div>
+    {% endfor %}
+  {% endif %}
+  </article>
 {% endblock agenda_content %}

--- a/src/pretalx/agenda/views/talk.py
+++ b/src/pretalx/agenda/views/talk.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from datetime import UTC
 from urllib.parse import unquote, urlparse
 
 import jwt
@@ -308,7 +309,7 @@ class OnlineVideoJoin(EventPermissionRequired, View):
 
         else:
             # Redirect user to online event
-            iat = dt.datetime.utcnow()
+            iat = dt.datetime.now(tz=UTC)
             exp = iat + dt.timedelta(days=30)
             profile = {
                 "display_name": request.user.name,

--- a/src/pretalx/api/templates/rest_framework/api.html
+++ b/src/pretalx/api/templates/rest_framework/api.html
@@ -4,18 +4,18 @@
 {% load static %}
 
 {% block bootstrap_theme %}
-    <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap.min.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/_reset.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/base.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/_variables.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/_fonts.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "api/css/api.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap.min.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/_reset.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/base.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/_variables.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/_fonts.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "api/css/api.css" %}" />
 {% endblock bootstrap_theme %}
 
 {% block branding %}
-    <a class="navbar-brand" rel="nofollow" href="#">
-        <img loading="lazy" src="{% static "common/img/icons/icon.svg" %}" alt="{% translate "The eventyay logo" %}">
-        <span>eventyay API</span>
-    </a>
+  <a class="navbar-brand" rel="nofollow" href="#">
+    <img loading="lazy" src="{% static "common/img/icons/icon.svg" %}" alt="{% translate "The eventyay logo" %}">
+    <span>eventyay API</span>
+  </a>
 {% endblock branding %}

--- a/src/pretalx/cfp/templates/cfp/event/base.html
+++ b/src/pretalx/cfp/templates/cfp/event/base.html
@@ -1,7 +1,7 @@
 {% extends "common/base.html" %}
 
 {% block custom_header %}
-    {% block cfp_header %}{% endblock cfp_header %}
+  {% block cfp_header %}{% endblock cfp_header %}
 {% endblock custom_header %}
 
 {% block nav_link %}{{ request.event.urls.base }}{% endblock nav_link %}

--- a/src/pretalx/cfp/templates/cfp/event/cfp.html
+++ b/src/pretalx/cfp/templates/cfp/event/cfp.html
@@ -7,63 +7,63 @@
 {% load rules %}
 
 {% block content %}
-    {% with cfp=request.event.cfp %}
-        {% has_perm "agenda.view_featured_submissions" request.user request.event as can_view_featured_submissions %}
-        {% has_perm "orga.edit_cfp" request.user request.event as can_edit_cfp %}
-        <div class="d-flex align-items-start">
-            <h1>{{ cfp.headline|default:"" }}</h1>
-            {% if can_edit_cfp %}
-                {% orga_edit_link request.event.cfp.urls.text %}
-            {% endif %}
-        </div>
-        {{ cfp.text|rich_text }}
-        {% if request.event.cfp.settings.show_deadline and request.event.cfp.max_deadline %}
-            <p>
-                <strong>
-                    {% if cfp.is_open %}
-                        {% blocktranslate with deadline=cfp.max_deadline|date:"SHORT_DATETIME_FORMAT" timezone=request.timezone until_string=cfp.max_deadline|timeuntil trimmed %}
-                            You can enter proposals until {{ deadline }} ({{ timezone }}), {{ until_string }} from now.
-                        {% endblocktranslate %}
-                    {% else %}
-                        {% blocktranslate with deadline=cfp.max_deadline|date:"SHORT_DATETIME_FORMAT" timezone=request.timezone trimmed %}
-                            This Call for Papers closed on {{ deadline }} ({{ timezone }}).
-                        {% endblocktranslate %}
-                    {% endif %}
-                </strong>
-            </p>
-        {% endif %}
-        <div class="url-links">
-            {% if request.event.current_schedule and request.event|get_feature_flag:"show_schedule" %}
-                <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.schedule }}">
-                    {{ phrases.agenda.view_schedule }}
-                </a>
-            {% elif can_view_featured_submissions and has_featured %}
-                <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.featured }}">
-                    {{ phrases.agenda.view_schedule_preview }}
-                </a>
-            {% endif %}
-            {% if request.user.is_authenticated %}
-            {% if has_submissions or request.user.is_anonymous %}
-            <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user_submissions }}">
-                {{ phrases.agenda.view_own_submissions }}
-            </a>
+  {% with cfp=request.event.cfp %}
+    {% has_perm "agenda.view_featured_submissions" request.user request.event as can_view_featured_submissions %}
+    {% has_perm "orga.edit_cfp" request.user request.event as can_edit_cfp %}
+    <div class="d-flex align-items-start">
+      <h1>{{ cfp.headline|default:"" }}</h1>
+      {% if can_edit_cfp %}
+        {% orga_edit_link request.event.cfp.urls.text %}
+      {% endif %}
+    </div>
+    {{ cfp.text|rich_text }}
+    {% if request.event.cfp.settings.show_deadline and request.event.cfp.max_deadline %}
+      <p>
+        <strong>
+          {% if cfp.is_open %}
+            {% blocktranslate with deadline=cfp.max_deadline|date:"SHORT_DATETIME_FORMAT" timezone=request.timezone until_string=cfp.max_deadline|timeuntil trimmed %}
+              You can enter proposals until {{ deadline }} ({{ timezone }}), {{ until_string }} from now.
+            {% endblocktranslate %}
+          {% else %}
+            {% blocktranslate with deadline=cfp.max_deadline|date:"SHORT_DATETIME_FORMAT" timezone=request.timezone trimmed %}
+              This Call for Papers closed on {{ deadline }} ({{ timezone }}).
+            {% endblocktranslate %}
+          {% endif %}
+        </strong>
+      </p>
+    {% endif %}
+    <div class="url-links">
+      {% if request.event.current_schedule and request.event|get_feature_flag:"show_schedule" %}
+        <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.schedule }}">
+          {{ phrases.agenda.view_schedule }}
+        </a>
+      {% elif can_view_featured_submissions and has_featured %}
+        <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.featured }}">
+          {{ phrases.agenda.view_schedule_preview }}
+        </a>
+      {% endif %}
+      {% if request.user.is_authenticated %}
+        {% if has_submissions or request.user.is_anonymous %}
+          <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user_submissions }}">
+            {{ phrases.agenda.view_own_submissions }}
+          </a>
         {% endif %}
 
         {% if has_submissions or request.user.is_anonymous %}
-            <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user }}">
-                {% translate "View or edit speaker profile" %}
-            </a>
+          <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user }}">
+            {% translate "View or edit speaker profile" %}
+          </a>
         {% endif %}
-            {% endif %}
+      {% endif %}
 
-            <a class="btn btn-success btn-lg btn-block {% if not cfp.is_open and not access_code.is_valid %}disabled{% endif %}"
-               href="{{ request.event.urls.submit }}{{ submit_qs }}">
-                {% if cfp.is_open or access_code.is_valid %}
-                    {% translate "Submit a proposal" %}
-                {% else %}
-                    {% translate "Proposals are closed" %}
-                {% endif %}
-            </a>
-        </div>
-    {% endwith %}
+      <a class="btn btn-success btn-lg btn-block {% if not cfp.is_open and not access_code.is_valid %}disabled{% endif %}"
+         href="{{ request.event.urls.submit }}{{ submit_qs }}">
+        {% if cfp.is_open or access_code.is_valid %}
+          {% translate "Submit a proposal" %}
+        {% else %}
+          {% translate "Proposals are closed" %}
+        {% endif %}
+      </a>
+    </div>
+  {% endwith %}
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/fragment_state.html
+++ b/src/pretalx/cfp/templates/cfp/event/fragment_state.html
@@ -2,20 +2,20 @@
 
 {% if as_badge %}<span class="badge submission-state submission-state-{{ state }}">{% endif %}
 {% if state == "submitted" %}
-    <i class="fa fa-inbox"></i> <span class="state-fragment">{{ phrases.submission.submitted }}</span>
+  <i class="fa fa-inbox"></i> <span class="state-fragment">{{ phrases.submission.submitted }}</span>
 {% elif state == "review" %}
-    <i class="fa fa-inbox"></i> <span class="state-fragment">{{ phrases.submission.in_review }}</span>
+  <i class="fa fa-inbox"></i> <span class="state-fragment">{{ phrases.submission.in_review }}</span>
 {% elif state == "rejected" %}
-    <i class="fa fa-ban"></i> <span class="state-fragment">{{ phrases.submission.not_accepted }}</span>
+  <i class="fa fa-ban"></i> <span class="state-fragment">{{ phrases.submission.not_accepted }}</span>
 {% elif state == "accepted" %}
-    <i class="fa fa-check-circle"></i> <span class="state-fragment">{% translate "accepted" %}</span>
+  <i class="fa fa-check-circle"></i> <span class="state-fragment">{% translate "accepted" %}</span>
 {% elif state == "confirmed" %}
-    <i class="fa fa-check-circle"></i> <span class="state-fragment">{% translate "confirmed" %}</span>
+  <i class="fa fa-check-circle"></i> <span class="state-fragment">{% translate "confirmed" %}</span>
 {% elif state == "canceled" %}
-    <i class="fa fa-times-circle"></i> <span class="state-fragment">{% translate "canceled" %}</span>
+  <i class="fa fa-times-circle"></i> <span class="state-fragment">{% translate "canceled" %}</span>
 {% elif state == "withdrawn" %}
-    <i class="fa fa-times-circle"></i> <span class="state-fragment">{% translate "withdrawn" %}</span>
+  <i class="fa fa-times-circle"></i> <span class="state-fragment">{% translate "withdrawn" %}</span>
 {% elif state == "deleted" %}
-    <i class="fa fa-times-circle"></i> <span class="state-fragment">{{ phrases.submission.deleted }}</span>
+  <i class="fa fa-times-circle"></i> <span class="state-fragment">{{ phrases.submission.deleted }}</span>
 {% endif %}
 {% if as_badge %}</span>{% endif %}

--- a/src/pretalx/cfp/templates/cfp/event/index.html
+++ b/src/pretalx/cfp/templates/cfp/event/index.html
@@ -6,36 +6,36 @@
 {% load rules %}
 
 {% block content %}
-    {% with cfp=request.event.cfp %}
-        {% has_perm "agenda.view_featured_submissions" request.user request.event as can_view_featured_submissions %}
-        {% if request.event.landing_page_text %}{{ request.event.landing_page_text|rich_text }}{% endif %}
-        <div class="url-links">
-            {% if has_submissions or request.user.is_anonymous %}
-                {% if not is_html_export %}
-                    <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user_submissions }}">
-                        {{ phrases.agenda.view_own_submissions }}
-                    </a>
-                {% endif %}
-            {% endif %}
-            {% if request.event.current_schedule and request.event|get_feature_flag:"show_schedule" %}
-                <a class="btn btn-success btn-lg btn-block" href="{{ request.event.urls.schedule }}">
-                    {{ phrases.agenda.view_schedule }}
-                </a>
-            {% elif can_view_featured_submissions and has_featured %}
-                <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.featured }}">
-                    {{ phrases.agenda.view_schedule_preview }}
-                </a>
-            {% endif %}
-            {% if cfp.is_open and not is_html_export %}
-                <a class="btn btn-info btn-lg btn-block" href="{{ request.event.cfp.urls.public }}{{ submit_qs }}">
-                    {{ phrases.cfp.go_to_cfp }}
-                </a>
-            {% endif %}
-            {% if can_see_orga_area %}
-                <a class="btn btn-info btn-lg btn-block" href="{{ request.event.orga_urls.base }}">
-                    {% translate "Go To Organiser Area" %}
-                </a>
-            {% endif %}
-        </div>
-    {% endwith %}
+  {% with cfp=request.event.cfp %}
+    {% has_perm "agenda.view_featured_submissions" request.user request.event as can_view_featured_submissions %}
+    {% if request.event.landing_page_text %}{{ request.event.landing_page_text|rich_text }}{% endif %}
+    <div class="url-links">
+      {% if has_submissions or request.user.is_anonymous %}
+        {% if not is_html_export %}
+          <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.user_submissions }}">
+            {{ phrases.agenda.view_own_submissions }}
+          </a>
+        {% endif %}
+      {% endif %}
+      {% if request.event.current_schedule and request.event|get_feature_flag:"show_schedule" %}
+        <a class="btn btn-success btn-lg btn-block" href="{{ request.event.urls.schedule }}">
+          {{ phrases.agenda.view_schedule }}
+        </a>
+      {% elif can_view_featured_submissions and has_featured %}
+        <a class="btn btn-info btn-lg btn-block" href="{{ request.event.urls.featured }}">
+          {{ phrases.agenda.view_schedule_preview }}
+        </a>
+      {% endif %}
+      {% if cfp.is_open and not is_html_export %}
+        <a class="btn btn-info btn-lg btn-block" href="{{ request.event.cfp.urls.public }}{{ submit_qs }}">
+          {{ phrases.cfp.go_to_cfp }}
+        </a>
+      {% endif %}
+      {% if can_see_orga_area %}
+        <a class="btn btn-info btn-lg btn-block" href="{{ request.event.orga_urls.base }}">
+          {% translate "Go To Organiser Area" %}
+        </a>
+      {% endif %}
+    </div>
+  {% endwith %}
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/invitation.html
+++ b/src/pretalx/cfp/templates/cfp/event/invitation.html
@@ -6,43 +6,43 @@
 {% block title %}{% translate "Accept invitation?" %}{% endblock title %}
 
 {% block content %}
-    <h2>{% translate "Accept invitation?" %}</h2>
-    {% if not can_accept_invite %}
+  <h2>{% translate "Accept invitation?" %}</h2>
+  {% if not can_accept_invite %}
 
-        <p>
-            {% blocktranslate trimmed %}
-                Unfortunately, you cannot accept this invitation at the moment.
-                This may be because the invitation has expired, or because the
-                proposal cannot be edited any more.
-            {% endblocktranslate %}
-        </p>
-        <p>
-            {% blocktranslate trimmed %}
-                Please contact the conference organizers for more information.
-            {% endblocktranslate %}
-        </p>
-    {% else %}
-        <p>
-            {% blocktranslate with name=request.user.get_display_name talk=submission.title trimmed %}
-                You, {{ name }}, have been invited to be a speaker for the session
-                “{{ talk }}”. Do you accept the invitation?
-            {% endblocktranslate %}
-        </p>
+    <p>
+      {% blocktranslate trimmed %}
+        Unfortunately, you cannot accept this invitation at the moment.
+        This may be because the invitation has expired, or because the
+        proposal cannot be edited any more.
+      {% endblocktranslate %}
+    </p>
+    <p>
+      {% blocktranslate trimmed %}
+        Please contact the conference organizers for more information.
+      {% endblocktranslate %}
+    </p>
+  {% else %}
+    <p>
+      {% blocktranslate with name=request.user.get_display_name talk=submission.title trimmed %}
+        You, {{ name }}, have been invited to be a speaker for the session
+        “{{ talk }}”. Do you accept the invitation?
+      {% endblocktranslate %}
+    </p>
 
-        {% if submission.abstract %}
-            <div class="card ml-auto mr-auto col-md-9">
-                <div class="card-header">{% translate "Abstract:" %} {{ submission.title }}</div>
-                <div class="card-body mt-0 mb-0 mr-3 ml-3">
-                    <p class="card-text">{{ submission.abstract|rich_text }}</p>
-                </div>
-            </div>
-        {% endif %}
-        <form method="post" class="form">
-            {% csrf_token %}
-            <div class="url-links">
-                <a href="/" class="btn btn-danger btn-lg btn-block">{% translate "No" %}</a>
-                <button type="submit" class="btn btn-success btn-lg btn-block">{% translate "Accept invitation" %}</button>
-            </div>
-        </form>
+    {% if submission.abstract %}
+      <div class="card ml-auto mr-auto col-md-9">
+        <div class="card-header">{% translate "Abstract:" %} {{ submission.title }}</div>
+        <div class="card-body mt-0 mb-0 mr-3 ml-3">
+          <p class="card-text">{{ submission.abstract|rich_text }}</p>
+        </div>
+      </div>
     {% endif %}
+    <form method="post" class="form">
+      {% csrf_token %}
+      <div class="url-links">
+        <a href="/" class="btn btn-danger btn-lg btn-block">{% translate "No" %}</a>
+        <button type="submit" class="btn btn-success btn-lg btn-block">{% translate "Accept invitation" %}</button>
+      </div>
+    </form>
+  {% endif %}
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/login.html
+++ b/src/pretalx/cfp/templates/cfp/event/login.html
@@ -5,18 +5,18 @@
 {% block title %}{% translate "Login" %} :: {% endblock title %}
 
 {% block content %}
-    <h2>{% translate "Welcome back!" %}</h2>
-    <p>
-        {% blocktranslate trimmed %}
-            If you already created a proposal for a different event on this server, you can re-use your account to log in for this event.
-        {% endblocktranslate %}
-    </p>
-    <p>
-        {% blocktranslate trimmed %}
-            You do not need an account to view the event, submit feedback, or receive schedule updates.
-            An account is only necessary if you want to create your own personalized schedule,
-            or if you are participating in the event as a speaker or organizer.
-        {% endblocktranslate %}
-    </p>
-    {% include "common/auth.html" with hide_register=True next_url=request.get_full_path %}
+  <h2>{% translate "Welcome back!" %}</h2>
+  <p>
+    {% blocktranslate trimmed %}
+      If you already created a proposal for a different event on this server, you can re-use your account to log in for this event.
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% blocktranslate trimmed %}
+      You do not need an account to view the event, submit feedback, or receive schedule updates.
+      An account is only necessary if you want to create your own personalized schedule,
+      or if you are participating in the event as a speaker or organizer.
+    {% endblocktranslate %}
+  </p>
+  {% include "common/auth.html" with hide_register=True next_url=request.get_full_path %}
 {% endblock %}

--- a/src/pretalx/cfp/templates/cfp/event/recover.html
+++ b/src/pretalx/cfp/templates/cfp/event/recover.html
@@ -7,29 +7,29 @@
 {% block title %}{{ phrases.base.password_reset_heading }}{% endblock title %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
-        <script defer src="{% static 'common/js/base.js' %}"></script>
-        <script defer src="{% static 'common/js/password_strength.js' %}"></script>
-    {% endcompress %}
-    {% compress css %}
-        <link rel="stylesheet" type="text/css" href="{% static "common/css/_forms.css" %}" />
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
+    <script defer src="{% static 'common/js/base.js' %}"></script>
+    <script defer src="{% static 'common/js/password_strength.js' %}"></script>
+  {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static "common/css/_forms.css" %}" />
+  {% endcompress %}
 {% endblock %}
 
 {% block content %}
-    <form method="post">
-        {% csrf_token %}
-        <div class="col-md-8 labelless-password-input-form">
-            {% if is_invite_template %}
-                <h2>{% translate "Set your password to access your profile and proposals" %}</h2>
-                <p>{{ phrases.base.password_reset_nearly_done }}</p>
-            {% else %}
-                <h2>{{ phrases.base.password_reset_heading }}</h2>
-                <p>{{ phrases.base.password_reset_nearly_done }}</p>
-            {% endif %}
-            {{ form }}
-            <button type="submit" class="btn btn-block btn-success">{{ phrases.base.save }}</button>
-        </div>
-    </form>
+  <form method="post">
+    {% csrf_token %}
+    <div class="col-md-8 labelless-password-input-form">
+      {% if is_invite_template %}
+        <h2>{% translate "Set your password to access your profile and proposals" %}</h2>
+        <p>{{ phrases.base.password_reset_nearly_done }}</p>
+      {% else %}
+        <h2>{{ phrases.base.password_reset_heading }}</h2>
+        <p>{{ phrases.base.password_reset_nearly_done }}</p>
+      {% endif %}
+      {{ form }}
+      <button type="submit" class="btn btn-block btn-success">{{ phrases.base.save }}</button>
+    </div>
+  </form>
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/reset.html
+++ b/src/pretalx/cfp/templates/cfp/event/reset.html
@@ -5,17 +5,17 @@
 {% block title %}{{ phrases.base.password_reset_heading }}{% endblock title %}
 
 {% block cfp_header %}
-    {% include "cfp/includes/forms_header.html" %}
+  {% include "cfp/includes/forms_header.html" %}
 {% endblock cfp_header %}
 
 {% block content %}
-    <div class="col-md-6 ml-auto mr-auto">
-        <h2 class="text-center">{{ phrases.base.password_reset_question }}</h2>
-        <p></p>
-        <form method="post">
-            {% csrf_token %}
-            {{ form }}
-            <button type="submit" class="btn btn-block btn-success">{{ phrases.base.password_reset_action }}</button>
-        </form>
-    </div>
+  <div class="col-md-6 ml-auto mr-auto">
+    <h2 class="text-center">{{ phrases.base.password_reset_question }}</h2>
+    <p></p>
+    <form method="post">
+      {% csrf_token %}
+      {{ form }}
+      <button type="submit" class="btn btn-block btn-success">{{ phrases.base.password_reset_action }}</button>
+    </form>
+  </div>
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/submission_base.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_base.html
@@ -10,81 +10,81 @@
 {% block title %}{% if submission_title %}{{ submission_title }}{% else %}{% translate "Create proposal" %}{% endif %} :: {{ request.event.name }}{% endblock title %}
 
 {% block cfp_header %}
-    {% include "cfp/includes/forms_header.html" %}
-    {% compress js %}
-        <script defer src="{% static "cfp/js/proposalTabTitles.js" %}"></script>
-    {% endcompress %}
-    {% block cfp_submission_header %}{% endblock cfp_submission_header %}
+  {% include "cfp/includes/forms_header.html" %}
+  {% compress js %}
+    <script defer src="{% static "cfp/js/proposalTabTitles.js" %}"></script>
+  {% endcompress %}
+  {% block cfp_submission_header %}{% endblock cfp_submission_header %}
 {% endblock cfp_header %}
 
 {% block content %}
-    <div id="submission-steps" class="stages">
-        {% for stp in cfp_flow %}
-            {% if stp.identifier != 'user' %}
-            <a {% if stp.resolved_url %}href="{{ stp.resolved_url }}"{% endif %} class="step step-{% if stp.is_before %}done{% elif stp.identifier == step.identifier %}current{% else %}tbd{% endif %}">
-                <div class="step-icon">
-                    <span class="fa {% if stp.is_before %}fa-check{% elif stp.icon %}fa-{{ stp.icon }}{% else %}fa-pencil{% endif %}"></span>
-                </div>
-                <div class="step-label">{{ stp.label }}</div>
-            </a>
-            {% endif %}
-        {% endfor %}
-        <div class="step step-tbd">
-            <div class="step-icon">
-                <span class="fa fa-check"></span>
-            </div>
-            <div class="step-label">{% translate "Done!" %}</div>
-        </div>
+  <div id="submission-steps" class="stages">
+    {% for stp in cfp_flow %}
+      {% if stp.identifier != 'user' %}
+        <a {% if stp.resolved_url %}href="{{ stp.resolved_url }}"{% endif %} class="step step-{% if stp.is_before %}done{% elif stp.identifier == step.identifier %}current{% else %}tbd{% endif %}">
+          <div class="step-icon">
+            <span class="fa {% if stp.is_before %}fa-check{% elif stp.icon %}fa-{{ stp.icon }}{% else %}fa-pencil{% endif %}"></span>
+          </div>
+          <div class="step-label">{{ stp.label }}</div>
+        </a>
+      {% endif %}
+    {% endfor %}
+    <div class="step step-tbd">
+      <div class="step-icon">
+        <span class="fa fa-check"></span>
+      </div>
+      <div class="step-label">{% translate "Done!" %}</div>
     </div>
-    {% block cfp_form %}
-        {% if request.user.is_authenticated %}
-        <form method="post"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
-            {% csrf_token %}
-            {{ wizard.management_form }}
-            <div class="d-flex align-items-start">
-                <h2>{% block submission_step_title %}{{ title|default:'' }}{% endblock submission_step_title %}</h2>
-                {% has_perm "orga.edit_cfp" request.user request.event as can_edit_cfp %}
-                {% if can_edit_cfp %}{% block orga_edit_link %}{% orga_edit_link request.event.cfp.urls.editor %}{% endblock %}{% endif %}
+  </div>
+  {% block cfp_form %}
+    {% if request.user.is_authenticated %}
+      <form method="post"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+        {% csrf_token %}
+        {{ wizard.management_form }}
+        <div class="d-flex align-items-start">
+          <h2>{% block submission_step_title %}{{ title|default:'' }}{% endblock submission_step_title %}</h2>
+          {% has_perm "orga.edit_cfp" request.user request.event as can_edit_cfp %}
+          {% if can_edit_cfp %}{% block orga_edit_link %}{% orga_edit_link request.event.cfp.urls.editor %}{% endblock %}{% endif %}
+        </div>
+        {% block submission_step_text %}<p>{{ text|rich_text }}</p>{% endblock %}
+        {% block inner %}
+          {{ form }}
+        {% endblock inner %}
+        {% block buttons %}
+          <div class="row flex-row-reverse">
+            <div class="col-md-3 flip ml-auto d-flex flex-column">
+              {% if request.GET.draft == "1" %}
+                <button type="submit" class="btn btn-block btn-success btn-lg" name="action" value="draft">
+                  {% translate "Save as draft" %}
+                </button>
+              {% else %}
+                <button type="submit" class="btn btn-block btn-success btn-lg" name="action" value="submit">
+                  {% if next_url %}
+                    {% translate "Continue" %} »
+                  {% else %}
+                    {% translate "Submit proposal!" %} »
+                  {% endif %}
+                </button>
+                <button type="submit" class="btn btn-link text-center" name="action" value="draft">
+                  {% translate "or save as draft for now" %}
+                  <i class="fa fa-question-circle" title="{% translate "You can save your proposal as a draft and submit it later. Organisers will not be able to see your proposal, though they will be able to send you reminder emails about the upcoming deadline." %}"></i>
+                </button>
+              {% endif %}
             </div>
-            {% block submission_step_text %}<p>{{ text|rich_text }}</p>{% endblock %}
-            {% block inner %}
-                {{ form }}
-            {% endblock inner %}
-            {% block buttons %}
-                <div class="row flex-row-reverse">
-                    <div class="col-md-3 flip ml-auto d-flex flex-column">
-                        {% if request.GET.draft == "1" %}
-                            <button type="submit" class="btn btn-block btn-success btn-lg" name="action" value="draft">
-                                {% translate "Save as draft" %}
-                            </button>
-                        {% else %}
-                            <button type="submit" class="btn btn-block btn-success btn-lg" name="action" value="submit">
-                                {% if next_url %}
-                                    {% translate "Continue" %} »
-                                {% else %}
-                                    {% translate "Submit proposal!" %} »
-                                {% endif %}
-                            </button>
-                            <button type="submit" class="btn btn-link text-center" name="action" value="draft">
-                                {% translate "or save as draft for now" %}
-                                <i class="fa fa-question-circle" title="{% translate "You can save your proposal as a draft and submit it later. Organisers will not be able to see your proposal, though they will be able to send you reminder emails about the upcoming deadline." %}"></i>
-                            </button>
-                        {% endif %}
-                    </div>
-                    <div class="col-md-3">
-                        {% if prev_url %}
-                            <a href="{{ prev_url }}" class="btn btn-block btn-info btn-lg">
-                                « {{ phrases.base.back_button }}
-                            </a>
-                        {% endif %}
-                    </div>
-                </div>
-            {% endblock buttons %}
-        </form>
-        {% else %}
-            <h2>{{ _('You need to be logged in to submit a proposal') }}</h2>
-            <p>{{ _('Please log in or create an account to submit a proposal. This enables us to contact you and allows you to edit your proposal or check its status at any time.') }}</p>
-            {% include "common/auth.html" with form=form no_form=True no_buttons=True next_url=request.get_full_path %}
-        {% endif %}
-    {% endblock cfp_form %}
+            <div class="col-md-3">
+              {% if prev_url %}
+                <a href="{{ prev_url }}" class="btn btn-block btn-info btn-lg">
+                  « {{ phrases.base.back_button }}
+                </a>
+              {% endif %}
+            </div>
+          </div>
+        {% endblock buttons %}
+      </form>
+    {% else %}
+      <h2>{{ _('You need to be logged in to submit a proposal') }}</h2>
+      <p>{{ _('Please log in or create an account to submit a proposal. This enables us to contact you and allows you to edit your proposal or check its status at any time.') }}</p>
+      {% include "common/auth.html" with form=form no_form=True no_buttons=True next_url=request.get_full_path %}
+    {% endif %}
+  {% endblock cfp_form %}
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/submission_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_profile.html
@@ -4,26 +4,26 @@
 {% load orga_edit_link %}
 
 {% block orga_edit_link %}
-    {% orga_edit_link request.event.cfp.urls.text "information" %}
+  {% orga_edit_link request.event.cfp.urls.text "information" %}
 {% endblock orga_edit_link %}
 
 {% block inner %}
 
-    {{ form.name.as_field_group }}
-    {% if form.biography %}
-        {{ form.biography.as_field_group }}
-    {% endif %}
+  {{ form.name.as_field_group }}
+  {% if form.biography %}
+    {{ form.biography.as_field_group }}
+  {% endif %}
 
-    {% if form.avatar or form.get_gravatar %}
-        {% include "common/avatar.html" with user=user form=form %}
-    {% endif %}
-    {% if form.avatar_source %}{{ form.avatar_source.as_field_group }}{% endif %}
-    {% if form.avatar_license %}{{ form.avatar_license.as_field_group }}{% endif %}
+  {% if form.avatar or form.get_gravatar %}
+    {% include "common/avatar.html" with user=user form=form %}
+  {% endif %}
+  {% if form.avatar_source %}{{ form.avatar_source.as_field_group }}{% endif %}
+  {% if form.avatar_license %}{{ form.avatar_license.as_field_group }}{% endif %}
 
-    {% if form.availabilities %}
-        {% include "common/availabilities.html" %}
+  {% if form.availabilities %}
+    {% include "common/availabilities.html" %}
 
-        {{ form.availabilities.as_field_group }}
-    {% endif %}
+    {{ form.availabilities.as_field_group }}
+  {% endif %}
 
 {% endblock inner %}

--- a/src/pretalx/cfp/templates/cfp/event/submission_questions.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_questions.html
@@ -4,24 +4,24 @@
 {% load orga_edit_link %}
 
 {% block orga_edit_link %}
-    {% orga_edit_link request.event.cfp.urls.questions %}
+  {% orga_edit_link request.event.cfp.urls.questions %}
 {% endblock orga_edit_link %}
 
 {% block inner %}
-    {% if form.submission_fields %}
-        {% if form.speaker_fields and form.submission_fields %}
-            <h4>{% translate "… about your proposal:" %}</h4>
-        {% endif %}
-        {% for field in form.submission_fields %}
-            {{ field.as_field_group }}
-        {% endfor %}
+  {% if form.submission_fields %}
+    {% if form.speaker_fields and form.submission_fields %}
+      <h4>{% translate "… about your proposal:" %}</h4>
     {% endif %}
-    {% if form.speaker_fields %}
-        {% if form.speaker_fields and form.submission_fields %}
-            <h4>{% translate "… about yourself:" %}</h4>
-        {% endif %}
-        {% for field in form.speaker_fields %}
-            {{ field.as_field_group }}
-        {% endfor %}
+    {% for field in form.submission_fields %}
+      {{ field.as_field_group }}
+    {% endfor %}
+  {% endif %}
+  {% if form.speaker_fields %}
+    {% if form.speaker_fields and form.submission_fields %}
+      <h4>{% translate "… about yourself:" %}</h4>
     {% endif %}
+    {% for field in form.speaker_fields %}
+      {{ field.as_field_group }}
+    {% endfor %}
+  {% endif %}
 {% endblock inner %}

--- a/src/pretalx/cfp/templates/cfp/event/submission_user.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_user.html
@@ -4,25 +4,25 @@
 {% load rich_text %}
 
 {% block submission_step_title %}
-    {% if request.GET.draft == "1" %}
-        {% translate "Sign in or register to save your draft" %}
-    {% else %}
-        {{ title }}
-    {% endif %}
+  {% if request.GET.draft == "1" %}
+    {% translate "Sign in or register to save your draft" %}
+  {% else %}
+    {{ title }}
+  {% endif %}
 {% endblock submission_step_title %}
 
 {% block submission_step_text %}
-    <p>
-        {% if request.GET.draft == "1" %}
-            {% blocktranslate trimmed %}
-                Organisers will not be able to see your draft or your email address. They will be able to send you reminders about your pending proposal draft closer to the deadline.
-            {% endblocktranslate %}
-        {% else %}
-            {{ text|rich_text }}
-        {% endif %}
-    </p>
+  <p>
+    {% if request.GET.draft == "1" %}
+      {% blocktranslate trimmed %}
+        Organisers will not be able to see your draft or your email address. They will be able to send you reminders about your pending proposal draft closer to the deadline.
+      {% endblocktranslate %}
+    {% else %}
+      {{ text|rich_text }}
+    {% endif %}
+  </p>
 {% endblock submission_step_text %}
 
 {% block inner %}
-    {% include "common/auth.html" with form=form no_form=True no_buttons=True %}
+  {% include "common/auth.html" with form=form no_form=True no_buttons=True %}
 {% endblock inner %}

--- a/src/pretalx/cfp/templates/cfp/event/user_mails.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_mails.html
@@ -4,11 +4,11 @@
 {% block title %}{% translate "Your Emails" %} :: {% endblock title %}
 
 {% block content %}
-    <h2>{% translate "Your Emails" %}</h2>
-    <p>
-        {% translate "These are emails the organisers sent you, so you should be able to find them in your email inbox, but this page serves as a helper in case your email address was unavailable or the emails got lost in some way." %}
-    </p>
+  <h2>{% translate "Your Emails" %}</h2>
+  <p>
+    {% translate "These are emails the organisers sent you, so you should be able to find them in your email inbox, but this page serves as a helper in case your email address was unavailable or the emails got lost in some way." %}
+  </p>
 
-    {% include "common/mail_log.html" %}
+  {% include "common/mail_log.html" %}
 
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/user_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_profile.html
@@ -7,107 +7,107 @@
 {% block title %}{% translate "Your Profile" %} :: {% endblock title %}
 
 {% block cfp_header %}
-    {% include "cfp/includes/forms_header.html" %}
-    {% compress js %}
-        <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
-        <script defer src="{% static 'common/js/base.js' %}"></script>
-        <script defer src="{% static 'common/js/password_strength.js' %}"></script>
-    {% endcompress %}
+  {% include "cfp/includes/forms_header.html" %}
+  {% compress js %}
+    <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
+    <script defer src="{% static 'common/js/base.js' %}"></script>
+    <script defer src="{% static 'common/js/password_strength.js' %}"></script>
+  {% endcompress %}
 {% endblock cfp_header %}
 
 {% block content %}
-    {% html_signal "pretalx.cfp.signals.html_above_profile_page" sender=request.event request=request %}
+  {% html_signal "pretalx.cfp.signals.html_above_profile_page" sender=request.event request=request %}
 
-    <h2>{% translate "Your Profile" %}</h2>
-    <p>
-        {% translate "This data will be displayed publicly if your proposal is accepted. It is also visible to reviewers." %}
-    </p>
-    <form method="post" enctype="multipart/form-data" class="speaker-profile-form">
-        {% csrf_token %}
-        {% include "common/forms/errors.html" with form=profile_form %}
+  <h2>{% translate "Your Profile" %}</h2>
+  <p>
+    {% translate "This data will be displayed publicly if your proposal is accepted. It is also visible to reviewers." %}
+  </p>
+  <form method="post" enctype="multipart/form-data" class="speaker-profile-form">
+    {% csrf_token %}
+    {% include "common/forms/errors.html" with form=profile_form %}
 
-        {{ profile_form.name.as_field_group }}
-        {% if profile_form.biography %}
-            {{ profile_form.biography.as_field_group }}
-        {% endif %}
-        {% if request.event.cfp.request_avatar %}
-            {% include "common/avatar.html" with user=request.user form=profile_form %}
-        {% endif %}
-        {% if profile_form.avatar_source %}{{ profile_form.avatar_source.as_field_group }}{% endif %}
-        {% if profile_form.avatar_license %}{{ profile_form.avatar_license.as_field_group }}{% endif %}
-        {% if profile_form.availabilities %}
-            {% include "common/availabilities.html" %}
-            {{ profile_form.availabilities.as_field_group }}
-        {% endif %}
-        <div class="row">
-            <div class="col-md-4 flip ml-auto">
-                <input type="hidden" name="form" value="profile">
-                <button type="submit" class="btn btn-block btn-success btn-lg">
-                    {{ phrases.base.save }}
-                </button>
-            </div>
-        </div>
-    </form>
-
-    {% if questions_exist %}
-        <h2>{% translate "We have some questions" %}</h2>
-        <form method="post" enctype="multipart/form-data">
-            {% csrf_token %}
-            {{ questions_form }}
-            <div class="row">
-                <div class="col-md-4 flip ml-auto">
-                    <input type="hidden" name="form" value="questions">
-                    <button type="submit" class="btn btn-block btn-success btn-lg">
-                        {{ phrases.base.save }}
-                    </button>
-                </div>
-            </div>
-        </form>
+    {{ profile_form.name.as_field_group }}
+    {% if profile_form.biography %}
+      {{ profile_form.biography.as_field_group }}
     {% endif %}
+    {% if request.event.cfp.request_avatar %}
+      {% include "common/avatar.html" with user=request.user form=profile_form %}
+    {% endif %}
+    {% if profile_form.avatar_source %}{{ profile_form.avatar_source.as_field_group }}{% endif %}
+    {% if profile_form.avatar_license %}{{ profile_form.avatar_license.as_field_group }}{% endif %}
+    {% if profile_form.availabilities %}
+      {% include "common/availabilities.html" %}
+      {{ profile_form.availabilities.as_field_group }}
+    {% endif %}
+    <div class="row">
+      <div class="col-md-4 flip ml-auto">
+        <input type="hidden" name="form" value="profile">
+        <button type="submit" class="btn btn-block btn-success btn-lg">
+          {{ phrases.base.save }}
+        </button>
+      </div>
+    </div>
+  </form>
 
-    <h2>{% translate "Your Account" %}</h2>
-    <p>{% translate "You can change your log in data here." %}</p>
-    <form method="post" class="form password-input-form">
-        {% csrf_token %}
-        {{ login_form.media }}
-        {{ login_form.old_password.as_field_group }}
-        {{ login_form.email.as_field_group }}
-        {{ login_form.password.as_field_group }}
-        {{ login_form.password_repeat.as_field_group }}
-        <div class="row">
-            <div class="col-md-4 flip ml-auto">
-                <input type="hidden" name="form" value="login">
-                <button type="submit" class="btn btn-block btn-success btn-lg">
-                    {{ phrases.base.save }}
-                </button>
-            </div>
+  {% if questions_exist %}
+    <h2>{% translate "We have some questions" %}</h2>
+    <form method="post" enctype="multipart/form-data">
+      {% csrf_token %}
+      {{ questions_form }}
+      <div class="row">
+        <div class="col-md-4 flip ml-auto">
+          <input type="hidden" name="form" value="questions">
+          <button type="submit" class="btn btn-block btn-success btn-lg">
+            {{ phrases.base.save }}
+          </button>
         </div>
+      </div>
     </form>
+  {% endif %}
 
-    {% include "common/user_api_token.html" %}
+  <h2>{% translate "Your Account" %}</h2>
+  <p>{% translate "You can change your log in data here." %}</p>
+  <form method="post" class="form password-input-form">
+    {% csrf_token %}
+    {{ login_form.media }}
+    {{ login_form.old_password.as_field_group }}
+    {{ login_form.email.as_field_group }}
+    {{ login_form.password.as_field_group }}
+    {{ login_form.password_repeat.as_field_group }}
+    <div class="row">
+      <div class="col-md-4 flip ml-auto">
+        <input type="hidden" name="form" value="login">
+        <button type="submit" class="btn btn-block btn-success btn-lg">
+          {{ phrases.base.save }}
+        </button>
+      </div>
+    </div>
+  </form>
 
-    <div>&nbsp;</div>
-    <h3>{% translate "Account deletion" %}</h3>
-    <form action="{{ request.event.urls.user_delete }}" method="post" class="form">
-        {% csrf_token %}
-        <div class="alert alert-danger">
-            <div>
-                {% translate "You can delete your account here – all names, emails, and other personal information will be overwritten. <strong>This action is irreversible.</strong>" %}
-            </div>
-        </div>
-        <div class="form-group"{% if not "really" in request.GET %} style="visibility:hidden;"{% endif %}>
-            <input type="checkbox" name="really" id="really">
-            <label class="form-control-label" for="really">
-                {% translate "I really do want to delete my account, losing access to my proposals and sessions, and overriding my public and private data." %}
-            </label>
-        </div>
-        <div class="row">
-            <div class="col-md-4 flip ml-auto">
-                <input type="hidden" name="form" value="">
-                <button type="submit" class="btn btn-block btn-danger btn-lg">
-                    {% translate "Delete my account" %}
-                </button>
-            </div>
-        </div>
-    </form>
+  {% include "common/user_api_token.html" %}
+
+  <div>&nbsp;</div>
+  <h3>{% translate "Account deletion" %}</h3>
+  <form action="{{ request.event.urls.user_delete }}" method="post" class="form">
+    {% csrf_token %}
+    <div class="alert alert-danger">
+      <div>
+        {% translate "You can delete your account here – all names, emails, and other personal information will be overwritten. <strong>This action is irreversible.</strong>" %}
+      </div>
+    </div>
+    <div class="form-group"{% if not "really" in request.GET %} style="visibility:hidden;"{% endif %}>
+      <input type="checkbox" name="really" id="really">
+      <label class="form-control-label" for="really">
+        {% translate "I really do want to delete my account, losing access to my proposals and sessions, and overriding my public and private data." %}
+      </label>
+    </div>
+    <div class="row">
+      <div class="col-md-4 flip ml-auto">
+        <input type="hidden" name="form" value="">
+        <button type="submit" class="btn btn-block btn-danger btn-lg">
+          {% translate "Delete my account" %}
+        </button>
+      </div>
+    </div>
+  </form>
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/user_submission_confirm.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submission_confirm.html
@@ -7,51 +7,51 @@
 {% block title %}{{ submission.title }} :: {% endblock title %}
 
 {% block cfp_header %}
-    {% include "cfp/includes/forms_header.html" %}
+  {% include "cfp/includes/forms_header.html" %}
 {% endblock cfp_header %}
 
 {% block content %}
-    <div class="col-md-10 ml-auto mr-auto">
+  <div class="col-md-10 ml-auto mr-auto">
 
-        {% include "cfp/includes/user_submission_header.html" %}
+    {% include "cfp/includes/user_submission_header.html" %}
 
-        <div class="text">
-            {% blocktranslate trimmed %}
-                Congratulations on your acceptance!
-            {% endblocktranslate %}
-            {% if form.availabilities %}
-                {% blocktranslate trimmed %}
-                    Please provide us with your available hours during the event, so that we can schedule your event accordingly:
-                {% endblocktranslate %}
-                <p></p>
-            {% endif %}
-        </div>
-        <form method="post" class="availability-form">
-            {% csrf_token %}
-            {% if form.availabilities %}
-
-                {% include "common/availabilities.html" %}
-                {{ form.availabilities.as_field_group }}
-
-                <div class="text-muted">{{ form.availabilities.help_text }}</div>
-            {% endif %}
-            <p></p>
-            {% blocktranslate trimmed %}
-                By confirming your proposal, you agree that you are able and willing to participate in this event and
-                present the content of this proposal.
-                The proposal data, such as title, abstract, description, and any uploads you provided, can be made
-                publicly available once the proposal is confirmed.
-            {% endblocktranslate %}
-            <p></p>
-            <div class="submit-group">
-                <span>
-                    <a href="{{ submission.urls.user_base }}" class="btn btn-lg btn-info">{{ phrases.base.back_button }}</a>
-                    <a href="{{ submission.urls.withdraw }}" class="btn btn-lg btn-danger">{% translate "Withdraw" %}</a>
-                </span>
-                <span>
-                    <button type="submit" class="btn btn-lg btn-success">{% translate "Confirm" %}</button>
-                </span>
-            </div>
-        </form>
+    <div class="text">
+      {% blocktranslate trimmed %}
+        Congratulations on your acceptance!
+      {% endblocktranslate %}
+      {% if form.availabilities %}
+        {% blocktranslate trimmed %}
+          Please provide us with your available hours during the event, so that we can schedule your event accordingly:
+        {% endblocktranslate %}
+        <p></p>
+      {% endif %}
     </div>
+    <form method="post" class="availability-form">
+      {% csrf_token %}
+      {% if form.availabilities %}
+
+        {% include "common/availabilities.html" %}
+        {{ form.availabilities.as_field_group }}
+
+        <div class="text-muted">{{ form.availabilities.help_text }}</div>
+      {% endif %}
+      <p></p>
+      {% blocktranslate trimmed %}
+        By confirming your proposal, you agree that you are able and willing to participate in this event and
+        present the content of this proposal.
+        The proposal data, such as title, abstract, description, and any uploads you provided, can be made
+        publicly available once the proposal is confirmed.
+      {% endblocktranslate %}
+      <p></p>
+      <div class="submit-group">
+        <span>
+          <a href="{{ submission.urls.user_base }}" class="btn btn-lg btn-info">{{ phrases.base.back_button }}</a>
+          <a href="{{ submission.urls.withdraw }}" class="btn btn-lg btn-danger">{% translate "Withdraw" %}</a>
+        </span>
+        <span>
+          <button type="submit" class="btn btn-lg btn-success">{% translate "Confirm" %}</button>
+        </span>
+      </div>
+    </form>
+  </div>
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/user_submission_confirm_error.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submission_confirm_error.html
@@ -7,10 +7,10 @@
 {% block title %}{% translate "Proposal not found" %} :: {% endblock title %}
 
 {% block content %}
-    <div class="col-md-10 ml-auto mr-auto">
-        <h2>{% translate "Proposal not found" %}</h2>
-        <p>
-            {% translate "The proposal you’re trying to confirm either does not exist or does not belong to the account you’re currently logged in with. Try logging in with a different account, or contact the event organisers for further information." %}
-        </p>
-    </div>
+  <div class="col-md-10 ml-auto mr-auto">
+    <h2>{% translate "Proposal not found" %}</h2>
+    <p>
+      {% translate "The proposal you’re trying to confirm either does not exist or does not belong to the account you’re currently logged in with. Try logging in with a different account, or contact the event organisers for further information." %}
+    </p>
+  </div>
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/user_submission_discard.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submission_discard.html
@@ -7,21 +7,21 @@
 {% block title %}{{ submission.title }} :: {% endblock title %}
 
 {% block content %}
-    <div class="col-md-10 ml-auto mr-auto">
+  <div class="col-md-10 ml-auto mr-auto">
 
-        {% include "cfp/includes/user_submission_header.html" %}
+    {% include "cfp/includes/user_submission_header.html" %}
 
-        <div class="alert alert-danger">
-            {% blocktranslate trimmed %}
-                Do you really want to discard your draft proposal? All data will be lost.
-            {% endblocktranslate %}
-        </div>
-        <form method="post">
-            {% csrf_token %}
-            <div class="submit-group">
-                <a href="{{ submission.urls.user_base }}" class="btn btn-lg btn-info">{{ phrases.base.back_button }}</a>
-                <button type="submit" class="btn btn-lg btn-danger">{{ phrases.base.delete_button }}</button>
-            </div>
-        </form>
+    <div class="alert alert-danger">
+      {% blocktranslate trimmed %}
+        Do you really want to discard your draft proposal? All data will be lost.
+      {% endblocktranslate %}
     </div>
+    <form method="post">
+      {% csrf_token %}
+      <div class="submit-group">
+        <a href="{{ submission.urls.user_base }}" class="btn btn-lg btn-info">{{ phrases.base.back_button }}</a>
+        <button type="submit" class="btn btn-lg btn-danger">{{ phrases.base.delete_button }}</button>
+      </div>
+    </form>
+  </div>
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/user_submission_edit.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submission_edit.html
@@ -11,145 +11,145 @@
 {% block title %}{{ submission.title }} :: {% endblock title %}
 
 {% block cfp_header %}
-    {% include "cfp/includes/forms_header.html" %}
-    {% compress js %}
-        <script defer src="{% static "js/jquery.js" %}"></script>
-        <script defer src="{% static "js/jquery.formset.js" %}"></script>
-        <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
-    {% endcompress %}
+  {% include "cfp/includes/forms_header.html" %}
+  {% compress js %}
+    <script defer src="{% static "js/jquery.js" %}"></script>
+    <script defer src="{% static "js/jquery.formset.js" %}"></script>
+    <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
+  {% endcompress %}
 {% endblock cfp_header %}
 
 {% block content %}
-    {% has_perm "cfp.add_speakers" request.user submission as can_invite_speakers %}
+  {% has_perm "cfp.add_speakers" request.user submission as can_invite_speakers %}
 
-    {% include "cfp/includes/user_submission_header.html" %}
+  {% include "cfp/includes/user_submission_header.html" %}
 
-    <p>
-        {% if submission.state == "accepted" %}
-            <a href="{{ submission.urls.confirm }}" class="btn btn-sm btn-success">
-                <i class="fa fa-check"></i> {% translate "Confirm your attendance" %}
-            </a>
-        {% elif submission.state == "confirmed" and request.event|get_feature_flag:"use_feedback" %}
-            <a href="{{ submission.urls.feedback }}">
-                {% if submission.does_accept_feedback %}
-                    {% translate "Audience feedback" %}
-                {% else %}
-                    {% translate "Attendees can leave feedback here after your session has taken place." %}
-                {% endif %}
-            </a>
+  <p>
+    {% if submission.state == "accepted" %}
+      <a href="{{ submission.urls.confirm }}" class="btn btn-sm btn-success">
+        <i class="fa fa-check"></i> {% translate "Confirm your attendance" %}
+      </a>
+    {% elif submission.state == "confirmed" and request.event|get_feature_flag:"use_feedback" %}
+      <a href="{{ submission.urls.feedback }}">
+        {% if submission.does_accept_feedback %}
+          {% translate "Audience feedback" %}
+        {% else %}
+          {% translate "Attendees can leave feedback here after your session has taken place." %}
         {% endif %}
-    </p>
-    <h5>
-        <form class="add-speaker" action="{{ submission.urls.invite }}">
-            <div class="form-group form-inline flex-row">
-                <div class="mt-1">
-                    {% if submission.state == "confirmed" %}
-                        {% blocktranslate trimmed count count=submission.speakers.count %}Speaker{% plural %}Speakers{% endblocktranslate %}:
-                    {% else %}
-                        {% blocktranslate trimmed count count=submission.speakers.count %}Submitter{% plural %}Submitters{% endblocktranslate %}:
-                    {% endif %}
-                    {{ submission.display_speaker_names }}{% if can_invite_speakers %},
-                        </div>
-                        <div class="input-group pl-2 w-auto">
-                            <input name="email" class="form-control form-control-sm" placeholder="mail@example.org">
-                            <span class="input-group-btn input-group-append">
-                                <button class="btn btn-success btn-sm">
-                                    <i class="fa fa-plus"></i>
-                                </button>
-                            </span>
-                        </div>
-                    {% endif %}
-                </div>
-            </form>
-        </h5>
-        <form method="post" enctype="multipart/form-data">
-            {% include "common/forms/errors.html" %}
-            {% include "common/forms/errors.html" with form=qform %}
-            {% csrf_token %}
-            {{ form }}
-            {{ qform }}
-            {% if can_edit or form.instance.resources.count %}
-                {% include "cfp/includes/submission_resources_form.html" %}
-            {% endif %}
-            {% if can_edit %}
-                <div class="row mt-4">
-                    {% if submission.state == "draft" %}
-                        <div class="col-md-6 flip ml-auto">
-                            <div class="d-flex align-items-start">
-                                <button type="submit" class="btn btn-block btn-outline-success btn-lg" name="action" value="submit">
-                                    {% translate "Save draft" %}
-                                </button>
-                                <button type="submit" class="btn btn-block btn-success btn-lg mt-0 ml-2" name="action" value="dedraft">
-                                    {% translate "Submit proposal" %}
-                                </button>
-                            </div>
-                        </div>
-                    {% else %}
-                        <div class="col-md-3 flip ml-auto">
-                            <button type="submit" class="btn btn-block btn-success btn-lg" name="action" value="submit">
-                                {{ phrases.base.save }}
-                            </button>
-                        </div>
-                    {% endif %}
-                </div>
-            {% endif %}
-        </form>
-
-        {% if submission.review_code and request.event|get_feature_flag:"submission_public_review" %}
-            <h3 id="share-proposal">{% translate "Share proposal" %}</h3>
-            <p>
-                {% blocktranslate trimmed %}
-                    If you need a review from a colleague or a friend here’s a link that you can send out for viewing your proposal:
-                {% endblocktranslate %}
-                <a target="_blank" rel="noopener" href="{{ submission.urls.review.full }}">{{ submission.urls.review.full }}</a>
-            </p>
-        {% endif %}
-
-        {% if submission.state == "submitted" or submission.state == "accepted" %}
-            <h3>{% translate "Withdraw proposal" %}</h3>
-            <p>
-                {% blocktranslate trimmed %}
-                    You can withdraw your proposal from the selection process here. You cannot undo this - if you are
-                    just uncertain if you can or should hold your session, please contact the organiser instead.
-                {% endblocktranslate %}
-            </p>
-            <div class="row">
-                <div class="col-md-3 flip ml-auto">
-                    <a href="{{ submission.urls.withdraw }}"
-                       class="btn float-right btn-danger btn-block">
-                        {% translate "Withdraw" %}
-                    </a>
-                </div>
+      </a>
+    {% endif %}
+  </p>
+  <h5>
+    <form class="add-speaker" action="{{ submission.urls.invite }}">
+      <div class="form-group form-inline flex-row">
+        <div class="mt-1">
+          {% if submission.state == "confirmed" %}
+            {% blocktranslate trimmed count count=submission.speakers.count %}Speaker{% plural %}Speakers{% endblocktranslate %}:
+          {% else %}
+            {% blocktranslate trimmed count count=submission.speakers.count %}Submitter{% plural %}Submitters{% endblocktranslate %}:
+          {% endif %}
+          {{ submission.display_speaker_names }}{% if can_invite_speakers %},
             </div>
-        {% elif submission.state == "draft" %}
-            <h3>{% translate "Discard draft proposal" %}</h3>
-            <p>
-                {% blocktranslate trimmed %}
-                    You can discard your draft proposal here. You cannot undo this - if you are
-                    just uncertain if you can or should submit your proposal, please contact the organiser instead.
-                {% endblocktranslate %}
-            </p>
-            <div class="row">
-                <div class="col-md-3 flip ml-auto">
-                    <a href="{{ submission.urls.discard }}"
-                       class="btn float-right btn-danger btn-block">
-                        {% translate "Discard" %}
-                    </a>
-                </div>
+            <div class="input-group pl-2 w-auto">
+              <input name="email" class="form-control form-control-sm" placeholder="mail@example.org">
+              <span class="input-group-btn input-group-append">
+                <button class="btn btn-success btn-sm">
+                  <i class="fa fa-plus"></i>
+                </button>
+              </span>
             </div>
-        {% elif submission.state == "confirmed" %}
-            <h3>{% translate "Cancel proposal" %}</h3>
-            <p>
-                {% blocktranslate trimmed %}
-                    As your proposal has been accepted already, please contact the event’s organising team to cancel
-                    it. The best way to reach out would be an answer to your acceptance mail.
-                {% endblocktranslate %}
-            </p>
-        {% endif %}
-
-        <div class="user-logs">
-
-            {% include "common/logs.html" with entries=submission.logged_actions hide_orga="true" %}
-
+          {% endif %}
         </div>
+      </form>
+    </h5>
+    <form method="post" enctype="multipart/form-data">
+      {% include "common/forms/errors.html" %}
+      {% include "common/forms/errors.html" with form=qform %}
+      {% csrf_token %}
+      {{ form }}
+      {{ qform }}
+      {% if can_edit or form.instance.resources.count %}
+        {% include "cfp/includes/submission_resources_form.html" %}
+      {% endif %}
+      {% if can_edit %}
+        <div class="row mt-4">
+          {% if submission.state == "draft" %}
+            <div class="col-md-6 flip ml-auto">
+              <div class="d-flex align-items-start">
+                <button type="submit" class="btn btn-block btn-outline-success btn-lg" name="action" value="submit">
+                  {% translate "Save draft" %}
+                </button>
+                <button type="submit" class="btn btn-block btn-success btn-lg mt-0 ml-2" name="action" value="dedraft">
+                  {% translate "Submit proposal" %}
+                </button>
+              </div>
+            </div>
+          {% else %}
+            <div class="col-md-3 flip ml-auto">
+              <button type="submit" class="btn btn-block btn-success btn-lg" name="action" value="submit">
+                {{ phrases.base.save }}
+              </button>
+            </div>
+          {% endif %}
+        </div>
+      {% endif %}
+    </form>
+
+    {% if submission.review_code and request.event|get_feature_flag:"submission_public_review" %}
+      <h3 id="share-proposal">{% translate "Share proposal" %}</h3>
+      <p>
+        {% blocktranslate trimmed %}
+          If you need a review from a colleague or a friend here’s a link that you can send out for viewing your proposal:
+        {% endblocktranslate %}
+        <a target="_blank" rel="noopener" href="{{ submission.urls.review.full }}">{{ submission.urls.review.full }}</a>
+      </p>
+    {% endif %}
+
+    {% if submission.state == "submitted" or submission.state == "accepted" %}
+      <h3>{% translate "Withdraw proposal" %}</h3>
+      <p>
+        {% blocktranslate trimmed %}
+          You can withdraw your proposal from the selection process here. You cannot undo this - if you are
+          just uncertain if you can or should hold your session, please contact the organiser instead.
+        {% endblocktranslate %}
+      </p>
+      <div class="row">
+        <div class="col-md-3 flip ml-auto">
+          <a href="{{ submission.urls.withdraw }}"
+             class="btn float-right btn-danger btn-block">
+            {% translate "Withdraw" %}
+          </a>
+        </div>
+      </div>
+    {% elif submission.state == "draft" %}
+      <h3>{% translate "Discard draft proposal" %}</h3>
+      <p>
+        {% blocktranslate trimmed %}
+          You can discard your draft proposal here. You cannot undo this - if you are
+          just uncertain if you can or should submit your proposal, please contact the organiser instead.
+        {% endblocktranslate %}
+      </p>
+      <div class="row">
+        <div class="col-md-3 flip ml-auto">
+          <a href="{{ submission.urls.discard }}"
+             class="btn float-right btn-danger btn-block">
+            {% translate "Discard" %}
+          </a>
+        </div>
+      </div>
+    {% elif submission.state == "confirmed" %}
+      <h3>{% translate "Cancel proposal" %}</h3>
+      <p>
+        {% blocktranslate trimmed %}
+          As your proposal has been accepted already, please contact the event’s organising team to cancel
+          it. The best way to reach out would be an answer to your acceptance mail.
+        {% endblocktranslate %}
+      </p>
+    {% endif %}
+
+    <div class="user-logs">
+
+      {% include "common/logs.html" with entries=submission.logged_actions hide_orga="true" %}
+
+    </div>
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/user_submission_invitation.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submission_invitation.html
@@ -8,36 +8,36 @@
 {% block title %}{{ submission.title }} :: {% endblock title %}
 
 {% block cfp_header %}
-    {% include "cfp/includes/forms_header.html" %}
-    {% compress js %}
-        <script defer src="{% static "common/js/copy.js" %}"></script>
-    {% endcompress %}
+  {% include "cfp/includes/forms_header.html" %}
+  {% compress js %}
+    <script defer src="{% static "common/js/copy.js" %}"></script>
+  {% endcompress %}
 {% endblock cfp_header %}
 
 {% block content %}
 
-    {% include "cfp/includes/user_submission_header.html" %}
+  {% include "cfp/includes/user_submission_header.html" %}
 
-    <div class="alert alert-info offset-md-3" role="alert"><div>
-        {% blocktranslate trimmed %}
-            Invite another speaker to your proposal here. Instead of letting us send an email,
-            (which might get caught by spam filters) you can also give them this link:
-        {% endblocktranslate %}
-        <br>
-        {{ submission.urls.accept_invitation.full|copyable }}
-    </div></div>
-    <form method="post">
-        {% csrf_token %}
-        {{ form }}
-        <div class="row">
-            <div class="w-25 flip ml-auto url-links">
-                <a class="btn btn-block btn-info btn-lg" href="{{ submission.urls.user_base }}">
-                    {{ phrases.base.cancel }}
-                </a>
-                <button type="submit" class="btn btn-block btn-success btn-lg">
-                    {{ phrases.base.send }}
-                </button>
-            </div>
-        </div>
-    </form>
+  <div class="alert alert-info offset-md-3" role="alert"><div>
+    {% blocktranslate trimmed %}
+      Invite another speaker to your proposal here. Instead of letting us send an email,
+      (which might get caught by spam filters) you can also give them this link:
+    {% endblocktranslate %}
+    <br>
+    {{ submission.urls.accept_invitation.full|copyable }}
+  </div></div>
+  <form method="post">
+    {% csrf_token %}
+    {{ form }}
+    <div class="row">
+      <div class="w-25 flip ml-auto url-links">
+        <a class="btn btn-block btn-info btn-lg" href="{{ submission.urls.user_base }}">
+          {{ phrases.base.cancel }}
+        </a>
+        <button type="submit" class="btn btn-block btn-success btn-lg">
+          {{ phrases.base.send }}
+        </button>
+      </div>
+    </div>
+  </form>
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/user_submission_withdraw.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submission_withdraw.html
@@ -6,25 +6,25 @@
 
 {% block content %}
 
-    {% include "cfp/includes/user_submission_header.html" %}
+  {% include "cfp/includes/user_submission_header.html" %}
 
-    <form method="post">
-        {% csrf_token %}
-        <h3>{% translate "Withdraw proposal" %}</h3>
-        <div class="alert alert-danger">
-            {% blocktranslate trimmed %}
-                Do you really want to withdraw your proposal?
-            {% endblocktranslate %}
-        </div>
-        <p>
-            <button type="submit"
-                    class="btn float-right btn-danger">
-                {% translate "Withdraw" %}
-            </button>
-            <a href="{{ submission.urls.user_base }}" class="btn float-right btn-info">
-                {{ phrases.base.back_button }}
-            </a>
-            {% translate "You will not be able to revert this action." %}
-        </p>
-    </form>
+  <form method="post">
+    {% csrf_token %}
+    <h3>{% translate "Withdraw proposal" %}</h3>
+    <div class="alert alert-danger">
+      {% blocktranslate trimmed %}
+        Do you really want to withdraw your proposal?
+      {% endblocktranslate %}
+    </div>
+    <p>
+      <button type="submit"
+              class="btn float-right btn-danger">
+        {% translate "Withdraw" %}
+      </button>
+      <a href="{{ submission.urls.user_base }}" class="btn float-right btn-info">
+        {{ phrases.base.back_button }}
+      </a>
+      {% translate "You will not be able to revert this action." %}
+    </p>
+  </form>
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/event/user_submissions.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submissions.html
@@ -12,156 +12,156 @@
 {% block title %}{% translate "Your proposals" %} :: {% endblock title %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/copy.js" %}"></script>
-        <script defer src="{% static "vendored/moment-with-locales.js" %}"></script>
-        <script defer src="{% static "vendored/moment-timezone-with-data-10-year-range.js" %}"></script>
-        <script defer src="{% static "agenda/js/datetime-local.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/copy.js" %}"></script>
+    <script defer src="{% static "vendored/moment-with-locales.js" %}"></script>
+    <script defer src="{% static "vendored/moment-timezone-with-data-10-year-range.js" %}"></script>
+    <script defer src="{% static "agenda/js/datetime-local.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block content %}
-    {% if information %}
-        <h2>{% translate "Important Information" %}</h2>
-        {% for info in information %}
-            <h4>{{ info.title }}</h4>
-            {{ info.text|rich_text }}
-            {% if info.resource %}
-                <a href="{{ info.resource.url }}"><i class="fa fa-file-o"></i> {{ info.resource.name }}</a>
-            {% endif %}
-            {% if not forloop.last %}<hr>{% endif %}
-        {% endfor %}
-    {% endif %}
-    {% html_signal "pretalx.cfp.signals.html_above_submission_list" sender=request.event request=request %}
-    {% if drafts %}
-        <h2>{% translate "Your drafts" %}</h2>
-        <div class="table-responsive">
-            <table class="table table-sm table-flip">
-                <thead>
-                    <tr>
-                        <th>{% translate "Title" %}</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for submission in drafts %}
-                        <tr>
-                            <td>
-                                <a href="{{ submission.urls.user_base }}">{{ submission.title }}</a>
-                            </td>
-                            <td class="flip text-right">
-                                {% if submission.review_code and request.event|get_feature_flag:"submission_public_review" %}
-                                    <button data-destination="{{ submission.urls.review.full }}"
-                                            class="btn btn-sm btn-info copyable-text"
-                                            data-toggle="tooltip"
-                                            data-placement="top"
-                                            title="{% translate "Copy code for review" %}"
-                                            target="_blank"
-                                            rel="noopener">
-                                        <i class="fa fa-link"></i>
-                                    </button>
-                                {% endif %}
-                                <a href="{{ submission.urls.user_base }}" class="btn btn-sm btn-success">
-                                    {% if submission.editable %}
-                                        <i class="fa fa-edit" title="{% translate "Edit draft" %}"></i>
-                                    {% else %}
-                                        <i class="fa fa-edit" title="{% translate "Open draft" %}"></i>
-                                    {% endif %}
-                                </a>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% endif %}
-    <h2>{% translate "Your proposals" %}</h2>
-    {% if submissions %}
-        <div class="table-responsive">
-            <table class="table table-sm table-flip">
-                <thead>
-                    <tr>
-                        <th>{% translate "Title" %}</th>
-                        <th>{% translate "State" %}</th>
-                        <th></th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for submission in submissions %}
-                        <tr>
-                            <td>
-                                <a href="{{ submission.urls.user_base }}">{{ submission.title }}</a>
-                            </td>
-                            <td>
-
-                                {% include "cfp/event/fragment_state.html" with state=submission.user_state as_badge=True %}
-
-                            </td>
-                            <td class="flip text-right">
-                                {% if submission.public_slots %}
-                                    <a href="{{ submission.urls.public }}">
-                                        {% for talk in submission.public_slots %}
-                                            {{ talk.start|datetimerange:talk.end }}, {{ talk.room.name }}
-                                            {% if not forloop.last %}<br>{% endif %}
-                                        {% endfor %}
-                                    </a>
-                                {% endif %}
-                            </td>
-                            <td class="flip text-right">
-                                {% if submission.review_code and request.event|get_feature_flag:"submission_public_review" %}
-                                    <button data-destination="{{ submission.urls.review.full }}"
-                                            class="btn btn-sm btn-info copyable-text"
-                                            data-toggle="tooltip"
-                                            data-placement="top"
-                                            title="{% translate "Copy code for review" %}"
-                                            target="_blank"
-                                            rel="noopener">
-                                        <i class="fa fa-link"></i>
-                                    </button>
-                                {% endif %}
-                                <a href="{{ submission.urls.user_base }}" class="btn btn-sm btn-info">
-                                    {% if submission.editable %}
-                                        <i class="fa fa-edit" title="{% translate "Edit proposal" %}"></i>
-                                    {% else %}
-                                        <i class="fa fa-edit" title="{% translate "Open proposal" %}"></i>
-                                    {% endif %}
-                                </a>
-                                {% if submission.state == "accepted" %}
-                                    <a href="{{ submission.urls.confirm }}" class="btn btn-sm btn-success">
-                                        <i class="fa fa-check"></i> {% translate "Confirm" %}
-                                    </a>
-                                {% endif %}
-                                {% if request.event|get_feature_flag:"use_feedback" and submission.does_accept_feedback %}
-                                    <a href="{{ submission.urls.feedback }}" class="btn btn-sm btn-info">
-                                        <i class="fa fa-comments"></i> {% translate "Feedback" %}
-                                        {% if submission.feedback.count %}({{ submission.feedback.count }}){% endif %}
-                                    </a>
-                                {% endif %}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-        <p>
-            {% if request.event.cfp.is_open %}
-                <a class="btn btn-success btn-lg" href="{{ request.event.urls.submit }}">{% translate "Create a new proposal" %}</a>
-            {% endif %}
-        </p>
-    {% else %}
-        <p class="text-center">{% translate "It seems like you haven’t submitted anything to this event yet." %}</p>
-        <p class="text-center">{% translate "If you did, maybe you used a different account? Check your emails!" %}</p>
-        {% if request.event.cfp.is_open %}
-            <p class="text-center">
-                {% translate "If you did not, why not go ahead and create a proposal now? We’d love to hear from you!" %}
-            </p>
-            <p class="text-center">
-                <a class="btn btn-success btn-lg btn-block"
-                   href="{{ request.event.urls.submit }}">
-                    {% translate "Submit something now!" %}
+  {% if information %}
+    <h2>{% translate "Important Information" %}</h2>
+    {% for info in information %}
+      <h4>{{ info.title }}</h4>
+      {{ info.text|rich_text }}
+      {% if info.resource %}
+        <a href="{{ info.resource.url }}"><i class="fa fa-file-o"></i> {{ info.resource.name }}</a>
+      {% endif %}
+      {% if not forloop.last %}<hr>{% endif %}
+    {% endfor %}
+  {% endif %}
+  {% html_signal "pretalx.cfp.signals.html_above_submission_list" sender=request.event request=request %}
+  {% if drafts %}
+    <h2>{% translate "Your drafts" %}</h2>
+    <div class="table-responsive">
+      <table class="table table-sm table-flip">
+        <thead>
+          <tr>
+            <th>{% translate "Title" %}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for submission in drafts %}
+            <tr>
+              <td>
+                <a href="{{ submission.urls.user_base }}">{{ submission.title }}</a>
+              </td>
+              <td class="flip text-right">
+                {% if submission.review_code and request.event|get_feature_flag:"submission_public_review" %}
+                  <button data-destination="{{ submission.urls.review.full }}"
+                          class="btn btn-sm btn-info copyable-text"
+                          data-toggle="tooltip"
+                          data-placement="top"
+                          title="{% translate "Copy code for review" %}"
+                          target="_blank"
+                          rel="noopener">
+                    <i class="fa fa-link"></i>
+                  </button>
+                {% endif %}
+                <a href="{{ submission.urls.user_base }}" class="btn btn-sm btn-success">
+                  {% if submission.editable %}
+                    <i class="fa fa-edit" title="{% translate "Edit draft" %}"></i>
+                  {% else %}
+                    <i class="fa fa-edit" title="{% translate "Open draft" %}"></i>
+                  {% endif %}
                 </a>
-            </p>
-        {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+  <h2>{% translate "Your proposals" %}</h2>
+  {% if submissions %}
+    <div class="table-responsive">
+      <table class="table table-sm table-flip">
+        <thead>
+          <tr>
+            <th>{% translate "Title" %}</th>
+            <th>{% translate "State" %}</th>
+            <th></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for submission in submissions %}
+            <tr>
+              <td>
+                <a href="{{ submission.urls.user_base }}">{{ submission.title }}</a>
+              </td>
+              <td>
+
+                {% include "cfp/event/fragment_state.html" with state=submission.user_state as_badge=True %}
+
+              </td>
+              <td class="flip text-right">
+                {% if submission.public_slots %}
+                  <a href="{{ submission.urls.public }}">
+                    {% for talk in submission.public_slots %}
+                      {{ talk.start|datetimerange:talk.end }}, {{ talk.room.name }}
+                      {% if not forloop.last %}<br>{% endif %}
+                    {% endfor %}
+                  </a>
+                {% endif %}
+              </td>
+              <td class="flip text-right">
+                {% if submission.review_code and request.event|get_feature_flag:"submission_public_review" %}
+                  <button data-destination="{{ submission.urls.review.full }}"
+                          class="btn btn-sm btn-info copyable-text"
+                          data-toggle="tooltip"
+                          data-placement="top"
+                          title="{% translate "Copy code for review" %}"
+                          target="_blank"
+                          rel="noopener">
+                    <i class="fa fa-link"></i>
+                  </button>
+                {% endif %}
+                <a href="{{ submission.urls.user_base }}" class="btn btn-sm btn-info">
+                  {% if submission.editable %}
+                    <i class="fa fa-edit" title="{% translate "Edit proposal" %}"></i>
+                  {% else %}
+                    <i class="fa fa-edit" title="{% translate "Open proposal" %}"></i>
+                  {% endif %}
+                </a>
+                {% if submission.state == "accepted" %}
+                  <a href="{{ submission.urls.confirm }}" class="btn btn-sm btn-success">
+                    <i class="fa fa-check"></i> {% translate "Confirm" %}
+                  </a>
+                {% endif %}
+                {% if request.event|get_feature_flag:"use_feedback" and submission.does_accept_feedback %}
+                  <a href="{{ submission.urls.feedback }}" class="btn btn-sm btn-info">
+                    <i class="fa fa-comments"></i> {% translate "Feedback" %}
+                    {% if submission.feedback.count %}({{ submission.feedback.count }}){% endif %}
+                  </a>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <p>
+      {% if request.event.cfp.is_open %}
+        <a class="btn btn-success btn-lg" href="{{ request.event.urls.submit }}">{% translate "Create a new proposal" %}</a>
+      {% endif %}
+    </p>
+  {% else %}
+    <p class="text-center">{% translate "It seems like you haven’t submitted anything to this event yet." %}</p>
+    <p class="text-center">{% translate "If you did, maybe you used a different account? Check your emails!" %}</p>
+    {% if request.event.cfp.is_open %}
+      <p class="text-center">
+        {% translate "If you did not, why not go ahead and create a proposal now? We’d love to hear from you!" %}
+      </p>
+      <p class="text-center">
+        <a class="btn btn-success btn-lg btn-block"
+           href="{{ request.event.urls.submit }}">
+          {% translate "Submit something now!" %}
+        </a>
+      </p>
     {% endif %}
+  {% endif %}
 {% endblock content %}

--- a/src/pretalx/cfp/templates/cfp/includes/forms_header.html
+++ b/src/pretalx/cfp/templates/cfp/includes/forms_header.html
@@ -2,16 +2,16 @@
 {% load static %}
 
 {% compress css %}
-    <link rel="stylesheet" type="text/css" href="{% static "vendored/choices/choices.min.css" %}" />
-    <link rel="stylesheet" type="text/x-scss" href="{% static "vendored/forkawesome/scss/fork-awesome.scss" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/tabs.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/_forms.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/availabilities.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/avatar.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "vendored/choices/choices.min.css" %}" />
+  <link rel="stylesheet" type="text/x-scss" href="{% static "vendored/forkawesome/scss/fork-awesome.scss" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/tabs.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/_forms.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/availabilities.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/avatar.css" %}" />
 {% endcompress %}
 {% compress js %}
-    <script defer src="{% static "vendored/choices/choices.min.js" %}"></script>
-    <script defer src="{% static "vendored/marked.min.js" %}"></script> {# required by formtools.js #}
-    <script defer src="{% static "vendored/purify.min.js" %}"></script> {# required by formtools.js #}
-    <script defer src="{% static "common/js/formTools.js" %}"></script>
+  <script defer src="{% static "vendored/choices/choices.min.js" %}"></script>
+  <script defer src="{% static "vendored/marked.min.js" %}"></script> {# required by formtools.js #}
+  <script defer src="{% static "vendored/purify.min.js" %}"></script> {# required by formtools.js #}
+  <script defer src="{% static "common/js/formTools.js" %}"></script>
 {% endcompress %}

--- a/src/pretalx/cfp/templates/cfp/includes/submission_resources_form.html
+++ b/src/pretalx/cfp/templates/cfp/includes/submission_resources_form.html
@@ -4,108 +4,108 @@
 {% load static %}
 
 <div class="formset form-group row" id="resource-upload" data-formset data-formset-prefix="{{ formset.prefix }}">
-    {{ formset.management_form }}
-    {{ formset.non_form_errors }}
-    <label class="col-md-3 col-form-label">{% translate "Resources" %}</label>
-    <div data-formset-body class="col-md-9">
-        {% if can_edit %}
-            <div class="alert alert-info flip ml-auto">
-                {% translate "Resources will be publicly visible." %}
-                {{ size_warning }}
-            </div>
-        {% endif %}
-        {% for form in formset %}
-            <div data-formset-form class="mb-2">
-                <div class="sr-only">
-                    {{ form.id }}
-                    {{ form.DELETE }}
-                </div>
-                {% include "common/forms/errors.html" %}
-                <div class="resource-option-row flip ml-auto d-flex">
-                    <div class="d-flex flex-column flex-grow-1 mr-2 resource-option{% if not form.errors %}-input{% endif %}{% if action == "view" %} disabled{% endif %}">
-                        {% if form.errors %}
-                            {{ form.description.as_field_group }}
-                            <div class="resource-option-inline">
-                                {{ form.link.as_field_group }}
-                                {{ form.resource.as_field_group }}
-                            </div>
-                        {% else %}
-                            {% if form.instance.link %}
-                                <div class="col-md-12">
-                                    {{ form.description.as_field_group }}
-                                    {{ form.link.as_field_group }}
-                                </div>
-                            {% else %}
-                                <div class="d-flex flex-row align-items-end">
-                                    <div class="col-md-6">
-                                        {{ form.description.as_field_group }}
-                                    </div>
-                                    <div class="mb-1 col-md-6">
-                                        <i class="fa fa-paperclip mr-1 ml-2 pt-1"></i> <a href="{{ form.instance.url }}">{{ form.instance.filename }}</a>
-                                    </div>
-                                </div>
-                            {% endif %}
-                        {% endif %}
-                    </div>
-                    {% if can_edit %}
-                        <div class="resource-option-delete mt-3 pt-1">
-                            <button type="button" class="btn btn-danger btn-sm mt-3" data-formset-delete-button>
-                                <i class="fa fa-trash"></i></button>
-                        </div>
-                    {% endif %}
-                </div>
-            </div>
-            {% if not forloop.last %}
-                <hr>
-            {% endif %}
-        {% empty %}
-            <div class="mt-1">{% translate "This proposal has no resources yet." %}</div>
-        {% endfor %}
-    </div>
+  {{ formset.management_form }}
+  {{ formset.non_form_errors }}
+  <label class="col-md-3 col-form-label">{% translate "Resources" %}</label>
+  <div data-formset-body class="col-md-9">
     {% if can_edit %}
-        <script type="form-template" data-formset-empty-form>
-            {% escapescript %}
-                <div data-formset-form class="formset-row">
-                <hr>
-                <div class="resource-option-row flip ml-auto d-flex flex-column col-md-12">
-                <div class="sr-only">
-                {{ formset.empty_form.id }}
-                {{ formset.empty_form.DELETE }}
-                </div>
-                <div class="resource-option-fields d-flex">
-                <div class="mr-2 flex-grow-1">
-                {{ formset.empty_form.description.as_field_group }}
-                </div>
-                <div class="resource-option-delete mt-3 pt-1">
-                <button type="button" class="btn btn-danger btn-sm ml-auto mt-3" data-formset-delete-button>
-                <i class="fa fa-trash"></i>
-                </button>
-                </div>
-                </div>
-                <div class="resource-option-inline d-flex">
-                <div class="mr-2 flex-grow-1">
-                {{ formset.empty_form.link.as_field_group }}
-                </div>
-                <div class="ml-2 flex-grow-1">
-                {{ formset.empty_form.resource.as_field_group }}
-                </div>
-                </div>
-                <div class="text-muted mt-0 pt-0 mb-2 mt-2">
-                {% translate "You can either provide a URL or upload a file." %}
-                {{ formset.empty_form.resource.help_text }}
-                </div>
-                </div>
-                </div>
-            {% endescapescript %}
-        </script>
-        {% if action != "view" %}
-            <div class="d-flex flex-row-reverse w-100 mr-3">
-                <button type="button" class="btn btn-info" data-formset-add>
-                    <i class="fa fa-plus"></i> {% translate "Add another resource" %}
-                </button>
-            </div>
-        {% endif %}
+      <div class="alert alert-info flip ml-auto">
+        {% translate "Resources will be publicly visible." %}
+        {{ size_warning }}
+      </div>
     {% endif %}
+    {% for form in formset %}
+      <div data-formset-form class="mb-2">
+        <div class="sr-only">
+          {{ form.id }}
+          {{ form.DELETE }}
+        </div>
+        {% include "common/forms/errors.html" %}
+        <div class="resource-option-row flip ml-auto d-flex">
+          <div class="d-flex flex-column flex-grow-1 mr-2 resource-option{% if not form.errors %}-input{% endif %}{% if action == "view" %} disabled{% endif %}">
+            {% if form.errors %}
+              {{ form.description.as_field_group }}
+              <div class="resource-option-inline">
+                {{ form.link.as_field_group }}
+                {{ form.resource.as_field_group }}
+              </div>
+            {% else %}
+              {% if form.instance.link %}
+                <div class="col-md-12">
+                  {{ form.description.as_field_group }}
+                  {{ form.link.as_field_group }}
+                </div>
+              {% else %}
+                <div class="d-flex flex-row align-items-end">
+                  <div class="col-md-6">
+                    {{ form.description.as_field_group }}
+                  </div>
+                  <div class="mb-1 col-md-6">
+                    <i class="fa fa-paperclip mr-1 ml-2 pt-1"></i> <a href="{{ form.instance.url }}">{{ form.instance.filename }}</a>
+                  </div>
+                </div>
+              {% endif %}
+            {% endif %}
+          </div>
+          {% if can_edit %}
+            <div class="resource-option-delete mt-3 pt-1">
+              <button type="button" class="btn btn-danger btn-sm mt-3" data-formset-delete-button>
+                <i class="fa fa-trash"></i></button>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+      {% if not forloop.last %}
+        <hr>
+      {% endif %}
+    {% empty %}
+      <div class="mt-1">{% translate "This proposal has no resources yet." %}</div>
+    {% endfor %}
+  </div>
+  {% if can_edit %}
+    <script type="form-template" data-formset-empty-form>
+      {% escapescript %}
+        <div data-formset-form class="formset-row">
+        <hr>
+        <div class="resource-option-row flip ml-auto d-flex flex-column col-md-12">
+        <div class="sr-only">
+        {{ formset.empty_form.id }}
+        {{ formset.empty_form.DELETE }}
+        </div>
+        <div class="resource-option-fields d-flex">
+        <div class="mr-2 flex-grow-1">
+        {{ formset.empty_form.description.as_field_group }}
+        </div>
+        <div class="resource-option-delete mt-3 pt-1">
+        <button type="button" class="btn btn-danger btn-sm ml-auto mt-3" data-formset-delete-button>
+        <i class="fa fa-trash"></i>
+        </button>
+        </div>
+        </div>
+        <div class="resource-option-inline d-flex">
+        <div class="mr-2 flex-grow-1">
+        {{ formset.empty_form.link.as_field_group }}
+        </div>
+        <div class="ml-2 flex-grow-1">
+        {{ formset.empty_form.resource.as_field_group }}
+        </div>
+        </div>
+        <div class="text-muted mt-0 pt-0 mb-2 mt-2">
+        {% translate "You can either provide a URL or upload a file." %}
+        {{ formset.empty_form.resource.help_text }}
+        </div>
+        </div>
+        </div>
+      {% endescapescript %}
+    </script>
+    {% if action != "view" %}
+      <div class="d-flex flex-row-reverse w-100 mr-3">
+        <button type="button" class="btn btn-info" data-formset-add>
+          <i class="fa fa-plus"></i> {% translate "Add another resource" %}
+        </button>
+      </div>
+    {% endif %}
+  {% endif %}
 </div>
 
 <link rel="stylesheet" type="text/css" href="{% static "common/css/resource-form.css" %}" />

--- a/src/pretalx/cfp/templates/cfp/includes/user_submission_header.html
+++ b/src/pretalx/cfp/templates/cfp/includes/user_submission_header.html
@@ -4,62 +4,62 @@
 {% load static %}
 
 {% compress js %}
-    <script defer src="{% static "vendored/moment-with-locales.js" %}"></script>
-    <script defer src="{% static "vendored/moment-timezone-with-data-10-year-range.js" %}"></script>
-    <script defer src="{% static "agenda/js/datetime-local.js" %}"></script>
+  <script defer src="{% static "vendored/moment-with-locales.js" %}"></script>
+  <script defer src="{% static "vendored/moment-timezone-with-data-10-year-range.js" %}"></script>
+  <script defer src="{% static "agenda/js/datetime-local.js" %}"></script>
 {% endcompress %}
 
 <h2>
-    {{ quotation_open }}{{ submission.title }}{{ quotation_close }}
-    {% if submission.state == "draft" %}
-        <span class="badge color-secondary">{% translate "Draft" %}</span>
-    {% endif %}
+  {{ quotation_open }}{{ submission.title }}{{ quotation_close }}
+  {% if submission.state == "draft" %}
+    <span class="badge color-secondary">{% translate "Draft" %}</span>
+  {% endif %}
 </h2>
 {% if submission.state != "draft" %}
-    <p>
-        {% translate "Current state of your proposal:" %}
+  <p>
+    {% translate "Current state of your proposal:" %}
 
-        {% include "cfp/event/fragment_state.html" with state=submission.state as_badge=True %}
+    {% include "cfp/event/fragment_state.html" with state=submission.state as_badge=True %}
 
-    </p>
+  </p>
 {% else %}
-    <div class="alert alert-info">
-        {% blocktranslate trimmed %}
-            This is a draft proposal.
-            It will never be visible to anybody else, unless you submit it or explicitly share it.
-        {% endblocktranslate %}
-    </div>
+  <div class="alert alert-info">
+    {% blocktranslate trimmed %}
+      This is a draft proposal.
+      It will never be visible to anybody else, unless you submit it or explicitly share it.
+    {% endblocktranslate %}
+  </div>
 {% endif %}
 {% if submission.public_slots %}
-    <h3>
-        <small>
-            {% for talk in submission.public_slots %}
-                {{ talk.start|datetimerange:talk.end }}, {{ talk.room.name }}
-                {% if not forloop.last %}·{% endif %}
-            {% endfor %}
-        </small>
-    </h3>
+  <h3>
+    <small>
+      {% for talk in submission.public_slots %}
+        {{ talk.start|datetimerange:talk.end }}, {{ talk.room.name }}
+        {% if not forloop.last %}·{% endif %}
+      {% endfor %}
+    </small>
+  </h3>
 {% endif %}
 <div class="submission-info d-flex">
-    {% if submission.submission_type and request.event.submission_types.all|length > 1 %}
-        <p class="mr-1 ml-1">
-            <strong>{% translate "Session type" %}</strong>: {{ submission.submission_type.name }}
-        </p>
-        ·
-    {% endif %}
-    {% if submission.track and request.event.tracks.all|length > 1 %}
-        <p class="mr-1 ml-1">
-            <strong>{% translate "Track" %}</strong> {{ submission.track.name }}
-        </p>
-        ·
-    {% endif %}
-    {% if request.event.is_multilingual and request.event.cfp.request_content_locale %}
-        <p class="mr-1 ml-1">
-            <strong>{{ phrases.base.language }}</strong> {{ submission.get_content_locale_display }}
-        </p>
-        ·
-    {% endif %}
+  {% if submission.submission_type and request.event.submission_types.all|length > 1 %}
     <p class="mr-1 ml-1">
-        <strong>{% translate "Duration" %}</strong> {{ submission.export_duration }}
+      <strong>{% translate "Session type" %}</strong>: {{ submission.submission_type.name }}
     </p>
+    ·
+  {% endif %}
+  {% if submission.track and request.event.tracks.all|length > 1 %}
+    <p class="mr-1 ml-1">
+      <strong>{% translate "Track" %}</strong> {{ submission.track.name }}
+    </p>
+    ·
+  {% endif %}
+  {% if request.event.is_multilingual and request.event.cfp.request_content_locale %}
+    <p class="mr-1 ml-1">
+      <strong>{{ phrases.base.language }}</strong> {{ submission.get_content_locale_display }}
+    </p>
+    ·
+  {% endif %}
+  <p class="mr-1 ml-1">
+    <strong>{% translate "Duration" %}</strong> {{ submission.export_duration }}
+  </p>
 </div>

--- a/src/pretalx/cfp/templates/cfp/index.html
+++ b/src/pretalx/cfp/templates/cfp/index.html
@@ -4,47 +4,47 @@
 {% block title %}{% translate "Events" %}{% endblock title %}
 
 {% block content %}
-    {% if current_events or future_events or past_events %}
-        <h1>{% translate "Events" %}</h1>
-    {% endif %}
-    {% if current_events %}
-        <ul>
-            {% for event in current_events %}
-                <li>
-                    <a href="{{ event.urls.base }}">
-                        {{ event.name }}
-                        ({{ event.get_date_range_display }})
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-    {% else %}
-        <p>{% translate "No events are currently ongoing." %}</p>
-    {% endif %}
-    {% if future_events %}
-        <h2>{% translate "Upcoming events" %}</h2>
-        <ul>
-            {% for event in future_events %}
-                <li>
-                    <a href="{{ event.urls.base }}">
-                        {{ event.name }}
-                        ({{ event.get_date_range_display }})
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-    {% endif %}
-    {% if past_events %}
-        <h2>{% translate "Past events" %}</h2>
-        <ul>
-            {% for event in past_events %}
-                <li>
-                    <a href="{{ event.urls.base }}">
-                        {{ event.name }}
-                        ({{ event.get_date_range_display }})
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-    {% endif %}
+  {% if current_events or future_events or past_events %}
+    <h1>{% translate "Events" %}</h1>
+  {% endif %}
+  {% if current_events %}
+    <ul>
+      {% for event in current_events %}
+        <li>
+          <a href="{{ event.urls.base }}">
+            {{ event.name }}
+            ({{ event.get_date_range_display }})
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>{% translate "No events are currently ongoing." %}</p>
+  {% endif %}
+  {% if future_events %}
+    <h2>{% translate "Upcoming events" %}</h2>
+    <ul>
+      {% for event in future_events %}
+        <li>
+          <a href="{{ event.urls.base }}">
+            {{ event.name }}
+            ({{ event.get_date_range_display }})
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+  {% if past_events %}
+    <h2>{% translate "Past events" %}</h2>
+    <ul>
+      {% for event in past_events %}
+        <li>
+          <a href="{{ event.urls.base }}">
+            {{ event.name }}
+            ({{ event.get_date_range_display }})
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
 {% endblock content %}

--- a/src/pretalx/common/templates/400.html
+++ b/src/pretalx/common/templates/400.html
@@ -4,25 +4,25 @@
 {% load static %}
 
 {% block error_image %}
-    <img loading="lazy" src="{% static "common/img/error_5xx.svg" %}" class="img" alt="{{ phrases.base.bad_request }}">
+  <img loading="lazy" src="{% static "common/img/error_5xx.svg" %}" class="img" alt="{{ phrases.base.bad_request }}">
 {% endblock error_image %}
 
 {% block error_message %}
-    <p>
-        {{ phrases.base.bad_request }}
+  <p>
+    {{ phrases.base.bad_request }}
+    <br>
+  </p>
+  </h2>
+  <h3>
+    <p class="ml-auto mr-auto text-center">
+      {% blocktranslate trimmed %}
+        It looks as if the communication between you and eventyay went wrong in
+        some way.
         <br>
+        Please return to the last page and try again!
+      {% endblocktranslate %}
     </p>
-    </h2>
-    <h3>
-        <p class="ml-auto mr-auto text-center">
-            {% blocktranslate trimmed %}
-                It looks as if the communication between you and eventyay went wrong in
-                some way.
-                <br>
-                Please return to the last page and try again!
-            {% endblocktranslate %}
-        </p>
-    </h3>
-    <h2>
+  </h3>
+  <h2>
 {% endblock error_message %}
 {% block error_code %}400{% endblock error_code %}

--- a/src/pretalx/common/templates/403.html
+++ b/src/pretalx/common/templates/403.html
@@ -5,13 +5,13 @@
 
 {% block title %}{{ phrases.base.permission_denied }}{% endblock title %}
 {% block error_image %}
-    <img loading="lazy" src="{% static "common/img/error_403.svg" %}" class="img" alt="{{ phrases.base.permission_denied }}">
+  <img loading="lazy" src="{% static "common/img/error_403.svg" %}" class="img" alt="{{ phrases.base.permission_denied }}">
 {% endblock error_image %}
 {% block error_message %}
-    {{ phrases.base.permission_denied }}
-    </h2>
-    <h5>
-        <p class="ml-auto mr-auto text-center">{{ phrases.base.permission_denied_long }}</p>
-    </h5>
+  {{ phrases.base.permission_denied }}
+  </h2>
+  <h5>
+    <p class="ml-auto mr-auto text-center">{{ phrases.base.permission_denied_long }}</p>
+  </h5>
 {% endblock error_message %}
 {% block error_code %}403{% endblock error_code %}

--- a/src/pretalx/common/templates/403_csrf.html
+++ b/src/pretalx/common/templates/403_csrf.html
@@ -4,23 +4,23 @@
 {% load static %}
 
 {% block error_image %}
-    <img loading="lazy" src="{% static "common/img/error_5xx.svg" %}" class="img" alt="{% translate "Verification failed." %}">
+  <img loading="lazy" src="{% static "common/img/error_5xx.svg" %}" class="img" alt="{% translate "Verification failed." %}">
 {% endblock error_image %}
 {% block error_message %}
-    <p>
-        {% translate "Verification failed." %}
+  <p>
+    {% translate "Verification failed." %}
+    <br>
+  </p>
+  </h2>
+  <h3>
+    <p class="ml-auto mr-auto text-center">
+      {% blocktranslate trimmed %}
+        We could not verify that this request really was sent by you. For security reasons, we cannot process it.
         <br>
+        Please go back to the last page, refresh, and then try again.
+      {% endblocktranslate %}
     </p>
-    </h2>
-    <h3>
-        <p class="ml-auto mr-auto text-center">
-            {% blocktranslate trimmed %}
-                We could not verify that this request really was sent by you. For security reasons, we cannot process it.
-                <br>
-                Please go back to the last page, refresh, and then try again.
-            {% endblocktranslate %}
-        </p>
-    </h3>
-    <h2>
+  </h3>
+  <h2>
 {% endblock error_message %}
 {% block error_code %}403: CSRF{% endblock error_code %}

--- a/src/pretalx/common/templates/404.html
+++ b/src/pretalx/common/templates/404.html
@@ -5,13 +5,13 @@
 
 {% block title %}{{ phrases.base.not_found }}{% endblock title %}
 {% block error_image %}
-    <img loading="lazy" src="{% static "common/img/error_403.svg" %}" class="img" alt="{{ phrases.base.not_found }}">
+  <img loading="lazy" src="{% static "common/img/error_403.svg" %}" class="img" alt="{{ phrases.base.not_found }}">
 {% endblock error_image %}
 {% block error_message %}
-    {{ phrases.base.not_found }}
-    </h2>
-    <h5>
-        <p class="ml-auto mr-auto text-center">{{ phrases.base.not_found_long }}</p>
-    </h5>
+  {{ phrases.base.not_found }}
+  </h2>
+  <h5>
+    <p class="ml-auto mr-auto text-center">{{ phrases.base.not_found_long }}</p>
+  </h5>
 {% endblock error_message %}
 {% block error_code %}404{% endblock error_code %}

--- a/src/pretalx/common/templates/500.html
+++ b/src/pretalx/common/templates/500.html
@@ -4,13 +4,13 @@
 {% load static %}
 
 {% block error_image %}
-    <img loading="lazy" src="{% static "common/img/error_5xx.svg" %}" class="img" alt="{% translate "Internal server error." %}">
+  <img loading="lazy" src="{% static "common/img/error_5xx.svg" %}" class="img" alt="{% translate "Internal server error." %}">
 {% endblock error_image %}
 {% block error_message %}
-    <p>
-        {% translate "We have encountered an error." %}
-        <br>
-    </p>
-    </h2>
+  <p>
+    {% translate "We have encountered an error." %}
+    <br>
+  </p>
+  </h2>
 {% endblock error_message %}
 {% block error_code %}500{% endblock error_code %}

--- a/src/pretalx/common/templates/bootstrap4/form_errors.html
+++ b/src/pretalx/common/templates/bootstrap4/form_errors.html
@@ -1,7 +1,7 @@
 <div class="alert alert-danger">
     {% comment %}We remove alert-link and alert-dismissable, because those don’t match our design choices{% endcomment %}
-    {% for error in errors %}
-        {{ error }}
-        {% if not forloop.last %}<br>{% endif %}
-    {% endfor %}
+  {% for error in errors %}
+    {{ error }}
+    {% if not forloop.last %}<br>{% endif %}
+  {% endfor %}
 </div>

--- a/src/pretalx/common/templates/common/action_confirm.html
+++ b/src/pretalx/common/templates/common/action_confirm.html
@@ -4,6 +4,6 @@
 
 {% block content %}
 
-    {% include "common/includes/action_confirm.html" %}
+  {% include "common/includes/action_confirm.html" %}
 
 {% endblock content %}

--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -6,42 +6,42 @@
 
 {% include "common/forms/errors.html" %}
 {% if no_form %}
-    <div id="auth-form" class="password-input-form">
+  <div id="auth-form" class="password-input-form">
 {% else %}
-    <form id="auth-form" class="password-input-form" method="post" autocomplete="off">
+  <form id="auth-form" class="password-input-form" method="post" autocomplete="off">
 {% endif %}
 
 {% csrf_token %}
 
 {% compress css %}
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/_forms.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/_forms.css" %}" />
 {% endcompress %}
 
 
 {% compress js %}
-    <script defer src="{% static "vendored/zxcvbn.js" %}"></script>
-    <script defer src="{% static "common/js/formTools.js" %}"></script>
-    <script defer src="{% static "common/js/password_strength.js" %}"></script>
+  <script defer src="{% static "vendored/zxcvbn.js" %}"></script>
+  <script defer src="{% static "common/js/formTools.js" %}"></script>
+  <script defer src="{% static "common/js/password_strength.js" %}"></script>
 {% endcompress %}
 <div class="panel-group" id="accordion">
-    {% if not hide_login %}
-        <div class="panel panel-default">
-            <div class="panel-heading text-center" id="headingOne">
-                <a class="btn btn-lg btn-primary btn-block mt-3" href="{% oauth_login_url next_url %}">
-                    {{ login_button_label }}
-                </a>
-            </div>
-        </div>
-    {% endif %}
-    {% if not hide_register %}
-        <hr>
-        <div class="panel panel-default">
-            <div class="panel-heading text-center" id="headingTwo">
-                <a class="btn btn-lg btn-primary btn-block mt-3" href="{% register_account_url next_url %}">
-                  {{ _('Register account') }}
-                </a>
-            </div>
-        </div>
-    {% endif %}
+  {% if not hide_login %}
+    <div class="panel panel-default">
+      <div class="panel-heading text-center" id="headingOne">
+        <a class="btn btn-lg btn-primary btn-block mt-3" href="{% oauth_login_url next_url %}">
+          {{ login_button_label }}
+        </a>
+      </div>
+    </div>
+  {% endif %}
+  {% if not hide_register %}
+    <hr>
+    <div class="panel panel-default">
+      <div class="panel-heading text-center" id="headingTwo">
+        <a class="btn btn-lg btn-primary btn-block mt-3" href="{% register_account_url next_url %}">
+          {{ _('Register account') }}
+        </a>
+      </div>
+    </div>
+  {% endif %}
 </div>
 {% if no_form %}</div>{% else %}</form>{% endif %}

--- a/src/pretalx/common/templates/common/availabilities.html
+++ b/src/pretalx/common/templates/common/availabilities.html
@@ -2,21 +2,21 @@
 {% load static %}
 
 {% compress js %}
-    <script defer src="{% static "vendored/moment-with-locales.js" %}"></script>
-    <script defer src="{% static "vendored/moment-timezone-with-data-10-year-range.js" %}"></script>
+  <script defer src="{% static "vendored/moment-with-locales.js" %}"></script>
+  <script defer src="{% static "vendored/moment-timezone-with-data-10-year-range.js" %}"></script>
 
-    <script defer src="{% static "vendored/fullcalendar/fullcalendar.min.js" %}"></script>
-    <script defer src="{% static "vendored/fullcalendar/moment-timezone-plugin.min.js" %}"></script>
+  <script defer src="{% static "vendored/fullcalendar/fullcalendar.min.js" %}"></script>
+  <script defer src="{% static "vendored/fullcalendar/moment-timezone-plugin.min.js" %}"></script>
 
-    <script defer src="{% static "common/js/availabilities.js" %}"></script>
+  <script defer src="{% static "common/js/availabilities.js" %}"></script>
 {% endcompress %}
 {% compress css %}
-    <link rel="stylesheet" type="text/css" href="{% static "vendored/fullcalendar/fullcalendar.min.css" %}" />
-    <link rel="stylesheet" href="{% static "common/css/availabilities.css" %}">
+  <link rel="stylesheet" type="text/css" href="{% static "vendored/fullcalendar/fullcalendar.min.css" %}" />
+  <link rel="stylesheet" href="{% static "common/css/availabilities.css" %}">
 {% endcompress %}
 
 {% with html_locale|slice:":2" as calendar_locale %}
-    {% if calendar_locale and calendar_locale in AVAILABLE_CALENDAR_LOCALES %}
-        <script defer id="calendar-locale" data-locale="{{ calendar_locale }}" src="{% static "vendored/fullcalendar/"|add:calendar_locale|add:".js" %}"></script>
-    {% endif %}
+  {% if calendar_locale and calendar_locale in AVAILABLE_CALENDAR_LOCALES %}
+    <script defer id="calendar-locale" data-locale="{{ calendar_locale }}" src="{% static "vendored/fullcalendar/"|add:calendar_locale|add:".js" %}"></script>
+  {% endif %}
 {% endwith %}

--- a/src/pretalx/common/templates/common/avatar.html
+++ b/src/pretalx/common/templates/common/avatar.html
@@ -4,32 +4,32 @@
 {% load thumbnail %}
 
 <div class="avatar-form form-group row">
-    <label class="col-md-3 col-form-label">{% translate "Profile picture" %}</label>
-    <div class="avatar-form-fields col-md-9">
-        <div class="d-flex align-items-start hide-label">
-            <div>
-                <div class="avatar-upload hide-label">
-                    {{ form.avatar.as_field_group }}
-                </div>
-                {{ form.get_gravatar.as_field_group }}
-            </div>
-            <div class="form-image-preview {% if not user.avatar and not user.get_gravatar %}d-none{% endif %}">
-                <a href="{% if user.avatar %}{{ user.avatar|thumbnail:"default" }}{% endif %}" data-lightbox="{% if user.avatar %}{{ user.avatar.url }}{% endif %}">
-                    <img loading="lazy"
-                         class="avatar"
-                         data-gravatar="{{ user.gravatar_parameter }}"
-                         data-avatar="{% if user.avatar %}{{ user.avatar.url }}{% endif %}"
-                         alt="{% translate "Your avatar" %}"
-                         {% if user.avatar %}src="{{ user.avatar.url }}"{% endif %} />
-                </a>
-            </div>
+  <label class="col-md-3 col-form-label">{% translate "Profile picture" %}</label>
+  <div class="avatar-form-fields col-md-9">
+    <div class="d-flex align-items-start hide-label">
+      <div>
+        <div class="avatar-upload hide-label">
+          {{ form.avatar.as_field_group }}
         </div>
+        {{ form.get_gravatar.as_field_group }}
+      </div>
+      <div class="form-image-preview {% if not user.avatar and not user.get_gravatar %}d-none{% endif %}">
+        <a href="{% if user.avatar %}{{ user.avatar|thumbnail:"default" }}{% endif %}" data-lightbox="{% if user.avatar %}{{ user.avatar.url }}{% endif %}">
+          <img loading="lazy"
+               class="avatar"
+               data-gravatar="{{ user.gravatar_parameter }}"
+               data-avatar="{% if user.avatar %}{{ user.avatar.url }}{% endif %}"
+               alt="{% translate "Your avatar" %}"
+               {% if user.avatar %}src="{{ user.avatar.url }}"{% endif %} />
+        </a>
+      </div>
     </div>
+  </div>
 </div>
 
 {% compress css %}
-    <link rel="stylesheet" href="{% static "common/css/avatar.css" %}">
+  <link rel="stylesheet" href="{% static "common/css/avatar.css" %}">
 {% endcompress %}
 {% compress js %}
-    <script defer src="{% static "cfp/js/profile.js" %}"></script>
+  <script defer src="{% static "cfp/js/profile.js" %}"></script>
 {% endcompress %}

--- a/src/pretalx/common/templates/common/base.html
+++ b/src/pretalx/common/templates/common/base.html
@@ -6,181 +6,181 @@
 
 <!DOCTYPE html>
 <html lang="{{ html_locale }}"{% if rtl %} dir="rtl" class="rtl"{% endif %}>
-    <head>
-        <meta charset="utf-8">
-        <title>{% block title %}{% endblock %} {% if request.event %} {{ request.event.name }} {% endif %}:: {{site_name}} </title>
-        <meta name="title" content="{% block meta_title %}{% endblock %} {% if request.event %} - {{ request.event.name }} {% endif %} {{site_name}}">
-        <meta name="description" content="{% block meta_description %}{% if request.event %}Schedule, talks and talk submissions for {{ request.event.name }}{% else %}Talks and talk submissions by {{site_name}} {% endif %}{% endblock %}">
-        <meta name="application-name" content="{{site_name}}">
-        <meta name="generator" content="{{site_name}}">
-        <meta name="keywords" content="{% if request.event %}{{ request.event.name }}, {{ request.event.slug }}, {% if request.event.date_from %}{{ request.event.date_from.year }}, {% endif %}{% endif %}schedule, talks, cfp, call for papers, conference, submissions, organizer">
-        {{ html_head|safe }}
-        {% if request.event and request.event.display_settings.meta_noindex %}
-            <meta name="robots" content="noindex, nofollow">
-        {% else %}
-            <meta name="robots" content="index, follow">
-        {% endif %}
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="theme-color" content="{% if request.event %}{{ request.event.visible_primary_color }}{% else %}#2185d0{% endif %}">
-        <meta name="HandheldFriendly" content="True"/>
-        {% block meta_image %}{% if request.event %}<meta property="thumbnail" content="{{ request.event.urls.social_image.full }}">
-            <meta property="og:image" content="{{ request.event.urls.social_image.full }}">
-        {% endif %}{% endblock meta_image %}
-        <meta property="og:title" content="{% block social_title %}{% endblock social_title %} {% if request.event %}{{ request.event.name }}{% endif %}">
-        <meta property="og:description" content="{% block social_description %}{% if request.event %}Schedule, talks and talk submissions for {{ request.event.name }}{% else %}Talks and talk submissions by {{site_name}} {% endif %}{% endblock social_description %}">
-        <meta property="og:url" content="{% if request.event and request.event.display_settings.html_export_url %}{{ request.event.display_settings.html_export_url }}{{ request.path|slice:"1:" }}{% else %}{{ request.build_absolute_uri }}{% endif %}">
-        <meta property="twitter:card" content="summary">
+  <head>
+    <meta charset="utf-8">
+    <title>{% block title %}{% endblock %} {% if request.event %} {{ request.event.name }} {% endif %}:: {{site_name}} </title>
+    <meta name="title" content="{% block meta_title %}{% endblock %} {% if request.event %} - {{ request.event.name }} {% endif %} {{site_name}}">
+    <meta name="description" content="{% block meta_description %}{% if request.event %}Schedule, talks and talk submissions for {{ request.event.name }}{% else %}Talks and talk submissions by {{site_name}} {% endif %}{% endblock %}">
+    <meta name="application-name" content="{{site_name}}">
+    <meta name="generator" content="{{site_name}}">
+    <meta name="keywords" content="{% if request.event %}{{ request.event.name }}, {{ request.event.slug }}, {% if request.event.date_from %}{{ request.event.date_from.year }}, {% endif %}{% endif %}schedule, talks, cfp, call for papers, conference, submissions, organizer">
+    {{ html_head|safe }}
+    {% if request.event and request.event.display_settings.meta_noindex %}
+      <meta name="robots" content="noindex, nofollow">
+    {% else %}
+      <meta name="robots" content="index, follow">
+    {% endif %}
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="{% if request.event %}{{ request.event.visible_primary_color }}{% else %}#2185d0{% endif %}">
+    <meta name="HandheldFriendly" content="True"/>
+    {% block meta_image %}{% if request.event %}<meta property="thumbnail" content="{{ request.event.urls.social_image.full }}">
+      <meta property="og:image" content="{{ request.event.urls.social_image.full }}">
+    {% endif %}{% endblock meta_image %}
+    <meta property="og:title" content="{% block social_title %}{% endblock social_title %} {% if request.event %}{{ request.event.name }}{% endif %}">
+    <meta property="og:description" content="{% block social_description %}{% if request.event %}Schedule, talks and talk submissions for {{ request.event.name }}{% else %}Talks and talk submissions by {{site_name}} {% endif %}{% endblock social_description %}">
+    <meta property="og:url" content="{% if request.event and request.event.display_settings.html_export_url %}{{ request.event.display_settings.html_export_url }}{{ request.path|slice:"1:" }}{% else %}{{ request.build_absolute_uri }}{% endif %}">
+    <meta property="twitter:card" content="summary">
 
-        {% include "common/includes/favicon.html" %}
+    {% include "common/includes/favicon.html" %}
 
-        {% if request.event.display_settings.header_pattern %}
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/headers-uncompressed.css" %}" />
-        {% endif %}
-        {% compress css %}
-            <link rel="stylesheet" type="text/x-scss" href="{% static "vendored/forkawesome/scss/fork-awesome.scss" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_reset.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/base.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_variables.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_fonts.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_dropdown.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_tooltip.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_pretalx.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_rtl.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_stages.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "cfp/css/_layout.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "agenda/css/_agenda.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "agenda/css/_speaker.css" %}" />
-        {% endcompress %}
-        {% block stylesheets %}{% endblock stylesheets %}
-        {% if request.event and request.event.primary_color %}<link rel="stylesheet" type="text/css" href="{{ request.event.urls.settings_css }}" />{% endif %}
-        {% if request.event and request.event.custom_css %}<link rel="stylesheet" type="text/css" href="{{ request.event.custom_css.url }}"/>{% endif %}
-        {% compress js %}
-            <script defer src="{% static "common/js/base.js" %}"></script>
-            <script src="{% static "jquery/js/jquery-3.7.1.min.js" %}"></script>
-            <script src="{% static "agenda/js/join-online-event.js" %}"></script>
-        {% endcompress %}
-        {% block scripts %}{% endblock scripts %}
-        {% block custom_header %}{% endblock custom_header %}
-    </head>
-    <body data-datetimeformat="{{ js_datetime_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}">
-        <div id="top-bg" class="header {{ request.event.display_settings.header_pattern|default:"bg-primary" }}">
-            {% if request.event and request.event.header_image %}
+    {% if request.event.display_settings.header_pattern %}
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/headers-uncompressed.css" %}" />
+    {% endif %}
+    {% compress css %}
+      <link rel="stylesheet" type="text/x-scss" href="{% static "vendored/forkawesome/scss/fork-awesome.scss" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_reset.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/base.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_variables.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_fonts.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_dropdown.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_tooltip.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_pretalx.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_rtl.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_stages.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "cfp/css/_layout.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "agenda/css/_agenda.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "agenda/css/_speaker.css" %}" />
+    {% endcompress %}
+    {% block stylesheets %}{% endblock stylesheets %}
+    {% if request.event and request.event.primary_color %}<link rel="stylesheet" type="text/css" href="{{ request.event.urls.settings_css }}" />{% endif %}
+    {% if request.event and request.event.custom_css %}<link rel="stylesheet" type="text/css" href="{{ request.event.custom_css.url }}"/>{% endif %}
+    {% compress js %}
+      <script defer src="{% static "common/js/base.js" %}"></script>
+      <script src="{% static "jquery/js/jquery-3.7.1.min.js" %}"></script>
+      <script src="{% static "agenda/js/join-online-event.js" %}"></script>
+    {% endcompress %}
+    {% block scripts %}{% endblock scripts %}
+    {% block custom_header %}{% endblock custom_header %}
+  </head>
+  <body data-datetimeformat="{{ js_datetime_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}">
+    <div id="top-bg" class="header {{ request.event.display_settings.header_pattern|default:"bg-primary" }}">
+      {% if request.event and request.event.header_image %}
                 {# we’re not lazy-loading the header image, even though it can be large, because it’s a bit jarring to see it flash in 100ms after the page load #}
-                <img src="{{ request.event.header_image.url }}" id="header-image" alt="{{ request.event.name }}">
+        <img src="{{ request.event.header_image.url }}" id="header-image" alt="{{ request.event.name }}">
+      {% endif %}
+    </div>
+    {% if request.event and not request.event.is_public and not is_html_export %}
+      <div id="event-nonpublic" class="d-print-none">
+        <i class="fa fa-user-secret"></i>
+        {% blocktranslate trimmed %}
+          This event is currently non-public. Only organisers can see it.
+        {% endblocktranslate %}
+      </div>
+    {% endif %}
+    <div class="container{% block container_width %}{% endblock container_width %}" id="main-container">
+      <header>
+        <h1>
+          <a href="{% block nav_link %}{% endblock nav_link %}">
+            {% if request.event and request.event.logo %}
+              <img loading="lazy" src="{{ request.event.logo.url }}" id="event-logo" alt="{% translate "The event’s logo" %}">
+            {% elif request.event %}
+              {{ request.event.name }}
             {% endif %}
-        </div>
-        {% if request.event and not request.event.is_public and not is_html_export %}
-            <div id="event-nonpublic" class="d-print-none">
-                <i class="fa fa-user-secret"></i>
-                {% blocktranslate trimmed %}
-                    This event is currently non-public. Only organisers can see it.
-                {% endblocktranslate %}
-            </div>
-        {% endif %}
-        <div class="container{% block container_width %}{% endblock container_width %}" id="main-container">
-            <header>
-                <h1>
-                    <a href="{% block nav_link %}{% endblock nav_link %}">
-                        {% if request.event and request.event.logo %}
-                            <img loading="lazy" src="{{ request.event.logo.url }}" id="event-logo" alt="{% translate "The event’s logo" %}">
-                        {% elif request.event %}
-                            {{ request.event.name }}
-                        {% endif %}
-                    </a>
-                </h1>
-                <div class="header-wrapper">
-                    <div id="header-tabs">
-                        {% block header_tabs %}{% endblock header_tabs %}
-                    </div>
-                    <div class="header-row-right">
-                        {% if request.event and request.event.locales|length > 1 and not is_html_export %}
-                            <div class="locales">
-                                {% for l, name in request.event.named_locales %}
-                                    <a href="{% url "cfp:locale.set" event=request.event.slug %}?locale={{ l }}&next={{ request.path }}%3F{{ request.META.QUERY_STRING|urlencode }}"
-                                       class="{% if l|lower == request.LANGUAGE_CODE|lower %}active{% endif %}">{{ name }}</a>
-                                {% endfor %}
-                                •&nbsp;
-                            </div>
-                        {% endif %}
-                        {% block header_right %}{% endblock header_right %}
-                        {% if request.event and request.user.is_authenticated and not is_html_export %}
-                            <details id="user-dropdown-label" class="dropdown" aria-haspopup="menu" role="menu">
-                                {% has_perm "orga.view_orga_area" request.user request.event as can_see_orga_area %}
-                                <summary>
-                                    {{ request.user.get_display_name }} <i class="fa fa-caret-down ml-1"></i>
-                                </summary>
-                                <div id="user-dropdown" class="dropdown-content dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
-                                    <a href="{% url "cfp:event.user.submissions" event=request.event.slug %}" class="dropdown-item" role="menuitem" tabindex="-1">
-                                        <i class="fa fa-sticky-note-o mr-2"></i>
-                                        {% translate "My proposals" %}
-                                    </a>
-                                    <a href="{{ request.event.urls.user_mails }}" class="dropdown-item" role="menuitem" tabindex="-1">
-                                        <i class="fa fa-envelope mr-2"></i>
-                                        {% translate "My Emails" %}
-                                    </a>
-                                    <a href="{{ request.event.urls.user }}" class="dropdown-item" role="menuitem" tabindex="-1">
-                                        <i class="fa fa-address-card-o mr-2"></i>
-                                        {% translate "My profile" %}
-                                    </a>
-                                    {% if can_see_orga_area %}
-                                        <hr>
-                                        <a href="{{ request.event.orga_urls.base }}" class="dropdown-item" role="menuitem" tabindex="-1">
-                                            <i class="fa fa-gears mr-2"></i>
-                                            {% translate "Organiser area" %}
-                                        </a>
-                                    {% endif %}
-                                    <hr>
-                                    <form action="{% url "cfp:event.logout" event=request.event.slug %}" method="post">
-                                        {% csrf_token %}
-                                        <button class="dropdown-item" role="menuitem" type="submit" tabindex="-1">
-                                            <i class="fa fa-sign-out mr-2 ml-1"></i>
-                                            {% translate "Logout" %}
-                                        </button>
-                                    </form>
-                                </div>
-                            </details>
-                        {% elif not subheader_login_link_disabled and not is_html_export %}
-                            {% if request.event %}
-                                <a href="{{ request.event.urls.login }}?next={{ request.path|urlencode }}">login</a>
-                            {% else %}
-                                <a href="{% url "orga:login" %}">login</a>
-                            {% endif %}
-                        {% endif %}
-                    </div>
-                </div>
-            </header>
-            <div class="card" id="main-card">
-                <main>
-                    {% if messages %}
-                        {% for message in messages %}<div class="alert alert-{{ message.tags }}">{{ message }}</div>{% endfor %}
-                    {% endif %}
-
-                    {% block content %}{% endblock content %}
-                </main>
-            </div>
-            <footer>
-                {% if is_html_export %}
-                    <div id="exporttimestamp" class="text-muted mb-4">
-                        {% now "Y-m-d H:i T" as timestamp %}
-                        {% blocktranslate trimmed %}
-                            This is a static export generated at {{ timestamp }}
-                        {% endblocktranslate %}
-                    </div>
-                {% endif %}
-                {% include "common/powered_by.html" %}
-                {% if request.event %}
-                    ·
-                    <a href="mailto:{{ request.event.email }}">{% translate "Contact us" %}</a>
-                {% endif %}
-                {% if request.event.display_settings.imprint_url %}
-                    ·
-                    <a href="{{ request.event.display_settings.imprint_url }}" target="_blank" rel="noopener">{% translate "Imprint" %}</a>
-                {% endif %}
-                {% for footer in footer_links %}
-                    ·
-                    <a href="{% safelink footer.url %}" target="_blank" rel="noopener">{{ footer.label }}</a>
+          </a>
+        </h1>
+        <div class="header-wrapper">
+          <div id="header-tabs">
+            {% block header_tabs %}{% endblock header_tabs %}
+          </div>
+          <div class="header-row-right">
+            {% if request.event and request.event.locales|length > 1 and not is_html_export %}
+              <div class="locales">
+                {% for l, name in request.event.named_locales %}
+                  <a href="{% url "cfp:locale.set" event=request.event.slug %}?locale={{ l }}&next={{ request.path }}%3F{{ request.META.QUERY_STRING|urlencode }}"
+                     class="{% if l|lower == request.LANGUAGE_CODE|lower %}active{% endif %}">{{ name }}</a>
                 {% endfor %}
-            </footer>
+                •&nbsp;
+              </div>
+            {% endif %}
+            {% block header_right %}{% endblock header_right %}
+            {% if request.event and request.user.is_authenticated and not is_html_export %}
+              <details id="user-dropdown-label" class="dropdown" aria-haspopup="menu" role="menu">
+                {% has_perm "orga.view_orga_area" request.user request.event as can_see_orga_area %}
+                <summary>
+                  {{ request.user.get_display_name }} <i class="fa fa-caret-down ml-1"></i>
+                </summary>
+                <div id="user-dropdown" class="dropdown-content dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
+                  <a href="{% url "cfp:event.user.submissions" event=request.event.slug %}" class="dropdown-item" role="menuitem" tabindex="-1">
+                    <i class="fa fa-sticky-note-o mr-2"></i>
+                    {% translate "My proposals" %}
+                  </a>
+                  <a href="{{ request.event.urls.user_mails }}" class="dropdown-item" role="menuitem" tabindex="-1">
+                    <i class="fa fa-envelope mr-2"></i>
+                    {% translate "My Emails" %}
+                  </a>
+                  <a href="{{ request.event.urls.user }}" class="dropdown-item" role="menuitem" tabindex="-1">
+                    <i class="fa fa-address-card-o mr-2"></i>
+                    {% translate "My profile" %}
+                  </a>
+                  {% if can_see_orga_area %}
+                    <hr>
+                    <a href="{{ request.event.orga_urls.base }}" class="dropdown-item" role="menuitem" tabindex="-1">
+                      <i class="fa fa-gears mr-2"></i>
+                      {% translate "Organiser area" %}
+                    </a>
+                  {% endif %}
+                  <hr>
+                  <form action="{% url "cfp:event.logout" event=request.event.slug %}" method="post">
+                    {% csrf_token %}
+                    <button class="dropdown-item" role="menuitem" type="submit" tabindex="-1">
+                      <i class="fa fa-sign-out mr-2 ml-1"></i>
+                      {% translate "Logout" %}
+                    </button>
+                  </form>
+                </div>
+              </details>
+            {% elif not subheader_login_link_disabled and not is_html_export %}
+              {% if request.event %}
+                <a href="{{ request.event.urls.login }}?next={{ request.path|urlencode }}">login</a>
+              {% else %}
+                <a href="{% url "orga:login" %}">login</a>
+              {% endif %}
+            {% endif %}
+          </div>
         </div>
-    </body>
+      </header>
+      <div class="card" id="main-card">
+        <main>
+          {% if messages %}
+            {% for message in messages %}<div class="alert alert-{{ message.tags }}">{{ message }}</div>{% endfor %}
+          {% endif %}
+
+          {% block content %}{% endblock content %}
+        </main>
+      </div>
+      <footer>
+        {% if is_html_export %}
+          <div id="exporttimestamp" class="text-muted mb-4">
+            {% now "Y-m-d H:i T" as timestamp %}
+            {% blocktranslate trimmed %}
+              This is a static export generated at {{ timestamp }}
+            {% endblocktranslate %}
+          </div>
+        {% endif %}
+        {% include "common/powered_by.html" %}
+        {% if request.event %}
+          ·
+          <a href="mailto:{{ request.event.email }}">{% translate "Contact us" %}</a>
+        {% endif %}
+        {% if request.event.display_settings.imprint_url %}
+          ·
+          <a href="{{ request.event.display_settings.imprint_url }}" target="_blank" rel="noopener">{% translate "Imprint" %}</a>
+        {% endif %}
+        {% for footer in footer_links %}
+          ·
+          <a href="{% safelink footer.url %}" target="_blank" rel="noopener">{{ footer.label }}</a>
+        {% endfor %}
+      </footer>
+    </div>
+  </body>
 </html>

--- a/src/pretalx/common/templates/common/error.html
+++ b/src/pretalx/common/templates/common/error.html
@@ -4,28 +4,28 @@
 
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>{% block title %}{% endblock title %} {{site_name}}</title>
-        {% compress css %}
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_reset.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/base.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_variables.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_fonts.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/error.css" %}" />
-        {% endcompress %}
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta charset="UTF-8">
+  <head>
+    <title>{% block title %}{% endblock title %} {{site_name}}</title>
+    {% compress css %}
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_reset.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/base.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_variables.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_fonts.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/error.css" %}" />
+    {% endcompress %}
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
 
-        {% include "common/includes/favicon.html" %}
+    {% include "common/includes/favicon.html" %}
 
-    </head>
-    <body>
-        <div id="wrapper">
-            {% block error_image %}{% endblock error_image %}
-            {% block content %}
-                <h2>{% block error_message %}{% endblock error_message %}</h2>
-                <h4 class="mt-4">HTTP {% block error_code %}{% endblock error_code %}</h4>
-            {% endblock content %}
-        </div>
-    </body>
+  </head>
+  <body>
+    <div id="wrapper">
+      {% block error_image %}{% endblock error_image %}
+      {% block content %}
+        <h2>{% block error_message %}{% endblock error_message %}</h2>
+        <h4 class="mt-4">HTTP {% block error_code %}{% endblock error_code %}</h4>
+      {% endblock content %}
+    </div>
+  </body>
 </html>

--- a/src/pretalx/common/templates/common/forms/field.html
+++ b/src/pretalx/common/templates/common/forms/field.html
@@ -1,26 +1,26 @@
 {% load i18n %}
 <div class="form-group {{ form_group_class }}{% with classes=field.css_classes %}{% if classes %} {{ classes }}{% endif %}{% endwith %}">
-    {% block field_label_left %}
-        {% if field.field.widget.input_type != "checkbox" or field.field.widget.allow_multiple_selected %}
-            <label for="{{ field.auto_id }}" class="{{ label_class }}">
-                {{ field.label }}
-                {% if not field.field.required %}<span class="optional">{% translate "Optional" %}</span>{% endif %}
-            </label>
-        {% endif %}
-    {% endblock %}
+  {% block field_label_left %}
+    {% if field.field.widget.input_type != "checkbox" or field.field.widget.allow_multiple_selected %}
+      <label for="{{ field.auto_id }}" class="{{ label_class }}">
+        {{ field.label }}
+        {% if not field.field.required %}<span class="optional">{% translate "Optional" %}</span>{% endif %}
+      </label>
+    {% endif %}
+  {% endblock %}
 
-    {% block field_content_right %}
-        {% if field.use_fieldset %}<fieldset{% if field.help_text and field.auto_id and "aria-describedby" not in field.field.widget.attrs %} aria-describedby="{{ field.auto_id }}_helptext"{% endif %}>{% endif %}
-        {{ field }}
-        {% if field.field.widget.input_type == "checkbox" and not field.field.widget.allow_multiple_selected %}
-            <label class="form-check-label" for="{{ field.auto_id }}">
-                {{ field.label }}
-            </label>
-        {% endif %}
-        {% if field.use_fieldset %}</fieldset>{% endif %}
-        {% for text in field.errors %}
-            <div class="invalid-feedback">{{ text }}</div>
-        {% endfor %}
-        {% if field.help_text %}<small class="form-text text-muted"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</small>{% endif %}
-    {% endblock %}
+  {% block field_content_right %}
+    {% if field.use_fieldset %}<fieldset{% if field.help_text and field.auto_id and "aria-describedby" not in field.field.widget.attrs %} aria-describedby="{{ field.auto_id }}_helptext"{% endif %}>{% endif %}
+    {{ field }}
+    {% if field.field.widget.input_type == "checkbox" and not field.field.widget.allow_multiple_selected %}
+      <label class="form-check-label" for="{{ field.auto_id }}">
+        {{ field.label }}
+      </label>
+    {% endif %}
+    {% if field.use_fieldset %}</fieldset>{% endif %}
+    {% for text in field.errors %}
+      <div class="invalid-feedback">{{ text }}</div>
+    {% endfor %}
+    {% if field.help_text %}<small class="form-text text-muted"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</small>{% endif %}
+  {% endblock %}
 </div>

--- a/src/pretalx/common/templates/common/includes/action_confirm.html
+++ b/src/pretalx/common/templates/common/includes/action_confirm.html
@@ -4,30 +4,30 @@
 <p><b>{{ action_object_name }}</b></p>
 <p>{{ action_text }}</p>
 <form method="post">
-    {% csrf_token %}
-    <div class="submit-group">
-        <a href="{{ action_back_url }}" class="btn btn-lg btn-{{ action_back_color }}">
-            {% if action_back_icon %}<i class="fa fa-{{ action_back_icon }}"></i>{% endif %}
-            {{ action_back_label }}
-        </a>
-        <div>
-            {% for action in additional_actions %}
-                {% if action.href %}
-                    <a href="{{ action.href }}" class="btn btn-lg btn-{{ action.color }}">
-                        <i class="fa fa-{{ action.icon }}"></i>
-                        {{ action.label }}
-                    </a>
-                {% else %}
-                    <button type="submit" class="btn btn-lg btn-{{ action.color }}" name="{{ action.name }}" value="{{ action.value }}">
-                        {% if action.icon %}<i class="fa fa-{{ action.icon }}"></i>{% endif %}
-                        {{ action.label }}
-                    </button>
-                {% endif %}
-            {% endfor %}
-            <button type="submit" class="btn btn-lg btn-{{ action_confirm_color }}" {% if action_confirm_name %}name="{{ action_confirm_name }}"{% endif %} {% if action_confirm_value %}value="{{ action_confirm_value }}"{% endif %}>
-                {% if action_confirm_icon %}<i class="fa fa-{{ action_confirm_icon }}"></i>{% endif %}
-                {{ action_confirm_label }}
-            </button>
-        </div>
+  {% csrf_token %}
+  <div class="submit-group">
+    <a href="{{ action_back_url }}" class="btn btn-lg btn-{{ action_back_color }}">
+      {% if action_back_icon %}<i class="fa fa-{{ action_back_icon }}"></i>{% endif %}
+      {{ action_back_label }}
+    </a>
+    <div>
+      {% for action in additional_actions %}
+        {% if action.href %}
+          <a href="{{ action.href }}" class="btn btn-lg btn-{{ action.color }}">
+            <i class="fa fa-{{ action.icon }}"></i>
+            {{ action.label }}
+          </a>
+        {% else %}
+          <button type="submit" class="btn btn-lg btn-{{ action.color }}" name="{{ action.name }}" value="{{ action.value }}">
+            {% if action.icon %}<i class="fa fa-{{ action.icon }}"></i>{% endif %}
+            {{ action.label }}
+          </button>
+        {% endif %}
+      {% endfor %}
+      <button type="submit" class="btn btn-lg btn-{{ action_confirm_color }}" {% if action_confirm_name %}name="{{ action_confirm_name }}"{% endif %} {% if action_confirm_value %}value="{{ action_confirm_value }}"{% endif %}>
+        {% if action_confirm_icon %}<i class="fa fa-{{ action_confirm_icon }}"></i>{% endif %}
+        {{ action_confirm_label }}
+      </button>
     </div>
+  </div>
 </form>

--- a/src/pretalx/common/templates/common/includes/favicon.html
+++ b/src/pretalx/common/templates/common/includes/favicon.html
@@ -1,9 +1,9 @@
 {% load static %}
 
 {% if development_mode %}
-    <link rel="icon" type="image/png" sizes="16x16" href="{% static "common/img/icons/favicon_debug.ico" %}">
-    <link rel="apple-touch-icon" href="{% static "common/img/icons/apple-touch-icon-180x180_debug.png" %}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{% static "common/img/icons/favicon_debug.ico" %}">
+  <link rel="apple-touch-icon" href="{% static "common/img/icons/apple-touch-icon-180x180_debug.png" %}">
 {% else %}
-    <link rel="icon" type="image/png" sizes="16x16" href="{% static "common/img/icons/favicon.ico" %}">
-    <link rel="apple-touch-icon" href="{% static "common/img/icons/apple-touch-icon-180x180.png" %}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{% static "common/img/icons/favicon.ico" %}">
+  <link rel="apple-touch-icon" href="{% static "common/img/icons/apple-touch-icon-180x180.png" %}">
 {% endif %}

--- a/src/pretalx/common/templates/common/logs.html
+++ b/src/pretalx/common/templates/common/logs.html
@@ -1,37 +1,37 @@
 {% load i18n %}
 
 {% if entries|length %}
-    <div class="card">
-        <ul class="list-group list-group-flush">
-            {% for log in entries %}
-                <li class="list-group-item logentry">
-                    <span class="time">
-                        <i class="fa fa-clock-o"></i> {{ log.timestamp|date:"SHORT_DATETIME_FORMAT" }}
-                    </span>
-                    <span class="person">
-                        {% if log.person %}
-                            {% if log.is_orga_action %}
-                                <br>
-                                <i class="fa fa-check-circle fa-fw"
-                                   data-toggle="tooltip"
-                                   title="{% translate "This change was performed by a member of the event orga." %}">
-                                </i>
-                            {% else %}
-                                <i class="fa fa-user fa-fw"></i>
-                            {% endif %}
-                            {% if log.is_orga_action and hide_orga %}
-                                {% translate "An organiser" %}
-                            {% else %}
-                                {{ log.person.get_display_name }}
-                            {% endif %}
-                        {% endif %}
-                    </span>
-                    <span class="log-object">
-                        {% if not hide_orga and log.display_object %}<i class="fa fa-flag"></i>{{ log.display_object|safe }}{% endif %}
-                    </span>
-                    <span class="log-text">{{ log.display }}</span>
-                </li>
-            {% endfor %}
-        </ul>
-    </div>
+  <div class="card">
+    <ul class="list-group list-group-flush">
+      {% for log in entries %}
+        <li class="list-group-item logentry">
+          <span class="time">
+            <i class="fa fa-clock-o"></i> {{ log.timestamp|date:"SHORT_DATETIME_FORMAT" }}
+          </span>
+          <span class="person">
+            {% if log.person %}
+              {% if log.is_orga_action %}
+                <br>
+                <i class="fa fa-check-circle fa-fw"
+                   data-toggle="tooltip"
+                   title="{% translate "This change was performed by a member of the event orga." %}">
+                </i>
+              {% else %}
+                <i class="fa fa-user fa-fw"></i>
+              {% endif %}
+              {% if log.is_orga_action and hide_orga %}
+                {% translate "An organiser" %}
+              {% else %}
+                {{ log.person.get_display_name }}
+              {% endif %}
+            {% endif %}
+          </span>
+          <span class="log-object">
+            {% if not hide_orga and log.display_object %}<i class="fa fa-flag"></i>{{ log.display_object|safe }}{% endif %}
+          </span>
+          <span class="log-text">{{ log.display }}</span>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
 {% endif %}

--- a/src/pretalx/common/templates/common/mail_log.html
+++ b/src/pretalx/common/templates/common/mail_log.html
@@ -1,24 +1,24 @@
 {% load rich_text %}
 {% if mails %}
-    <div id="accordion">
-        {% for mail in mails %}
-            <div class="card mail-card">
-                <div class="card-header" id="subject-{{ mail.pk }}">
-                    <h5 class="mb-0 d-flex justify-content-between align-items-baseline w-100" data-toggle="collapse" data-target="#mail-{{ mail.pk }}" aria-controls="mail-{{ mail.pk }}">
-                        <span class="mb-2 mt-2">
-                            <i class="fa fa-envelope mr-2"></i>
-                            {{ mail.subject }}
-                        </span>
-                        <small class="text-muted">{{ mail.sent }}</small>
-                    </h5>
-                </div>
+  <div id="accordion">
+    {% for mail in mails %}
+      <div class="card mail-card">
+        <div class="card-header" id="subject-{{ mail.pk }}">
+          <h5 class="mb-0 d-flex justify-content-between align-items-baseline w-100" data-toggle="collapse" data-target="#mail-{{ mail.pk }}" aria-controls="mail-{{ mail.pk }}">
+            <span class="mb-2 mt-2">
+              <i class="fa fa-envelope mr-2"></i>
+              {{ mail.subject }}
+            </span>
+            <small class="text-muted">{{ mail.sent }}</small>
+          </h5>
+        </div>
 
-                <div id="mail-{{ mail.pk }}" class="collapse" aria-labelledby="subject-{{ subject.pk }}" aria-expanded="false" data-parent="#accordion">
-                    <div class="card-body">
-                        {{ mail.text|rich_text }}
-                    </div>
-                </div>
-            </div>
-        {% endfor %}
-    </div>
+        <div id="mail-{{ mail.pk }}" class="collapse" aria-labelledby="subject-{{ subject.pk }}" aria-expanded="false" data-parent="#accordion">
+          <div class="card-body">
+            {{ mail.text|rich_text }}
+          </div>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
 {% endif %}

--- a/src/pretalx/common/templates/common/powered_by.html
+++ b/src/pretalx/common/templates/common/powered_by.html
@@ -33,7 +33,7 @@
 {% endcomment %}
 {% safelink "https://eventyay.com" as redir %}
 {% with 'href="'|add:redir|add:'" target="_blank" rel="noopener"'|safe as a_attr %}
-    {% blocktranslate trimmed %}
-        powered by <a {{ a_attr }}>eventyay</a>
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+    powered by <a {{ a_attr }}>eventyay</a>
+  {% endblocktranslate %}
 {% endwith %}

--- a/src/pretalx/common/templates/common/question_answer.html
+++ b/src/pretalx/common/templates/common/question_answer.html
@@ -2,16 +2,16 @@
 {% load rich_text %}
 
 {% if answer.question.variant == "file" %}
-    <i class="fa fa-file-o"></i>
-    {% if answer.answer_file %}
-        <a href="{{ answer.answer_file.url }}">{{ answer.answer_file }}</a>
-    {% else %}
-        {% translate "No file provided" %}
-    {% endif %}
+  <i class="fa fa-file-o"></i>
+  {% if answer.answer_file %}
+    <a href="{{ answer.answer_file.url }}">{{ answer.answer_file }}</a>
+  {% else %}
+    {% translate "No file provided" %}
+  {% endif %}
 {% elif answer.question.variant == "boolean" %}
-    {{ answer.boolean_answer|yesno }}
+  {{ answer.boolean_answer|yesno }}
 {% elif answer %}
-    {{ answer.answer|rich_text }}
+  {{ answer.answer|rich_text }}
 {% else %}
-    {% translate "Not answered" %}
+  {% translate "Not answered" %}
 {% endif %}

--- a/src/pretalx/common/templates/common/redirect.html
+++ b/src/pretalx/common/templates/common/redirect.html
@@ -9,22 +9,22 @@
 {% block error_image %}<i class="fa fa-link fa-fw big-icon"></i>{% endblock error_image %}
 
 {% block content %}
-    <div class="error-details">
-        <h1>{% translate "Redirect" %}</h1>
-        <h3>
-            {% blocktranslate trimmed with host="<strong>"|add:hostname|add:"</strong>"|safe %}
-                The link you clicked on wants to redirect you to a destination on the website {{ host }}.
-            {% endblocktranslate %}
-            {% blocktranslate trimmed %}
-                Please only proceed if you trust this website to be safe.
-            {% endblocktranslate %}
-        </h3>
-        <p>
-            <a href="{{ url }}" class="btn btn-primary btn-lg">
-                {% blocktranslate trimmed with host=hostname %}
-                    Proceed to {{ host }}
-                {% endblocktranslate %}
-            </a>
-        </p>
-    </div>
+  <div class="error-details">
+    <h1>{% translate "Redirect" %}</h1>
+    <h3>
+      {% blocktranslate trimmed with host="<strong>"|add:hostname|add:"</strong>"|safe %}
+        The link you clicked on wants to redirect you to a destination on the website {{ host }}.
+      {% endblocktranslate %}
+      {% blocktranslate trimmed %}
+        Please only proceed if you trust this website to be safe.
+      {% endblocktranslate %}
+    </h3>
+    <p>
+      <a href="{{ url }}" class="btn btn-primary btn-lg">
+        {% blocktranslate trimmed with host=hostname %}
+          Proceed to {{ host }}
+        {% endblocktranslate %}
+      </a>
+    </p>
+  </div>
 {% endblock content %}

--- a/src/pretalx/common/templates/common/table.html
+++ b/src/pretalx/common/templates/common/table.html
@@ -1,38 +1,38 @@
 {% load i18n %}
 
 <div class="table-container table-responsive">
-    <table {{ attrs.table }}>
-        {% if show_header %}
-            <thead {{ attrs.thead }}>
-                <tr>
-                    {% for column in columns %}
-                        <th {{ column.attrs.th }}>
-                            {% if column.orderable %}
-                                <a href="{% querystring order_by=column.order_by_alias.next %}">{{ column.header }}</a>
-                            {% else %}
-                                {{ column.header }}
-                            {% endif %}
-                        </th>
-                    {% endfor %}
-                </tr>
-            </thead>
+  <table {{ attrs.table }}>
+    {% if show_header %}
+      <thead {{ attrs.thead }}>
+        <tr>
+          {% for column in columns %}
+            <th {{ column.attrs.th }}>
+              {% if column.orderable %}
+                <a href="{% querystring order_by=column.order_by_alias.next %}">{{ column.header }}</a>
+              {% else %}
+                {{ column.header }}
+              {% endif %}
+            </th>
+          {% endfor %}
+        </tr>
+      </thead>
+    {% endif %}
+    <tbody {{ attrs.tbody }}>
+      {% for row in table.rows %}
+        <tr>
+          {% for column, cell in row.items %}
+            <td {{ column.attrs.td.as_html }}>{{ cell }}</td>
+          {% endfor %}
+        </tr>
+      {% empty %}
+        {% if table.empty_text %}
+          <tr>
+            <td colspan="{{ table.columns|length }}">{{ table.empty_text }}</td>
+          </tr>
         {% endif %}
-        <tbody {{ attrs.tbody }}>
-            {% for row in table.rows %}
-                <tr>
-                    {% for column, cell in row.items %}
-                        <td {{ column.attrs.td.as_html }}>{{ cell }}</td>
-                    {% endfor %}
-                </tr>
-            {% empty %}
-                {% if table.empty_text %}
-                    <tr>
-                        <td colspan="{{ table.columns|length }}">{{ table.empty_text }}</td>
-                    </tr>
-                {% endif %}
-            {% endfor %}
-        </tbody>
-    </table>
+      {% endfor %}
+    </tbody>
+  </table>
 
-    {% include "orga/includes/pagination.html" %"}
+  {% include "orga/includes/pagination.html" %"}
 </div>

--- a/src/pretalx/common/templates/common/user_api_token.html
+++ b/src/pretalx/common/templates/common/user_api_token.html
@@ -3,38 +3,38 @@
 {% load static %}
 
 <form method="post">
-    {% csrf_token %}
-    <fieldset>
-        <h3>{% translate "API Access" %}</h3>
-        <div>
-            <p>
-                {% blocktranslate trimmed with apiurl='href="/api/events/" target="_blank" rel="noopener"' docurl='href="#" target="_blank" rel="noopener"' %}
-                    This token can be used to access the <a {{ apiurl }}>eventyay API</a>.
-                    You can generate a new token, which will invalidate the old one.
-                    To find out more, please have a look at the <a {{ docurl }}>
-                        API documentation</a>.
-                {% endblocktranslate %}
-            </p>
-        </div>
-        <div class="form-group row ml-0 mr-0">
-            <label class="col-md-3 col-form-label">{% translate "API Token" %}</label>
-            <div class="col-md-9">
-                <code>
-                    {{ token|copyable }}
-                </code>
-                <div class="text-muted">{% translate "Use for authentication when accessing the API." %}</div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="{% if orga %}submit-group{% else %}col-md-4 flip ml-auto{% endif %}">
-                <span></span>
-                {% if orga %}<div>{% endif %}
-                <button type="submit" class="btn btn-lg btn-danger {% if not orga %}btn-block{% endif %}" name="form" value="token" data-toggle="tooltip" data-placement="left" title="{% translate "Generate a new token. The current token will not be usable any longer." %}">
-                    {% translate "Invalidate and regenerate" %}
-                </button>
-                {% if orga %}</div>{% endif %}
-            </div>
-        </div>
-    </fieldset>
+  {% csrf_token %}
+  <fieldset>
+    <h3>{% translate "API Access" %}</h3>
+    <div>
+      <p>
+        {% blocktranslate trimmed with apiurl='href="/api/events/" target="_blank" rel="noopener"' docurl='href="#" target="_blank" rel="noopener"' %}
+          This token can be used to access the <a {{ apiurl }}>eventyay API</a>.
+          You can generate a new token, which will invalidate the old one.
+          To find out more, please have a look at the <a {{ docurl }}>
+            API documentation</a>.
+        {% endblocktranslate %}
+      </p>
+    </div>
+    <div class="form-group row ml-0 mr-0">
+      <label class="col-md-3 col-form-label">{% translate "API Token" %}</label>
+      <div class="col-md-9">
+        <code>
+          {{ token|copyable }}
+        </code>
+        <div class="text-muted">{% translate "Use for authentication when accessing the API." %}</div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="{% if orga %}submit-group{% else %}col-md-4 flip ml-auto{% endif %}">
+        <span></span>
+        {% if orga %}<div>{% endif %}
+        <button type="submit" class="btn btn-lg btn-danger {% if not orga %}btn-block{% endif %}" name="form" value="token" data-toggle="tooltip" data-placement="left" title="{% translate "Generate a new token. The current token will not be usable any longer." %}">
+          {% translate "Invalidate and regenerate" %}
+        </button>
+        {% if orga %}</div>{% endif %}
+      </div>
+    </div>
+  </fieldset>
 </form>
 <script defer src="{% static "common/js/copy.js" %}"></script>

--- a/src/pretalx/common/templates/common/widgets/image_input.html
+++ b/src/pretalx/common/templates/common/widgets/image_input.html
@@ -1,13 +1,13 @@
 {% if widget.value and widget.value.url %}
-    <div class="form-image-preview">
-        <a href="{{ widget.value.url }}" data-lightbox="{{ widget.value.url }}">
-            <img loading="lazy" src="{{ widget.value.url }}">
-        </a>
-    </div>
-    <br>
+  <div class="form-image-preview">
+    <a href="{{ widget.value.url }}" data-lightbox="{{ widget.value.url }}">
+      <img loading="lazy" src="{{ widget.value.url }}">
+    </a>
+  </div>
+  <br>
 {% endif %}
 {% if widget.is_initial %}<span class="form-image-initial">{{ widget.initial_text }}: <a href="{{ widget.value.url }}" data-lightbox="{{ widget.value.url }}">{{ widget.value }}</a>{% if not widget.is_required %}
-    <span class="form-image-clear"><input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}"{% if widget.attrs.disabled %} disabled{% endif %}>
-        <label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label></span>{% endif %}</span><br>
-    {{ widget.input_text }}:{% endif %}
+  <span class="form-image-clear"><input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}"{% if widget.attrs.disabled %} disabled{% endif %}>
+    <label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label></span>{% endif %}</span><br>
+  {{ widget.input_text }}:{% endif %}
 <input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>

--- a/src/pretalx/common/templates/django/forms/widgets/input_option.html
+++ b/src/pretalx/common/templates/django/forms/widgets/input_option.html
@@ -1,7 +1,7 @@
 {% include "django/forms/widgets/input.html" %}
 
 {% if widget.wrap_label %}
-    <label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>
-        {% if not widget.attrs.hide_label %}{{ widget.label }}{% endif %}
-    </label>
+  <label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %}>
+    {% if not widget.attrs.hide_label %}{{ widget.label }}{% endif %}
+  </label>
 {% endif %}

--- a/src/pretalx/eventyay_common/templates/eventyay_common/sso/detail.html
+++ b/src/pretalx/eventyay_common/templates/eventyay_common/sso/detail.html
@@ -3,24 +3,24 @@
 {% load rules %}
 {% block extra_title %}{% translate "SSO settings" %} :: {% endblock extra_title %}
 {% block content %}
-    <h2>{% translate "SSO client settings" %}</h2>
-    <form method="post">
-        {% csrf_token %}
-        {{ form }}
-        <div class="submit-group panel">
-            <span>
-              {% if sso_provider %}
-                <a class="btn-outline-danger btn-lg" role="button" href='{% url "orga:admin.sso.delete" %}'>
-                    {% translate "Delete key" %}
-                </a>
-              {% endif %}
-            </span>
-            <span>
-                <button type="submit" class="btn-success btn-lg">
-                    <i class="fa fa-check"></i>
-                    {{ phrases.base.save }}
-                </button>
-            </span>
-        </div>
-    </form>
+  <h2>{% translate "SSO client settings" %}</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form }}
+    <div class="submit-group panel">
+      <span>
+        {% if sso_provider %}
+          <a class="btn-outline-danger btn-lg" role="button" href='{% url "orga:admin.sso.delete" %}'>
+            {% translate "Delete key" %}
+          </a>
+        {% endif %}
+      </span>
+      <span>
+        <button type="submit" class="btn-success btn-lg">
+          <i class="fa fa-check"></i>
+          {{ phrases.base.save }}
+        </button>
+      </span>
+    </div>
+  </form>
 {% endblock content %}

--- a/src/pretalx/mail/templates/mail/mailwrapper.html
+++ b/src/pretalx/mail/templates/mail/mailwrapper.html
@@ -3,148 +3,148 @@
 
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, user-scalable=false">
-    </head>
-    <style type="text/css">
-        body {
-            background-color: #eee;
-            background-position: top;
-            background-repeat: repeat-x;
-            font-family: "Open Sans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-            font-size: 16px;
-            line-height: 22px;
-            color: #333;
-            margin: 0;
-            padding-top: 20px;
-            {% if rtl %}direction: rtl;{% endif %}
-        }
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=false">
+  </head>
+  <style type="text/css">
+    body {
+      background-color: #eee;
+      background-position: top;
+      background-repeat: repeat-x;
+      font-family: "Open Sans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-size: 16px;
+      line-height: 22px;
+      color: #333;
+      margin: 0;
+      padding-top: 20px;
+      {% if rtl %}direction: rtl;{% endif %}
+    }
 
-        {% if rtl %}
-            table.layout tr td {
-                text-align: right;
-            }
-        {% endif %}
+    {% if rtl %}
+      table.layout tr td {
+        text-align: right;
+      }
+    {% endif %}
 
-        .header h1 {
-            margin-top: 0px;
-            font-size: 26px;
-            line-height: 30px;
-        }
-        .header h2 {
-            margin-top: 20px;
-            margin-bottom: 10px;
-            font-size: 22px;
-            line-height: 26px;
-        }
-        .header h2 a {
-            text-decoration: none;
-        }
-        table.layout tr td.header {
-            text-align: center;
-        }
+    .header h1 {
+      margin-top: 0px;
+      font-size: 26px;
+      line-height: 30px;
+    }
+    .header h2 {
+      margin-top: 20px;
+      margin-bottom: 10px;
+      font-size: 22px;
+      line-height: 26px;
+    }
+    .header h2 a {
+      text-decoration: none;
+    }
+    table.layout tr td.header {
+      text-align: center;
+    }
 
-        a {
-            color: {{ color }};
-            font-weight: bold;
-        }
+    a {
+      color: {{ color }};
+      font-weight: bold;
+    }
 
-        a:hover, a:focus {
-            color: {{ color }};
-            text-decoration: underline;
-        }
+    a:hover, a:focus {
+      color: {{ color }};
+      text-decoration: underline;
+    }
 
-        a:hover, a:active {
-            outline: 0;
-        }
+    a:hover, a:active {
+      outline: 0;
+    }
 
-        p {
-            margin: 0 0 10px;
-        }
+    p {
+      margin: 0 0 10px;
+    }
 
-        .footer {
-            padding: 10px;
-            text-align: center;
-            font-size: 12px;
-        }
+    .footer {
+      padding: 10px;
+      text-align: center;
+      font-size: 12px;
+    }
 
-        .content {
-            padding: 20px 28px 0 28px;
-        }
+    .content {
+      padding: 20px 28px 0 28px;
+    }
 
-        ::selection {
-            background: {{ color }};
-            color: #fff;
-        }
+    ::selection {
+      background: {{ color }};
+      color: #fff;
+    }
 
-        table.layout {
-            background: white;
-            max-width: 600px;
-            width: 100%;
-            border-spacing: 0px;
-            border-collapse: separate;
-            margin: auto;
+    table.layout {
+      background: white;
+      max-width: 600px;
+      width: 100%;
+      border-spacing: 0px;
+      border-collapse: separate;
+      margin: auto;
 
-            overflow-wrap: break-word;
-            word-wrap: break-word;
-            word-break: break-word;
-            -ms-word-break: break-all;
+      overflow-wrap: break-word;
+      word-wrap: break-word;
+      word-break: break-word;
+      -ms-word-break: break-all;
 
-            -ms-hyphens: auto;
-            -moz-hyphens: auto;
-            -webkit-hyphens: auto;
-            hyphens: auto;
-        }
-        table.layout tr.signature {
-            color: #999;
-            font-size: 12px;
-        }
-        table.layout tr.signature td {
-            padding: 0 28px;
-            text-align: center;
-            padding-top: 20px;
-        }
-        table.layout tr.last {
-            height: 40px;
-        }
+      -ms-hyphens: auto;
+      -moz-hyphens: auto;
+      -webkit-hyphens: auto;
+      hyphens: auto;
+    }
+    table.layout tr.signature {
+      color: #999;
+      font-size: 12px;
+    }
+    table.layout tr.signature td {
+      padding: 0 28px;
+      text-align: center;
+      padding-top: 20px;
+    }
+    table.layout tr.last {
+      height: 40px;
+    }
 
-        @media (max-width: 480px) {
-        }
+    @media (max-width: 480px) {
+    }
 
-        {% block addcss %}{% endblock addcss %}
-    </style>
-    <body{% if rtl %} dir="rtl" class="rtl"{% endif %}>
-        <table width="600" cellspacing="0" border="0" class="layout">
-            <tr>
-                <td class="header" background="" align="center">
-                    {% if event %}
-                        <h2>
-                            <a href="{{ event.urls.base.full }}" target="_blank" rel="noopener">{{ event.name }}</a>
-                        </h2>
-                    {% endif %}
-                    {% block header %}<h1>{{ subject }}</h1>{% endblock header %}
-                </td>
-            </tr>
-            <tr>
-                <td class="containertd">
-                    <div class="content">{{ body|safe }}</div>
-                </td>
-            </tr>
-            {% if signature and signature.strip %}
-                <tr class="signature">
-                    <td>{{ signature|rich_text }}</td>
-                </tr>
-            {% else %}
-                <tr class="last"></tr>
-            {% endif %}
-        </table>
-        <div class="footer">
+    {% block addcss %}{% endblock addcss %}
+  </style>
+  <body{% if rtl %} dir="rtl" class="rtl"{% endif %}>
+    <table width="600" cellspacing="0" border="0" class="layout">
+      <tr>
+        <td class="header" background="" align="center">
+          {% if event %}
+            <h2>
+              <a href="{{ event.urls.base.full }}" target="_blank" rel="noopener">{{ event.name }}</a>
+            </h2>
+          {% endif %}
+          {% block header %}<h1>{{ subject }}</h1>{% endblock header %}
+        </td>
+      </tr>
+      <tr>
+        <td class="containertd">
+          <div class="content">{{ body|safe }}</div>
+        </td>
+      </tr>
+      {% if signature and signature.strip %}
+        <tr class="signature">
+          <td>{{ signature|rich_text }}</td>
+        </tr>
+      {% else %}
+        <tr class="last"></tr>
+      {% endif %}
+    </table>
+    <div class="footer">
 
-            {% include "common/powered_by.html" %}
+      {% include "common/powered_by.html" %}
 
-        </div>
-        <br />
-        <br />
-    </body>
+    </div>
+    <br />
+    <br />
+  </body>
 </html>

--- a/src/pretalx/orga/templates/orga/admin/admin.html
+++ b/src/pretalx/orga/templates/orga/admin/admin.html
@@ -6,147 +6,147 @@
 {% load static %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/copy.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/copy.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{% translate "Administrator information" %} :: {% endblock extra_title %}
 
 {% block content %}
 
-    <h1>{% translate "Administrator information" %}</h1>
+  <h1>{% translate "Administrator information" %}</h1>
 
-    {% if settings.DEBUG %}
-        <div class="alert alert-danger"><span></span><span>
-            {% blocktranslate trimmed %}
-                You are running {{site_name}} in development mode. Please <strong>STOP</strong>
-                and set the DEBUG variable to False if this page is in any way reachable
-                from the internet.
-            {% endblocktranslate %}
-        </span>
-        </div>
-    {% endif %}
+  {% if settings.DEBUG %}
+    <div class="alert alert-danger"><span></span><span>
+      {% blocktranslate trimmed %}
+        You are running {{site_name}} in development mode. Please <strong>STOP</strong>
+        and set the DEBUG variable to False if this page is in any way reachable
+        from the internet.
+      {% endblocktranslate %}
+    </span>
+    </div>
+  {% endif %}
 
-    <p>
-        {% translate "Your eventyay version is:" %} <strong>{{ pretalx_version|copyable }}</strong>.
-        {% url 'orga:admin.update' as update_url %}
-        {% blocktranslate trimmed %}
-            You can check for updates <a href="{{ update_url }}">here</a>.
-        {% endblocktranslate %}
-    </p>
+  <p>
+    {% translate "Your eventyay version is:" %} <strong>{{ pretalx_version|copyable }}</strong>.
+    {% url 'orga:admin.update' as update_url %}
+    {% blocktranslate trimmed %}
+      You can check for updates <a href="{{ update_url }}">here</a>.
+    {% endblocktranslate %}
+  </p>
 
-    <h2>{% translate "Settings" %}</h2>
+  <h2>{% translate "Settings" %}</h2>
 
-    <p>
-        {% if settings.CONFIG_FILES %}
-            {% translate "Settings have been loaded from:" %}
-            {% for config_file in settings.CONFIG_FILES %}
-                <code>{{ config_file|copyable }}</code>{% if not forloop.last %},{% endif %}
-            {% endfor %}
-        {% else %}
-            {% translate "No settings files were found, all settings are either set to their default value or have been read from environment variables." %}
-        {% endif %}
-    </p>
-    <ul>
-        <li>
-            {% translate "Database" %}
-            <ul>
-                <li>
-                    {% translate "Driver" %}: <code>{{ settings.DATABASES.default.ENGINE|copyable }}</code>
-                </li>
-                <li>
-                    {% translate "Name" %}: <code>{{ settings.DATABASES.default.NAME|copyable }}</code>
-                </li>
-            </ul>
-        </li>
-        <li>
-            {% translate "Files" %}
-            <ul>
-                <li>
-                    {% translate "Log" %}: <code>{{ settings.LOG_DIR|copyable }}</code>
-                </li>
-                <li>
-                    {% translate "Static files" %}: <code>{{ settings.STATIC_ROOT|copyable }}</code>
-                </li>
-                <li>
-                    {% translate "Media files" %}: <code>{{ settings.MEDIA_ROOT|copyable }}</code>
-                </li>
-            </ul>
-        </li>
-        <li>
-            {% translate "Mails" %}
-            <ul>
-                <li>
-                    {% translate "Host" %}: <code>{{ settings.EMAIL_HOST|copyable }}</code>
-                </li>
-                <li>
-                    {% translate "Port" %}: <code>{{ settings.EMAIL_PORT|copyable }}</code>
-                </li>
-                <li>
-                    {% translate "User" %}: <code>{{ settings.EMAIL_HOST_USER|copyable }}</code>
-                </li>
-                <li>
-                    {% translate "Password" %}:
-                    {% if settings.EMAIL_HOST_PASSWORD %}
-                        {% translate "An email password has been set." %}
-                    {% else %}
-                        {% translate "No email password has been set." %}
-                    {% endif %}
-                </li>
-            </ul>
-        </li>
-    </ul>
-    <h2>{% translate "System" %}</h2>
-    <ul>
-        <li>
-            {% translate "Executable" %}: <code>{{ executable|copyable }}</code>
-        </li>
-        <li>
-            {% translate "Plugins" %}:
-            {% if settings.PLUGINS %}
-                <ul>
-                    {% for plugin in settings.PLUGINS %}<li>{{ plugin|copyable }}</li>{% endfor %}
-                </ul>
-            {% else %}
-                –
-            {% endif %}
-        </li>
-        <li>
-            {% if settings.ADMINS %}
-                {% translate "On errors, emails will be sent to:" %}
-                {% for admin in settings.ADMINS %}
-                    <code>{{ admin.0|copyable }}</code>
-                    {% if not forloop.last %},{% endif %}
-                {% endfor %}
-            {% else %}
-                {% translate "On errors, no emails will be sent." %}
-            {% endif %}
-        </li>
-    </ul>
-
-    <h3 class="mt-4">redis</h3>
-    {% if not settings.HAS_REDIS %}
-        {% translate "No redis server has been configured." %}
+  <p>
+    {% if settings.CONFIG_FILES %}
+      {% translate "Settings have been loaded from:" %}
+      {% for config_file in settings.CONFIG_FILES %}
+        <code>{{ config_file|copyable }}</code>{% if not forloop.last %},{% endif %}
+      {% endfor %}
     {% else %}
-        {% translate "Redis is used as cache backend:" %} <code>{{ settings.CACHES.redis.LOCATION|copyable }}</code>
+      {% translate "No settings files were found, all settings are either set to their default value or have been read from environment variables." %}
     {% endif %}
-
-    <h3 class="mt-4">Celery</h3>
-    {% if not settings.HAS_CELERY %}
-        {% translate "No celery workers have been configured." %}
-    {% else %}
+  </p>
+  <ul>
+    <li>
+      {% translate "Database" %}
+      <ul>
+        <li>
+          {% translate "Driver" %}: <code>{{ settings.DATABASES.default.ENGINE|copyable }}</code>
+        </li>
+        <li>
+          {% translate "Name" %}: <code>{{ settings.DATABASES.default.NAME|copyable }}</code>
+        </li>
+      </ul>
+    </li>
+    <li>
+      {% translate "Files" %}
+      <ul>
+        <li>
+          {% translate "Log" %}: <code>{{ settings.LOG_DIR|copyable }}</code>
+        </li>
+        <li>
+          {% translate "Static files" %}: <code>{{ settings.STATIC_ROOT|copyable }}</code>
+        </li>
+        <li>
+          {% translate "Media files" %}: <code>{{ settings.MEDIA_ROOT|copyable }}</code>
+        </li>
+      </ul>
+    </li>
+    <li>
+      {% translate "Mails" %}
+      <ul>
+        <li>
+          {% translate "Host" %}: <code>{{ settings.EMAIL_HOST|copyable }}</code>
+        </li>
+        <li>
+          {% translate "Port" %}: <code>{{ settings.EMAIL_PORT|copyable }}</code>
+        </li>
+        <li>
+          {% translate "User" %}: <code>{{ settings.EMAIL_HOST_USER|copyable }}</code>
+        </li>
+        <li>
+          {% translate "Password" %}:
+          {% if settings.EMAIL_HOST_PASSWORD %}
+            {% translate "An email password has been set." %}
+          {% else %}
+            {% translate "No email password has been set." %}
+          {% endif %}
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <h2>{% translate "System" %}</h2>
+  <ul>
+    <li>
+      {% translate "Executable" %}: <code>{{ executable|copyable }}</code>
+    </li>
+    <li>
+      {% translate "Plugins" %}:
+      {% if settings.PLUGINS %}
         <ul>
-            <li>
-                {% translate "Broker" %}: <code>{{ settings.CELERY_BROKER_URL|copyable }}</code>
-            </li>
-            <li>
-                {% translate "Backend" %}: <code>{{ settings.CELERY_RESULT_BACKEND|copyable }}</code>
-            </li>
-            <li>
-                {% translate "Current queue length" %}: <strong>{{ queue_length }}</strong>
-            </li>
+          {% for plugin in settings.PLUGINS %}<li>{{ plugin|copyable }}</li>{% endfor %}
         </ul>
-    {% endif %}
+      {% else %}
+        –
+      {% endif %}
+    </li>
+    <li>
+      {% if settings.ADMINS %}
+        {% translate "On errors, emails will be sent to:" %}
+        {% for admin in settings.ADMINS %}
+          <code>{{ admin.0|copyable }}</code>
+          {% if not forloop.last %},{% endif %}
+        {% endfor %}
+      {% else %}
+        {% translate "On errors, no emails will be sent." %}
+      {% endif %}
+    </li>
+  </ul>
+
+  <h3 class="mt-4">redis</h3>
+  {% if not settings.HAS_REDIS %}
+    {% translate "No redis server has been configured." %}
+  {% else %}
+    {% translate "Redis is used as cache backend:" %} <code>{{ settings.CACHES.redis.LOCATION|copyable }}</code>
+  {% endif %}
+
+  <h3 class="mt-4">Celery</h3>
+  {% if not settings.HAS_CELERY %}
+    {% translate "No celery workers have been configured." %}
+  {% else %}
+    <ul>
+      <li>
+        {% translate "Broker" %}: <code>{{ settings.CELERY_BROKER_URL|copyable }}</code>
+      </li>
+      <li>
+        {% translate "Backend" %}: <code>{{ settings.CELERY_RESULT_BACKEND|copyable }}</code>
+      </li>
+      <li>
+        {% translate "Current queue length" %}: <strong>{{ queue_length }}</strong>
+      </li>
+    </ul>
+  {% endif %}
 
 {% endblock %}

--- a/src/pretalx/orga/templates/orga/admin/update.html
+++ b/src/pretalx/orga/templates/orga/admin/update.html
@@ -6,80 +6,80 @@
 
 {% block content %}
 
-    <h2>{% translate "Update check results" %}</h2>
+  <h2>{% translate "Update check results" %}</h2>
 
-    {% if not gs.settings.update_check_enabled %}
-        <div class="alert alert-warning">{% translate "Update checks are disabled." %}</div>
-    {% elif not gs.settings.update_check_last %}
-        <div class="alert alert-info">
-            {% translate "No update check has been performed yet since the last update of this installation. Update checks are performed on a daily basis if your cronjob is set up properly." %}
-        </div>
-        <form action="" method="post">
-            {% csrf_token %}
-            <p class="d-flex">
-                <button type="submit" name="trigger" value="1" class="btn btn-outline-info flip ml-auto">
-                    <i class="fa fa-refresh mr-2"></i>
-                    {% translate "Check for updates now" %}
-                </button>
-            </p>
-        </form>
-    {% elif "error" in gs.settings.update_check_result %}
-        <div class="alert alert-danger">
-            {% translate "The last update check was not successful." %}
-            {% if gs.settings.update_check_result.error == "http_error" %}
-                {% translate "The eventyay.com server returned an error code." %}
-            {% elif gs.settings.update_check_result.error == "unavailable" %}
-                {% translate "The eventyay.com server could not be reached." %}
-            {% elif gs.settings.update_check_result.error == "development" %}
-                {% translate "This installation appears to be a development installation." %}
-            {% endif %}
-        </div>
-        <form action="" method="post">
-            {% csrf_token %}
-            <p class="d-flex">
-                <button type="submit" name="trigger" value="1" class="btn btn-outline-info flip ml-auto">
-                    <i class="fa fa-refresh mr-2"></i>
-                    {% translate "Check for updates now" %}
-                </button>
-            </p>
-        </form>
-    {% else %}
-        <form action="" method="post">
-            {% csrf_token %}
-            <p class="d-flex flex-baseline">
-                {% blocktranslate trimmed with date=gs.settings.update_check_last|date:"SHORT_DATETIME_FORMAT" %}
-                    Last updated: {{ date }}
-                {% endblocktranslate %}
-                <button type="submit" name="trigger" value="1" class="btn btn-outline-info flip ml-auto">
-                    <i class="fa fa-refresh mr-2"></i>
-                    {% translate "Check for updates now" %}
-                </button>
-            </p>
-        </form>
-        <div class="table-responsive-md">
-            <table class="table table-condensed table-flip table-sticky">
-                <thead>
-                    <tr>
-                        <th>{% translate "Component" %}</th>
-                        <th class="numeric">{% translate "Installed version" %}</th>
-                        <th class="numeric">{% translate "Latest version" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for row in result_table %}
-                        <tr class="table-{% if row.3 %}danger{% elif row.2 == "?" %}warning{% else %}success{% endif %}">
-                            <td>{{ row.0 }}</td>
-                            <td class="numeric">{{ row.1 }}</td>
-                            <td class="numeric">{{ row.2 }}</td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% endif %}
+  {% if not gs.settings.update_check_enabled %}
+    <div class="alert alert-warning">{% translate "Update checks are disabled." %}</div>
+  {% elif not gs.settings.update_check_last %}
+    <div class="alert alert-info">
+      {% translate "No update check has been performed yet since the last update of this installation. Update checks are performed on a daily basis if your cronjob is set up properly." %}
+    </div>
+    <form action="" method="post">
+      {% csrf_token %}
+      <p class="d-flex">
+        <button type="submit" name="trigger" value="1" class="btn btn-outline-info flip ml-auto">
+          <i class="fa fa-refresh mr-2"></i>
+          {% translate "Check for updates now" %}
+        </button>
+      </p>
+    </form>
+  {% elif "error" in gs.settings.update_check_result %}
+    <div class="alert alert-danger">
+      {% translate "The last update check was not successful." %}
+      {% if gs.settings.update_check_result.error == "http_error" %}
+        {% translate "The eventyay.com server returned an error code." %}
+      {% elif gs.settings.update_check_result.error == "unavailable" %}
+        {% translate "The eventyay.com server could not be reached." %}
+      {% elif gs.settings.update_check_result.error == "development" %}
+        {% translate "This installation appears to be a development installation." %}
+      {% endif %}
+    </div>
+    <form action="" method="post">
+      {% csrf_token %}
+      <p class="d-flex">
+        <button type="submit" name="trigger" value="1" class="btn btn-outline-info flip ml-auto">
+          <i class="fa fa-refresh mr-2"></i>
+          {% translate "Check for updates now" %}
+        </button>
+      </p>
+    </form>
+  {% else %}
+    <form action="" method="post">
+      {% csrf_token %}
+      <p class="d-flex flex-baseline">
+        {% blocktranslate trimmed with date=gs.settings.update_check_last|date:"SHORT_DATETIME_FORMAT" %}
+          Last updated: {{ date }}
+        {% endblocktranslate %}
+        <button type="submit" name="trigger" value="1" class="btn btn-outline-info flip ml-auto">
+          <i class="fa fa-refresh mr-2"></i>
+          {% translate "Check for updates now" %}
+        </button>
+      </p>
+    </form>
+    <div class="table-responsive-md">
+      <table class="table table-condensed table-flip table-sticky">
+        <thead>
+          <tr>
+            <th>{% translate "Component" %}</th>
+            <th class="numeric">{% translate "Installed version" %}</th>
+            <th class="numeric">{% translate "Latest version" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in result_table %}
+            <tr class="table-{% if row.3 %}danger{% elif row.2 == "?" %}warning{% else %}success{% endif %}">
+              <td>{{ row.0 }}</td>
+              <td class="numeric">{{ row.1 }}</td>
+              <td class="numeric">{{ row.2 }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
 
-    <h2>{% translate "Update check settings" %}</h2>
+  <h2>{% translate "Update check settings" %}</h2>
 
-    {% include "orga/includes/base_form.html" %}
+  {% include "orga/includes/base_form.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/admin/user_list.html
+++ b/src/pretalx/orga/templates/orga/admin/user_list.html
@@ -8,72 +8,72 @@
 {% block extra_title %}{% translate "Users" %} :: {% endblock extra_title %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/copy.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/copy.js" %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block content %}
-    <h2>{% translate "Users" %}</h2>
+  <h2>{% translate "Users" %}</h2>
 
-    <form>
-        <input name="q" type="text" {% if request.GET.q %} value="{{ request.GET.q }}" {% endif %}>
+  <form>
+    <input name="q" type="text" {% if request.GET.q %} value="{{ request.GET.q }}" {% endif %}>
+  </form>
+
+  <form method="post">
+    {% csrf_token %}
+    <div class="table-responsive">
+      <table class="table table-sm table-hover table-flip">
+        <thead>
+          <tr>
+            <th>{% translate "Name" %}</th>
+            <th>{% translate "Email" %}</th>
+            <th>{{ phrases.base.language }}</th>
+            <th>{% translate "Teams" %}</th>
+            <th>{% translate "Events" %}</th>
+            <th class="numeric">{% translate "Submissions" %}</th>
+            <th class="numeric">{% translate "Last login" %}</th>
+            <th class="numeric">{% translate "Password reset time" %}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for user in users %}
+            <tr>
+              <td>
+                <a href="{% url "orga:admin.user.view" code=user.code %}">{{ user.name }}</a>
+              </td>
+              <td>{{ user.email|copyable }}</td>
+              <td>{{ user.locale }}</td>
+              <td>
+                <ul>
+                  {% for team in user.teams.all %}
+                    <li><a href="{{ team.urls.base }}">{{ team.name }}</a></li>
+                  {% endfor %}
+                </ul>
+              </td>
+              <td>
+                <ul>
+                  {% for event in user.get_events_with_any_permission %}
+                    <li><a href="{{ event.orga_urls.base }}">{{ event.name }}</a></li>
+                  {% endfor %}
+                </ul>
+              </td>
+              <td class="numeric">{{ user.submission_count }}</td>
+              <td class="numeric-left">{{ user.last_login|timesince }} {% if user.last_login %}ago{% endif %}</td>
+              <td class="numeric-left">{{ user.pw_reset_time|timesince }}{% if user.pw_reset_time %} ago{% endif %}</td>
+              <td>
+                <div class="d-flex mb-2">
+                  <a href="{% url "orga:admin.user.view" code=user.code %}" class="btn btn-xs btn-info mr-2"> <i class="fa fa-edit"></i> </a>
+                  <a href="{% url "orga:admin.user.delete" code=user.code %}" class="btn btn-xs btn-danger"><i class="fa fa-trash"></i></a>
+                </div>
+                <button name="action" value="reset-{{ user.id }}" class="btn btn-xs btn-warning mr-2">{{ phrases.base.password_reset_heading }}</button>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </form>
-
-    <form method="post">
-        {% csrf_token %}
-        <div class="table-responsive">
-            <table class="table table-sm table-hover table-flip">
-                <thead>
-                    <tr>
-                        <th>{% translate "Name" %}</th>
-                        <th>{% translate "Email" %}</th>
-                        <th>{{ phrases.base.language }}</th>
-                        <th>{% translate "Teams" %}</th>
-                        <th>{% translate "Events" %}</th>
-                        <th class="numeric">{% translate "Submissions" %}</th>
-                        <th class="numeric">{% translate "Last login" %}</th>
-                        <th class="numeric">{% translate "Password reset time" %}</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for user in users %}
-                        <tr>
-                            <td>
-                                <a href="{% url "orga:admin.user.view" code=user.code %}">{{ user.name }}</a>
-                            </td>
-                            <td>{{ user.email|copyable }}</td>
-                            <td>{{ user.locale }}</td>
-                            <td>
-                                <ul>
-                                    {% for team in user.teams.all %}
-                                        <li><a href="{{ team.urls.base }}">{{ team.name }}</a></li>
-                                    {% endfor %}
-                                </ul>
-                            </td>
-                            <td>
-                                <ul>
-                                    {% for event in user.get_events_with_any_permission %}
-                                        <li><a href="{{ event.orga_urls.base }}">{{ event.name }}</a></li>
-                                    {% endfor %}
-                                </ul>
-                            </td>
-                            <td class="numeric">{{ user.submission_count }}</td>
-                            <td class="numeric-left">{{ user.last_login|timesince }} {% if user.last_login %}ago{% endif %}</td>
-                            <td class="numeric-left">{{ user.pw_reset_time|timesince }}{% if user.pw_reset_time %} ago{% endif %}</td>
-                            <td>
-                                <div class="d-flex mb-2">
-                                    <a href="{% url "orga:admin.user.view" code=user.code %}" class="btn btn-xs btn-info mr-2"> <i class="fa fa-edit"></i> </a>
-                                    <a href="{% url "orga:admin.user.delete" code=user.code %}" class="btn btn-xs btn-danger"><i class="fa fa-trash"></i></a>
-                                </div>
-                                <button name="action" value="reset-{{ user.id }}" class="btn btn-xs btn-warning mr-2">{{ phrases.base.password_reset_heading }}</button>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </form>
-    </div>
-    {% include "orga/includes/pagination.html" %}
+  </div>
+  {% include "orga/includes/pagination.html" %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/auth/base.html
+++ b/src/pretalx/orga/templates/orga/auth/base.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>{% block title %}{% endblock %} :: {{site_name}} </title>
-        {% compress css %}
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_reset.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/base.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_variables.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_fonts.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_forms.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "orga/css/auth.css" %}" />
-        {% endcompress %}
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="theme-color" content="#2185d0">
+  <head>
+    <title>{% block title %}{% endblock %} :: {{site_name}} </title>
+    {% compress css %}
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_reset.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/base.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_variables.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_fonts.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_forms.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "orga/css/auth.css" %}" />
+    {% endcompress %}
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#2185d0">
 
-        {% include "common/includes/favicon.html" %}
+    {% include "common/includes/favicon.html" %}
 
-        {% block scripts %}{% endblock scripts %}
+    {% block scripts %}{% endblock scripts %}
 
-    </head>
-    <body>
-        <div id="wrapper"{% if request.event.primary_color %} style="background-color: {{ request.event.primary_color }}"{% endif %}>
+  </head>
+  <body>
+    <div id="wrapper"{% if request.event.primary_color %} style="background-color: {{ request.event.primary_color }}"{% endif %}>
             {# we're not lazy-loading these images, because they are central and immediately visible, and having them flash in 100ms later looks bad #}
-            {% if not request.event.logo %}
-                <img src="{% static "common/img/logo_white.svg" %}" class="logo" alt="{% translate "The eventyay logo" %}">
-            {% else %}
-                <img height="150" width="auto" src="{{ request.event.logo.url }}" id="event-logo" alt="{% translate "The event’s logo" %}">
-            {% endif %}
-            <p>
-                {% if messages %}
-                    {% for message in messages %}
-                        <div class="card card-inverse card-{{ message.tags }} mb-3 text-center">{{ message }}</div>
-                    {% endfor %}
-                {% endif %}
-            </p>
-            <div class="card">
-                {% block content %}{% endblock content %}
-            </div>
-        </div>
-    </body>
+      {% if not request.event.logo %}
+        <img src="{% static "common/img/logo_white.svg" %}" class="logo" alt="{% translate "The eventyay logo" %}">
+      {% else %}
+        <img height="150" width="auto" src="{{ request.event.logo.url }}" id="event-logo" alt="{% translate "The event’s logo" %}">
+      {% endif %}
+      <p>
+        {% if messages %}
+          {% for message in messages %}
+            <div class="card card-inverse card-{{ message.tags }} mb-3 text-center">{{ message }}</div>
+          {% endfor %}
+        {% endif %}
+      </p>
+      <div class="card">
+        {% block content %}{% endblock content %}
+      </div>
+    </div>
+  </body>
 </html>

--- a/src/pretalx/orga/templates/orga/auth/login.html
+++ b/src/pretalx/orga/templates/orga/auth/login.html
@@ -3,5 +3,5 @@
 {% load static %}
 {% block title %}{% translate "Sign in" %}{% endblock title %}
 {% block content %}
-    {% include "common/auth.html" with hide_register=True next_url=request.get_full_path %}
+  {% include "common/auth.html" with hide_register=True next_url=request.get_full_path %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/auth/recover.html
+++ b/src/pretalx/orga/templates/orga/auth/recover.html
@@ -7,21 +7,21 @@
 {% block title %}{{ phrases.base.password_reset_heading }}{% endblock title %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
-        <script defer src="{% static 'common/js/base.js' %}"></script>
-        <script defer src="{% static 'common/js/password_strength.js' %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
+    <script defer src="{% static 'common/js/base.js' %}"></script>
+    <script defer src="{% static 'common/js/password_strength.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block content %}
-    <form method="post">
-        {% csrf_token %}
-        <div class="labelless-password-input-form">
-            <h4>{{ phrases.base.password_reset_heading }}</h4>
-            <p>{{ phrases.base.password_reset_nearly_done }}</p>
-            {{ form }}
-            <button type="submit" class="btn btn-block btn-success">{{ phrases.base.save }}</button>
-        </div>
-    </form>
+  <form method="post">
+    {% csrf_token %}
+    <div class="labelless-password-input-form">
+      <h4>{{ phrases.base.password_reset_heading }}</h4>
+      <p>{{ phrases.base.password_reset_nearly_done }}</p>
+      {{ form }}
+      <button type="submit" class="btn btn-block btn-success">{{ phrases.base.save }}</button>
+    </div>
+  </form>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/auth/reset.html
+++ b/src/pretalx/orga/templates/orga/auth/reset.html
@@ -4,13 +4,13 @@
 
 {% block title %}{{ phrases.base.password_reset_heading }}{% endblock title %}
 {% block content %}
-    <div>
-        <h4 class="text-center">{{ phrases.base.password_reset_question }}</h4>
-        <p></p>
-        <form method="post">
-            {% csrf_token %}
-            {{ form }}
-            <button type="submit" class="btn btn-block btn-success">{{ phrases.base.password_reset_action }}</button>
-        </form>
-    </div>
+  <div>
+    <h4 class="text-center">{{ phrases.base.password_reset_question }}</h4>
+    <p></p>
+    <form method="post">
+      {% csrf_token %}
+      {{ form }}
+      <button type="submit" class="btn btn-block btn-success">{{ phrases.base.password_reset_action }}</button>
+    </form>
+  </div>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -7,514 +7,514 @@
 
 <!DOCTYPE html>
 <html lang="{{ html_locale }}"{% if rtl %} dir="rtl" class="rtl"{% endif %}>
-    <head>
-        <meta charset="utf-8">
-        <title>{% block title %}{% block extra_title %}{% endblock %}{% if request.event %}{{ request.event.name }} :: {% endif %}{% endblock %} {{ site_config.name }}</title>
-        <meta name="title" content="{% block meta_title %}{% endblock %} {% if request.event %} - {{ request.event.name }} {% endif %} {{ site_config.name }}">
-        <meta name="description" content="{% block meta_description %}{% if request.event %}Schedule, talks and talk submissions for {{ request.event.name }}{% else %}Talks and talk submissions by {{ site_config.name }} {% endif %}{% endblock %}">
-        <meta name="application-name" content={{ site_config.name }}>
-        <meta name="generator" content={{ site_config.name }}>
-        <meta name="keywords" content="{% if request.event %}{{ request.event.name }}, {{ request.event.slug }}, {% if request.event.date_from %}{{ request.event.date_from.year }}, {% endif %}{% endif %}schedule, talks, cfp, call for papers, conference, submissions, organizer">
-        <meta name="robots" content="nofollow">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="theme-color" content="#2185d0">
-        <meta name="HandheldFriendly" content="True"/>
-        {% if request.event and request.event.logo %}<meta property="thumbnail" content="{{ request.event.urls.logo.full }}">{% endif %}
-        {% block alternate_link %}
-            <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.base.full }}" />
-        {% endblock alternate_link %}
+  <head>
+    <meta charset="utf-8">
+    <title>{% block title %}{% block extra_title %}{% endblock %}{% if request.event %}{{ request.event.name }} :: {% endif %}{% endblock %} {{ site_config.name }}</title>
+    <meta name="title" content="{% block meta_title %}{% endblock %} {% if request.event %} - {{ request.event.name }} {% endif %} {{ site_config.name }}">
+    <meta name="description" content="{% block meta_description %}{% if request.event %}Schedule, talks and talk submissions for {{ request.event.name }}{% else %}Talks and talk submissions by {{ site_config.name }} {% endif %}{% endblock %}">
+    <meta name="application-name" content={{ site_config.name }}>
+    <meta name="generator" content={{ site_config.name }}>
+    <meta name="keywords" content="{% if request.event %}{{ request.event.name }}, {{ request.event.slug }}, {% if request.event.date_from %}{{ request.event.date_from.year }}, {% endif %}{% endif %}schedule, talks, cfp, call for papers, conference, submissions, organizer">
+    <meta name="robots" content="nofollow">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#2185d0">
+    <meta name="HandheldFriendly" content="True"/>
+    {% if request.event and request.event.logo %}<meta property="thumbnail" content="{{ request.event.urls.logo.full }}">{% endif %}
+    {% block alternate_link %}
+      <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.base.full }}" />
+    {% endblock alternate_link %}
 
-        {% include "common/includes/favicon.html" %}
+    {% include "common/includes/favicon.html" %}
 
-        {% compress css %}
-            <link rel="stylesheet" type="text/css" href="{% static "vendored/choices/choices.min.css" %}" />
-            <link rel="stylesheet" type="text/x-scss" href="{% static "vendored/forkawesome/scss/fork-awesome.scss" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_reset.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/base.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_variables.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_fonts.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_forms.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_tooltip.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/availabilities.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/tabs.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_stages.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/avatar.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_dropdown.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_rtl.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "common/css/_pretalx.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "orga/css/_flags.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "orga/css/_layout.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "orga/css/_rtl.css" %}" />
-        {% endcompress %}
-        {% if request.event and request.event.primary_color %}<link rel="stylesheet" type="text/css" href="{{ request.event.urls.settings_css }}?target=orga" />{% endif %}
-        {% block stylesheets %}{% endblock stylesheets %}
-        {% compress js %}
-            <script defer src="{% static "common/js/base.js" %}"></script>
-            <script defer src="{% static "common/js/collapse.js" %}"></script>
-            <script defer src="{% static "orga/js/main.js" %}"></script>
-            <script defer src="{% static "orga/js/typeahead.js" %}"></script>
-            <script defer src="{% static "vendored/choices/choices.min.js" %}"></script>
-            <script defer src="{% static "vendored/marked.min.js" %}"></script> {# required by formtools.js #}
-            <script defer src="{% static "vendored/purify.min.js" %}"></script> {# required by formtools.js #}
-            <script defer src="{% static "common/js/formTools.js" %}"></script>
-            <script defer src="{% static "orga/js/sidebar.js" %}"></script>
-        {% endcompress %}
-        {% block scripts %}{% endblock scripts %}
-        {{ html_head|safe }}
-    </head>
-    <body data-datetimeformat="{{ js_datetime_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}">
-        <nav class="navbar">
-            <ul class="navbar-nav d-block">
-                <li class="nav-item">
-                    <a class="nav-link" data-toggle="sidebar" href="#" id="sidebar-toggle">
-                        <i class="fa fa-bars fa-lg"></i>
-                    </a>
-                </li>
-            </ul>
-            <a class="navbar-brand" href="{% url "orga:event.list" %}">
-                <img loading="lazy" src="{% static "common/img/icons/icon.svg" %}" alt="{% translate "The {{ site_config.name }} logo" %}">
-                {{ site_config.name }}
+    {% compress css %}
+      <link rel="stylesheet" type="text/css" href="{% static "vendored/choices/choices.min.css" %}" />
+      <link rel="stylesheet" type="text/x-scss" href="{% static "vendored/forkawesome/scss/fork-awesome.scss" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_reset.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/base.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_variables.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_fonts.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_forms.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_tooltip.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/availabilities.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/tabs.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_stages.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/avatar.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_dropdown.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_rtl.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "common/css/_pretalx.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "orga/css/_flags.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "orga/css/_layout.css" %}" />
+      <link rel="stylesheet" type="text/css" href="{% static "orga/css/_rtl.css" %}" />
+    {% endcompress %}
+    {% if request.event and request.event.primary_color %}<link rel="stylesheet" type="text/css" href="{{ request.event.urls.settings_css }}?target=orga" />{% endif %}
+    {% block stylesheets %}{% endblock stylesheets %}
+    {% compress js %}
+      <script defer src="{% static "common/js/base.js" %}"></script>
+      <script defer src="{% static "common/js/collapse.js" %}"></script>
+      <script defer src="{% static "orga/js/main.js" %}"></script>
+      <script defer src="{% static "orga/js/typeahead.js" %}"></script>
+      <script defer src="{% static "vendored/choices/choices.min.js" %}"></script>
+      <script defer src="{% static "vendored/marked.min.js" %}"></script> {# required by formtools.js #}
+      <script defer src="{% static "vendored/purify.min.js" %}"></script> {# required by formtools.js #}
+      <script defer src="{% static "common/js/formTools.js" %}"></script>
+      <script defer src="{% static "orga/js/sidebar.js" %}"></script>
+    {% endcompress %}
+    {% block scripts %}{% endblock scripts %}
+    {{ html_head|safe }}
+  </head>
+  <body data-datetimeformat="{{ js_datetime_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}">
+    <nav class="navbar">
+      <ul class="navbar-nav d-block">
+        <li class="nav-item">
+          <a class="nav-link" data-toggle="sidebar" href="#" id="sidebar-toggle">
+            <i class="fa fa-bars fa-lg"></i>
+          </a>
+        </li>
+      </ul>
+      <a class="navbar-brand" href="{% url "orga:event.list" %}">
+        <img loading="lazy" src="{% static "common/img/icons/icon.svg" %}" alt="{% translate "The {{ site_config.name }} logo" %}">
+        {{ site_config.name }}
+      </a>
+      <div class="navbar-collapse" id="navbartoggle">
+        <ul class="navbar-nav mr-auto flip">
+          {% if request.event %}
+            <li class="nav-item">
+              {% if request.event.custom_domain and not request.event.is_public %}
+                <form action="{{ request.event.urls.auth.full }}"
+                      method="post"
+                      target="_blank"
+                      class="mobile-navbar-view-form d-flex align-items-center">
+                  <input type="hidden" value="{{ new_session }}" name="session">
+                  <input type="hidden" value="{{ go_to_target }}" name="target">
+                  <button type="submit" class="btn btn-link navbar-toggle pl-2">
+                    <i class="fa fa-eye mr-1"></i>
+                    {% translate "View event" %}
+                  </button>
+                </form>
+              {% else %}
+                <a class="nav-link d-flex align-items-center"
+                   target="_blank"
+                   rel="noopener"
+                   href="{% if go_to_target == "schedule" %}{{ request.event.urls.schedule }}{% else %}{{ request.event.cfp.urls.public }}{% endif %}">
+                  <i class="fa fa-eye mr-2 mt-0"></i>
+                  {% translate "View event" %}
+                </a>
+              {% endif %}
+            </li>
+          {% endif %}
+        </ul>
+      </div>
+      <ul class="navbar-nav">
+        {% if warning_update_available %}
+          <li class="nav-item">
+            <a href="{% url "orga:admin.update" %}" class="text-danger nav-link">
+              <i class="fa fa-bell"></i>
             </a>
-            <div class="navbar-collapse" id="navbartoggle">
-                <ul class="navbar-nav mr-auto flip">
-                    {% if request.event %}
-                        <li class="nav-item">
-                            {% if request.event.custom_domain and not request.event.is_public %}
-                                <form action="{{ request.event.urls.auth.full }}"
-                                      method="post"
-                                      target="_blank"
-                                      class="mobile-navbar-view-form d-flex align-items-center">
-                                    <input type="hidden" value="{{ new_session }}" name="session">
-                                    <input type="hidden" value="{{ go_to_target }}" name="target">
-                                    <button type="submit" class="btn btn-link navbar-toggle pl-2">
-                                        <i class="fa fa-eye mr-1"></i>
-                                        {% translate "View event" %}
-                                    </button>
-                                </form>
-                            {% else %}
-                                <a class="nav-link d-flex align-items-center"
-                                   target="_blank"
-                                   rel="noopener"
-                                   href="{% if go_to_target == "schedule" %}{{ request.event.urls.schedule }}{% else %}{{ request.event.cfp.urls.public }}{% endif %}">
-                                    <i class="fa fa-eye mr-2 mt-0"></i>
-                                    {% translate "View event" %}
-                                </a>
-                            {% endif %}
-                        </li>
-                    {% endif %}
-                </ul>
+          </li>
+        {% endif %}
+        {% block navbar_right %}{% endblock navbar_right %}
+        <li class="nav-item d-none d-md-block">
+          <a class="nav-link active" href="{% url "orga:user.view" %}">
+            <i class="fa fa-user"></i>
+            {{ request.user.get_display_name }}
+          </a>
+        </li>
+        <li class="nav-item">
+          <form action="{% url "orga:logout" %}" method="post">
+            {% csrf_token %}
+            <button class="nav-link active" type="submit">
+              <i class="fa fa-sign-out"></i>
+            </button>
+          </form>
+        </li>
+      </ul>
+    </nav>
+    {% if request.user.is_superuser %}
+      <div class="global-top-warning">
+        <i class="fa fa-exclamation-triangle"></i>
+        {% blocktranslate with link=link trimmed %}
+          You’re using eventyay as a superuser. This is not recommended.
+        {% endblocktranslate %}
+        <a href="{% url "orga:user.subuser" %}?next={{ request.path|urlencode }}">
+          {% translate "Please click here to switch to an administrator account." %}
+        </a>
+      </div>
+    {% endif %}
+    {% if warning_update_check_active %}
+      <div class="global-top-warning">
+        <a href="{% url "orga:admin.update" %}">
+          {% blocktranslate trimmed %}
+            Starting with version 1.1.0, eventyay automatically checks for updates in the background.
+            During this check, anonymous data is transmitted to servers operated by the eventyay
+            developers. Click on this message to find out more, disable this feature or enter your
+            email address to get notified via email if a new update arrives. This message will
+            disappear once you clicked it.
+          {% endblocktranslate %}
+        </a>
+      </div>
+    {% endif %}
+    <div id="page-wrapper">
+      {% if not request.user.is_anonymous %}<aside class="nav flex-column sidebar">
+        <details class="dropdown nav-link p-0" id="nav-search-wrapper">
+          <summary id="nav-search" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span id="search-context-icon" class="fa-stack fa-lg">
+              <i class="fa fa-circle fa-stack-2x"></i>
+              <i class="fa fa-{% if request.event %}calendar{% elif request.organiser %}group{% else %}user{% endif %} fa-stack-1x fa-inverse"></i>
+            </span>
+            <div id="search-context-text">
+              {% if request.event %}
+                <span class="context-name">{{ request.event.name }}</span>
+                <span class="context-meta">{{ request.event.get_date_range_display }}</span>
+              {% elif request.organiser %}
+                <span class="context-name">{{ request.organiser.name }}</span>
+                <span class="context-meta">{% translate "Organiser account" %}</span>
+              {% else %}
+                <span class="context-name">{{ request.user.get_display_name }}</span>
+              {% endif %}
             </div>
-            <ul class="navbar-nav">
-                {% if warning_update_available %}
-                    <li class="nav-item">
-                        <a href="{% url "orga:admin.update" %}" class="text-danger nav-link">
-                            <i class="fa fa-bell"></i>
-                        </a>
-                    </li>
-                {% endif %}
-                {% block navbar_right %}{% endblock navbar_right %}
-                <li class="nav-item d-none d-md-block">
-                    <a class="nav-link active" href="{% url "orga:user.view" %}">
-                        <i class="fa fa-user"></i>
-                        {{ request.user.get_display_name }}
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <form action="{% url "orga:logout" %}" method="post">
-                        {% csrf_token %}
-                        <button class="nav-link active" type="submit">
-                            <i class="fa fa-sign-out"></i>
-                        </button>
-                    </form>
-                </li>
+            <div class="arrow">
+              <i class="fa fa-angle-down"></i>
+            </div>
+          </summary>
+          <div id="nav-search-input-wrapper" class="dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url "orga:nav.typeahead" %}" data-event-typeahead data-organiser="{% if request.event %}{{ request.event.organiser.pk }}{% elif request.organiser %}{{ request.organiser.pk }}{% endif %}">
+            <div class="query-holder">
+              <div class="form-box">
+                <input type="search" class="form-control" placeholder="{% translate "Search" %} (Alt + k)" data-typeahead-query>
+              </div>
+            </div>
+            <ul id="search-results">
             </ul>
-        </nav>
-        {% if request.user.is_superuser %}
-            <div class="global-top-warning">
-                <i class="fa fa-exclamation-triangle"></i>
-                {% blocktranslate with link=link trimmed %}
-                    You’re using eventyay as a superuser. This is not recommended.
-                {% endblocktranslate %}
-                <a href="{% url "orga:user.subuser" %}?next={{ request.path|urlencode }}">
-                    {% translate "Please click here to switch to an administrator account." %}
-                </a>
-            </div>
-        {% endif %}
-        {% if warning_update_check_active %}
-            <div class="global-top-warning">
-                <a href="{% url "orga:admin.update" %}">
-                    {% blocktranslate trimmed %}
-                        Starting with version 1.1.0, eventyay automatically checks for updates in the background.
-                        During this check, anonymous data is transmitted to servers operated by the eventyay
-                        developers. Click on this message to find out more, disable this feature or enter your
-                        email address to get notified via email if a new update arrives. This message will
-                        disappear once you clicked it.
-                    {% endblocktranslate %}
-                </a>
-            </div>
-        {% endif %}
-        <div id="page-wrapper">
-            {% if not request.user.is_anonymous %}<aside class="nav flex-column sidebar">
-                <details class="dropdown nav-link p-0" id="nav-search-wrapper">
-                    <summary id="nav-search" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span id="search-context-icon" class="fa-stack fa-lg">
-                            <i class="fa fa-circle fa-stack-2x"></i>
-                            <i class="fa fa-{% if request.event %}calendar{% elif request.organiser %}group{% else %}user{% endif %} fa-stack-1x fa-inverse"></i>
-                        </span>
-                        <div id="search-context-text">
-                            {% if request.event %}
-                                <span class="context-name">{{ request.event.name }}</span>
-                                <span class="context-meta">{{ request.event.get_date_range_display }}</span>
-                            {% elif request.organiser %}
-                                <span class="context-name">{{ request.organiser.name }}</span>
-                                <span class="context-meta">{% translate "Organiser account" %}</span>
-                            {% else %}
-                                <span class="context-name">{{ request.user.get_display_name }}</span>
-                            {% endif %}
-                        </div>
-                        <div class="arrow">
-                            <i class="fa fa-angle-down"></i>
-                        </div>
-                    </summary>
-                    <div id="nav-search-input-wrapper" class="dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url "orga:nav.typeahead" %}" data-event-typeahead data-organiser="{% if request.event %}{{ request.event.organiser.pk }}{% elif request.organiser %}{{ request.organiser.pk }}{% endif %}">
-                        <div class="query-holder">
-                            <div class="form-box">
-                                <input type="search" class="form-control" placeholder="{% translate "Search" %} (Alt + k)" data-typeahead-query>
-                            </div>
-                        </div>
-                        <ul id="search-results">
-                        </ul>
-                    </div>
-                </details>
-                {% if request.event %}
-                    {% has_perm "orga.view_orga_area" request.user request.event as can_see_orga_area %}
-                    {% has_perm "orga.change_submissions" request.user request.event as can_see_orga_exclusive %}
-                    {% has_perm "orga.change_teams" request.user request.event as can_change_teams %}
-                    {% has_perm "orga.change_settings" request.user request.event as can_change_settings %}
-                    {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
-                    {% if can_see_orga_area %}
-                        <a class="nav-link {% if url_name == "event.dashboard" %}active{% endif %}" href="{{ request.event.orga_urls.base }}">
-                            <i class="fa fa-tachometer"></i>
-                            <span class="sidebar-text">{% translate "Dashboard" %}</span>
-                        </a>
-                    {% endif %}
-                    {% if can_see_orga_exclusive %}
-                        {% if can_change_settings %}
-                            <div class="nav-fold">
-                                <span class="has-children">
-                                    <a href="{{ request.event.orga_urls.settings }}" class="nav-link nav-link-inner">
-                                        <i class="fa fa-wrench"></i>
-                                        <span class="sidebar-text">{% translate "Settings" %}</span>
-                                    </a>
-                                    <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseSettings" aria-controls="collapseSettings">
-                                        <i class="fa fa-angle-down"></i>
-                                    </a>
-                                </span>
-                                <div class="collapse in{% if "settings." in url_name %} show{% endif %}" aria-expand="true" id="collapseSettings">
-                                    <a href="{{ request.event.orga_urls.settings }}" class="nav-link nav-link-second-level{% if "settings.event." in url_name %} active{% endif %}">
-                                        <span>{{ phrases.base.general }}</span>
-                                    </a>
-                                    {% if can_change_teams %}
-                                        <a href="{{ request.event.organiser.orga_urls.teams }}" class="nav-link nav-link-second-level{% if "settings.team." in url_name %} active{% endif %}">
-                                            <span>{% translate "Teams" %}</span>
-                                        </a>
-                                    {% endif %}
-                                    <a href="{{ request.event.orga_urls.review_settings }}" class="nav-link nav-link-second-level{% if "settings.review" in url_name %} active{% endif %}">
-                                        <span>{% translate "Review" %}</span>
-                                    </a>
-                                    <a href="{{ request.event.orga_urls.mail_settings }}" class="nav-link nav-link-second-level{% if "settings.mail" in url_name %} active{% endif %}">
-                                        <span>{% translate "Email" %}</span>
-                                    </a>
-                                    <a href="{{ request.event.orga_urls.widget_settings }}" class="nav-link nav-link-second-level{% if "settings.widget" in url_name %} active{% endif %}">
-                                        <span>{% translate "Widget" %}</span>
-                                    </a>
-                                    <a href="{{ request.event.orga_urls.plugins }}" class="nav-link nav-link-second-level{% if "settings.plugins.select" in url_name %} active{% endif %}">
-                                        <span>{% translate "Plugins" %}</span>
-                                    </a>
-                                    {% for plugin_setting in nav_settings %}
-                                        <a href="{{ plugin_setting.url }}" class="nav-link nav-link-second-level{% if plugin_setting.active %} active{% endif %}">
-                                            <span>{{ plugin_setting.label }}</span>
-                                        </a>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                            <div class="nav-fold">
-                                <span class="has-children">
-                                    <a class="nav-link nav-link-inner" href="{{ request.event.cfp.urls.text }}">
-                                        <i class="fa fa-bullhorn"></i>
-                                        <span class="sidebar-text">{% translate "Call for Speakers" %}</span>
-                                    </a>
-                                    <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseCfP" aria-controls="collapseCfP">
-                                        <i class="fa fa-angle-down"></i>
-                                    </a>
-                                </span>
-                                <div class="collapse in{% if "cfp." in url_name %} show{% endif %}" aria-expand="true" id="collapseCfP">
-                                    <a href="{{ request.event.cfp.urls.text }}" class="nav-link nav-link-second-level{% if "cfp.text" in url_name %} active{% endif %}">
-                                        <span>{% translate "Content" %}</span>
-                                    </a>
-                                    <a href="{{ request.event.cfp.urls.editor }}" class="nav-link nav-link-second-level{% if "cfp.flow" in url_name %} active{% endif %}">
-                                        <span>{% translate "Editor" %}</span>
-                                    </a>
-                                    <a href="{{ request.event.cfp.urls.questions }}" class="nav-link nav-link-second-level{% if "cfp.question" in url_name %} active{% endif %}">
-                                        <span>{{ phrases.cfp.questions }}</span>
-                                    </a>
-                                    {% if request.event|get_feature_flag:"use_tracks" %}
-                                        <a href="{{ request.event.cfp.urls.tracks }}" class="nav-link nav-link-second-level{% if "cfp.track" in url_name %} active{% endif %}">
-                                            <span>{% translate "Tracks" %}</span>
-                                        </a>
-                                    {% endif %}
-                                    <a href="{{ request.event.cfp.urls.types }}" class="nav-link nav-link-second-level{% if "cfp.type" in url_name %} active{% endif %}">
-                                        <span>{% translate "Session types" %}</span>
-                                    </a>
-                                    <a href="{{ request.event.cfp.urls.access_codes }}" class="nav-link nav-link-second-level{% if "cfp.access_code" in url_name %} active{% endif %}">
-                                        <span>{% translate "Access codes" %}</span>
-                                    </a>
-                                </div>
-                            </div>
-                        {% endif %}
-                    {% endif %}
-                    {% if can_see_orga_area %}
-                        <div class="nav-fold">
-                            <span class="has-children">
-                                <a class="nav-link nav-link-inner" href="{{ request.event.orga_urls.submissions }}">
-                                    <i class="fa fa-sticky-note-o"></i>
-                                    <span class="sidebar-text">{{ phrases.schedule.sessions }}</span>
-                                </a>
-                                <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseSubmissions" aria-controls="collapseSubmissions">
-                                    <i class="fa fa-angle-down"></i>
-                                </a>
-                            </span>
-                            <div class="collapse in{% if "submissions." in url_name|slice:":13" %} show{% endif %}" aria-expand="true" id="collapseSubmissions">
-                                <a href="{{ request.event.orga_urls.submissions }}" class="nav-link nav-link-second-level{% if "submissions." in url_name and "submissions.statistics" not in url_name and "submissions.feedback" not in url_name and "submissions.tag" not in url_name %} active{% endif %}">
-                                    <span>{{ phrases.schedule.sessions }}</span>
-                                </a>
-                                <a href="{{ request.event.orga_urls.tags }}" class="nav-link nav-link-second-level{% if "submissions.tag" in url_name %} active{% endif %}">
-                                    <span>{% translate "Tags" %}</span>
-                                </a>
-                                <a href="{{ request.event.orga_urls.stats }}" class="nav-link nav-link-second-level{% if "submissions.statistics" in url_name %} active{% endif %}">
-                                    <span>{% translate "Statistics" %}</span>
-                                </a>
-                                {% if request.event|get_feature_flag:"use_feedback" %}
-                                    <a href="{{ request.event.orga_urls.feedback }}" class="nav-link nav-link-second-level{% if "submissions.feedback" in url_name %} active{% endif %}">
-                                        <span>{% translate "Feedback" %}</span>
-                                    </a>
-                                {% endif %}
-                                <a href="{{ request.event.orga_urls.schedule_export }}" class="nav-link nav-link-second-level">
-                                    <span>{% translate "Export" %}</span>
-                                </a>
-                            </div>
-                        </div>
-                        {% if can_change_settings %}
-                            <div class="nav-fold">
-                                <span class="has-children">
-                                    <a class="nav-link nav-link-inner" href="{% url "orga:reviews.dashboard" event=request.event.slug %}">
-                                        <i class="fa fa-eye"></i>
-                                        <span class="sidebar-text">{% translate "Review" %}</span>
-                                    </a>
-                                    <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseReviews" aria-controls="collapseReviews">
-                                        <i class="fa fa-angle-down"></i>
-                                    </a>
-                                </span>
-                                <div class="collapse in{% if "reviews." in url_name|slice:":9" %} show{% endif %}" aria-expand="true" id="collapseReviews">
-                                    <a href="{% url "orga:reviews.dashboard" event=request.event.slug %}" class="nav-link nav-link-second-level{% if "reviews.dashboard" in url_name %} active{% endif %}">
-                                        <span>{% translate "Review" %}</span>
-                                    </a>
-                                    <a href="{% url "orga:reviews.assign" event=request.event.slug %}" class="nav-link nav-link-second-level{% if "reviews.assign" in url_name %} active{% endif %}">
-                                        <span>{% translate "Assign reviewers" %}</span>
-                                    </a>
-                                    <a href="{% url "orga:reviews.export" event=request.event.slug %}" class="nav-link nav-link-second-level{% if "reviews.export" in url_name %} active{% endif %}">
-                                        <span>{% translate "Export reviews" %}</span>
-                                    </a>
-                                </div>
-                            </div>
-                        {% else %}
-                            <a class="nav-link {% if "reviews." in url_name %}active{% endif %}" href="{% url "orga:reviews.dashboard" event=request.event.slug %}">
-                                <i class="fa fa-eye"></i>
-                                <span class="sidebar-text">{% translate "Review" %}</span>
-                            </a>
-                        {% endif %}
-                        {% if can_view_speakers %}
-                            <div class="nav-fold">
-                                <span class="has-children">
-                                    <a class="nav-link nav-link-inner" href="{{ request.event.orga_urls.speakers }}">
-                                        <i class="fa fa-address-card-o"></i>
-                                        <span class="sidebar-text">{{ phrases.schedule.speakers }}</span>
-                                    </a>
-                                    <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseSpeakers" aria-controls="collapseSpeakers">
-                                        <i class="fa fa-angle-down"></i>
-                                    </a>
-                                </span>
-                                <div class="collapse in{% if "speakers." in url_name|slice:":9" %} show{% endif %}" aria-expand="true" id="collapseSpeakers">
-                                    <a href="{{ request.event.orga_urls.speakers }}" class="nav-link nav-link-second-level{% if "speakers.list" in url_name or "speakers.view" in url_name %} active{% endif %}">
-                                        <span>{{ phrases.schedule.speakers }}</span>
-                                    </a>
-                                    {% if can_see_orga_exclusive %}
-                                        <a href="{{ request.event.orga_urls.information }}" class="nav-link nav-link-second-level{% if "speakers.information" in url_name %} active{% endif %}">
-                                            <span>{% translate "Speaker Information" %}</span>
-                                        </a>
-                                    {% endif %}
-                                    <a href="{{ request.event.orga_urls.speakers }}export/" class="nav-link nav-link-second-level{% if "speakers.export" in url_name %} active{% endif %}">
-                                        <span>{% translate "Export" %}</span>
-                                    </a>
-                                </div>
-                            </div>
-                        {% endif %}
-                    {% endif %}
-                    {% if can_see_orga_exclusive %}
-
-                        <div class="nav-fold">
-                            <span class="has-children">
-                                <a class="nav-link nav-link-inner" href="{{ request.event.orga_urls.schedule }}">
-                                    <i class="fa fa-calendar-o"></i>
-                                    <span class="sidebar-text">{{ phrases.schedule.schedule }}</span>
-                                </a>
-                                <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseSchedule" aria-controls="collapseSchedule">
-                                    <i class="fa fa-angle-down"></i>
-                                </a>
-                            </span>
-                            <div class="collapse in{% if "schedule." in url_name %} show{% endif %}" aria-expand="true" id="collapseSchedule">
-                                <a href="{{ request.event.orga_urls.schedule }}" class="nav-link nav-link-second-level{% if "schedule.main" in url_name %} active{% endif %}">
-                                    <span>{% translate "Editor" %}</span>
-                                </a>
-                                <a href="{{ request.event.orga_urls.room_settings }}" class="nav-link nav-link-second-level{% if "schedule.rooms." in url_name %} active{% endif %}">
-                                    <span>{% translate "Rooms" %}</span>
-                                </a>
-                                <a href="{{ request.event.orga_urls.schedule_export }}" class="nav-link nav-link-second-level{% if "schedule.export" in url_name %} active{% endif %}">
-                                    <span>{% translate "Export" %}</span>
-                                </a>
-                            </div>
-                        </div>
-
-                        <div class="nav-fold">
-                            <span class="has-children">
-                                <a class="nav-link nav-link-inner" href="{{ request.event.orga_urls.outbox }}">
-                                    <i class="fa fa-envelope"></i>
-                                    <span class="sidebar-text">
-                                        {% translate "Mails" %}
-                                        {% if request.event.pending_mails %}<span class="pending-mails">{{ request.event.pending_mails }}</span>{% endif %}
-                                    </span>
-                                </a>
-                                <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseMails" aria-controls="collapseMails">
-                                    <i class="fa fa-angle-down"></i>
-                                </a>
-                            </span>
-                            <div class="collapse in{% if "mails." in url_name %} show{% endif %}" aria-expand="true" id="collapseMails">
-                                <a href="{{ request.event.orga_urls.outbox }}" class="nav-link nav-link-second-level{% if "mails.outbox" in url_name %} {% if not form or not form.instance.sent %}active{% endif %}{% endif %}">
-                                    <span>{% translate "Outbox" %}</span>
-                                </a>
-                                <a href="{% if can_change_teams %}{{ request.event.orga_urls.compose_mails }}{% else %}{{ request.event.orga_urls.compose_mails_sessions }}{% endif %}" class="nav-link nav-link-second-level{% if "mails.compose" in url_name %} active{% endif %}">
-                                    <span>{% translate "Compose emails" %}</span>
-                                </a>
-                                <a href="{{ request.event.orga_urls.sent_mails }}" class="nav-link nav-link-second-level{% if "mails.sent" in url_name %} active{% elif url_name == "mails.outbox.mail.view" and form.instance.sent %} active{% endif %}">
-                                    <span>{% translate "Sent emails" %}</span>
-                                </a>
-                                <a href="{{ request.event.orga_urls.mail_templates }}" class="nav-link nav-link-second-level{% if "mails.templates" in url_name %} active{% endif %}">
-                                    <span>{% translate "Templates" %}</span>
-                                </a>
-                            </div>
-                        </div>
-                        {% for nav_element in nav_event %}
-                            {% include "orga/includes/sidebar_nav.html" %}
-                        {% endfor %}
-                    {% endif %}
-                {% elif request.organiser %}  {# if request.event #}
-                    <a class="nav-link {% if url_name == "organiser.dashboard" %} active{% endif %}" href="{{ request.organiser.orga_urls.base }}">
-                        <i class="fa fa-tachometer"></i>
-                        <span>{% translate "Dashboard" %}</span>
+          </div>
+        </details>
+        {% if request.event %}
+          {% has_perm "orga.view_orga_area" request.user request.event as can_see_orga_area %}
+          {% has_perm "orga.change_submissions" request.user request.event as can_see_orga_exclusive %}
+          {% has_perm "orga.change_teams" request.user request.event as can_change_teams %}
+          {% has_perm "orga.change_settings" request.user request.event as can_change_settings %}
+          {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
+          {% if can_see_orga_area %}
+            <a class="nav-link {% if url_name == "event.dashboard" %}active{% endif %}" href="{{ request.event.orga_urls.base }}">
+              <i class="fa fa-tachometer"></i>
+              <span class="sidebar-text">{% translate "Dashboard" %}</span>
+            </a>
+          {% endif %}
+          {% if can_see_orga_exclusive %}
+            {% if can_change_settings %}
+              <div class="nav-fold">
+                <span class="has-children">
+                  <a href="{{ request.event.orga_urls.settings }}" class="nav-link nav-link-inner">
+                    <i class="fa fa-wrench"></i>
+                    <span class="sidebar-text">{% translate "Settings" %}</span>
+                  </a>
+                  <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseSettings" aria-controls="collapseSettings">
+                    <i class="fa fa-angle-down"></i>
+                  </a>
+                </span>
+                <div class="collapse in{% if "settings." in url_name %} show{% endif %}" aria-expand="true" id="collapseSettings">
+                  <a href="{{ request.event.orga_urls.settings }}" class="nav-link nav-link-second-level{% if "settings.event." in url_name %} active{% endif %}">
+                    <span>{{ phrases.base.general }}</span>
+                  </a>
+                  {% if can_change_teams %}
+                    <a href="{{ request.event.organiser.orga_urls.teams }}" class="nav-link nav-link-second-level{% if "settings.team." in url_name %} active{% endif %}">
+                      <span>{% translate "Teams" %}</span>
                     </a>
-                    <a class="nav-link {% if "/settings/" in request.path %} active{% endif %}" href="{{ request.organiser.orga_urls.settings }}">
-                        <i class="fa fa-cog"></i>
-                        <span>{% translate "Settings" %}</span>
+                  {% endif %}
+                  <a href="{{ request.event.orga_urls.review_settings }}" class="nav-link nav-link-second-level{% if "settings.review" in url_name %} active{% endif %}">
+                    <span>{% translate "Review" %}</span>
+                  </a>
+                  <a href="{{ request.event.orga_urls.mail_settings }}" class="nav-link nav-link-second-level{% if "settings.mail" in url_name %} active{% endif %}">
+                    <span>{% translate "Email" %}</span>
+                  </a>
+                  <a href="{{ request.event.orga_urls.widget_settings }}" class="nav-link nav-link-second-level{% if "settings.widget" in url_name %} active{% endif %}">
+                    <span>{% translate "Widget" %}</span>
+                  </a>
+                  <a href="{{ request.event.orga_urls.plugins }}" class="nav-link nav-link-second-level{% if "settings.plugins.select" in url_name %} active{% endif %}">
+                    <span>{% translate "Plugins" %}</span>
+                  </a>
+                  {% for plugin_setting in nav_settings %}
+                    <a href="{{ plugin_setting.url }}" class="nav-link nav-link-second-level{% if plugin_setting.active %} active{% endif %}">
+                      <span>{{ plugin_setting.label }}</span>
                     </a>
-                    {% has_perm "orga.change_teams" request.user request.organiser as can_change_teams %}
-                    {% has_perm "orga.view_organiser_speakers" request.user request.organiser as can_view_speakers %}
-                    {% if can_change_teams %}
-                        <a class="nav-link {% if "/teams/" in request.path %} active{% endif %}" href="{% url "orga:organiser.teams" organiser=request.organiser.slug %}">
-                            <i class="fa fa-users"></i>
-                            <span>{% translate "Teams" %}</span>
-                        </a>
-                    {% endif %}
-                    {% if can_view_speakers %}
-                        <a class="nav-link {% if "/speakers/" in request.path %} active{% endif %}" href="{% url "orga:organiser.speakers" organiser=request.organiser.slug %}">
-                            <i class="fa fa-address-card-o"></i>
-                            <span>{% translate "Speakers" %}</span>
-                        </a>
-                    {% endif %}
-                    {% for nav_element in nav_global %}
-                        {% include "orga/includes/sidebar_nav.html" %}
-                    {% endfor %}
-                {% else %}  {# elif request.organiser #}
-                    {% has_perm "orga.view_organiser_lists" request.user request as can_see_organiser_lists %}
-                    {% if can_see_organiser_lists %}
-                        <a class="nav-link {% if request.path == "/orga/event/" %} active{% endif %}" href="{% url "orga:event.list" %}">
-                            <i class="fa fa-calendar-o"></i>
-                            <span>{% translate "Events" %}</span>
-                        </a>
-                    {% endif %}
-                    {% has_perm "orga.view_organisers" request.user request as can_see_organisers %}
-                    {% if can_see_organisers %}
-                        <a class='nav-link {% if "/orga/organiser/" in request.path %} active{% endif %}' href='{% url "orga:organiser.list" %}'>
-                            <i class="fa fa-users"></i>
-                            <span>{% translate "Organisers" %}</span>
-                        </a>
-                    {% endif %}
-                    {% if request.user.is_administrator %}
-                        <div class="nav-fold">
-                            <span class="has-children">
-                                <a class="nav-link nav-link-inner" href='{% url "orga:admin.dashboard" %}'>
-                                    <i class="fa fa-cogs"></i>
-                                    <span class="sidebar-text">
-                                        {% translate "Administration" %}
-                                    </span>
-                                </a>
-                                <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseAdmin" aria-controls="collapseAdmin">
-                                    <i class="fa fa-angle-down"></i>
-                                </a>
-                            </span>
-                            <div class="collapse in{% if "/orga/admin/" in request.path_info %} show{% endif %}" aria-expand="true" id="collapseAdmin">
-                                <a class="nav-link nav-link-second-level {% if "/orga/admin/" == request.path_info %} active{% endif %}" href='{% url "orga:admin.dashboard" %}'>
-                                    <span>{% translate "Admin information" %}</span>
-                                </a>
-                                <a href='{% url "orga:admin.user.list" %}' class="nav-link nav-link-second-level{% if "/orga/admin/users" in request.path_info %} active{% endif %}">
-                                    <span>{% translate "Users" %}</span>
-                                </a>
-                                <a href='{% url "orga:admin.sso.settings" %}' class="nav-link nav-link-second-level{% if "/orga/admin/sso/settings" in request.path_info %} active{% endif %}">
-                                    <span>{% translate "SSO settings" %}</span>
-                                </a>
-                            </div>
-                        </div>
-                    {% endif %}
-                    {% for nav_element in nav_global %}
-                        {% include "orga/includes/sidebar_nav.html" %}
-                    {% endfor %}
-                {% endif %}  {# if request.event #}
-            </aside>{% endif %}  {# if not request.user.is_anonymous #}
-            <div id="page-content">
-                <main>
-                    {% if messages %}
-                        {% for message in messages %}
-                            <div class="alert alert-{{ message.tags }}">
-                                {{ message }}
-                            </div>
-                        {% endfor %}
-                    {% endif %}
-
-                    {% block content %}
-                    {% endblock content %}
-                </main>
-                <footer>
-                    {% include "common/powered_by.html" %}
-                    {% if development_mode %}
-                        <span class="text-warning">· {% translate "running in development mode" %}</span>
-                    {% endif %}
-                    {% if pretalx_version %}
-                        <span>·
-                            {% if development_mode %}<a href="https://github.com/fossasia/eventyay-talk/tree/development/"> development<!--{{ pretalx_version }}--></a>
-                            {% else %}v{{ pretalx_version }}{% endif %}
-                        </span>
-                    {% endif %}
-                </footer>
+                  {% endfor %}
+                </div>
+              </div>
+              <div class="nav-fold">
+                <span class="has-children">
+                  <a class="nav-link nav-link-inner" href="{{ request.event.cfp.urls.text }}">
+                    <i class="fa fa-bullhorn"></i>
+                    <span class="sidebar-text">{% translate "Call for Speakers" %}</span>
+                  </a>
+                  <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseCfP" aria-controls="collapseCfP">
+                    <i class="fa fa-angle-down"></i>
+                  </a>
+                </span>
+                <div class="collapse in{% if "cfp." in url_name %} show{% endif %}" aria-expand="true" id="collapseCfP">
+                  <a href="{{ request.event.cfp.urls.text }}" class="nav-link nav-link-second-level{% if "cfp.text" in url_name %} active{% endif %}">
+                    <span>{% translate "Content" %}</span>
+                  </a>
+                  <a href="{{ request.event.cfp.urls.editor }}" class="nav-link nav-link-second-level{% if "cfp.flow" in url_name %} active{% endif %}">
+                    <span>{% translate "Editor" %}</span>
+                  </a>
+                  <a href="{{ request.event.cfp.urls.questions }}" class="nav-link nav-link-second-level{% if "cfp.question" in url_name %} active{% endif %}">
+                    <span>{{ phrases.cfp.questions }}</span>
+                  </a>
+                  {% if request.event|get_feature_flag:"use_tracks" %}
+                    <a href="{{ request.event.cfp.urls.tracks }}" class="nav-link nav-link-second-level{% if "cfp.track" in url_name %} active{% endif %}">
+                      <span>{% translate "Tracks" %}</span>
+                    </a>
+                  {% endif %}
+                  <a href="{{ request.event.cfp.urls.types }}" class="nav-link nav-link-second-level{% if "cfp.type" in url_name %} active{% endif %}">
+                    <span>{% translate "Session types" %}</span>
+                  </a>
+                  <a href="{{ request.event.cfp.urls.access_codes }}" class="nav-link nav-link-second-level{% if "cfp.access_code" in url_name %} active{% endif %}">
+                    <span>{% translate "Access codes" %}</span>
+                  </a>
+                </div>
+              </div>
+            {% endif %}
+          {% endif %}
+          {% if can_see_orga_area %}
+            <div class="nav-fold">
+              <span class="has-children">
+                <a class="nav-link nav-link-inner" href="{{ request.event.orga_urls.submissions }}">
+                  <i class="fa fa-sticky-note-o"></i>
+                  <span class="sidebar-text">{{ phrases.schedule.sessions }}</span>
+                </a>
+                <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseSubmissions" aria-controls="collapseSubmissions">
+                  <i class="fa fa-angle-down"></i>
+                </a>
+              </span>
+              <div class="collapse in{% if "submissions." in url_name|slice:":13" %} show{% endif %}" aria-expand="true" id="collapseSubmissions">
+                <a href="{{ request.event.orga_urls.submissions }}" class="nav-link nav-link-second-level{% if "submissions." in url_name and "submissions.statistics" not in url_name and "submissions.feedback" not in url_name and "submissions.tag" not in url_name %} active{% endif %}">
+                  <span>{{ phrases.schedule.sessions }}</span>
+                </a>
+                <a href="{{ request.event.orga_urls.tags }}" class="nav-link nav-link-second-level{% if "submissions.tag" in url_name %} active{% endif %}">
+                  <span>{% translate "Tags" %}</span>
+                </a>
+                <a href="{{ request.event.orga_urls.stats }}" class="nav-link nav-link-second-level{% if "submissions.statistics" in url_name %} active{% endif %}">
+                  <span>{% translate "Statistics" %}</span>
+                </a>
+                {% if request.event|get_feature_flag:"use_feedback" %}
+                  <a href="{{ request.event.orga_urls.feedback }}" class="nav-link nav-link-second-level{% if "submissions.feedback" in url_name %} active{% endif %}">
+                    <span>{% translate "Feedback" %}</span>
+                  </a>
+                {% endif %}
+                <a href="{{ request.event.orga_urls.schedule_export }}" class="nav-link nav-link-second-level">
+                  <span>{% translate "Export" %}</span>
+                </a>
+              </div>
             </div>
-        </div>
-    </body>
+            {% if can_change_settings %}
+              <div class="nav-fold">
+                <span class="has-children">
+                  <a class="nav-link nav-link-inner" href="{% url "orga:reviews.dashboard" event=request.event.slug %}">
+                    <i class="fa fa-eye"></i>
+                    <span class="sidebar-text">{% translate "Review" %}</span>
+                  </a>
+                  <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseReviews" aria-controls="collapseReviews">
+                    <i class="fa fa-angle-down"></i>
+                  </a>
+                </span>
+                <div class="collapse in{% if "reviews." in url_name|slice:":9" %} show{% endif %}" aria-expand="true" id="collapseReviews">
+                  <a href="{% url "orga:reviews.dashboard" event=request.event.slug %}" class="nav-link nav-link-second-level{% if "reviews.dashboard" in url_name %} active{% endif %}">
+                    <span>{% translate "Review" %}</span>
+                  </a>
+                  <a href="{% url "orga:reviews.assign" event=request.event.slug %}" class="nav-link nav-link-second-level{% if "reviews.assign" in url_name %} active{% endif %}">
+                    <span>{% translate "Assign reviewers" %}</span>
+                  </a>
+                  <a href="{% url "orga:reviews.export" event=request.event.slug %}" class="nav-link nav-link-second-level{% if "reviews.export" in url_name %} active{% endif %}">
+                    <span>{% translate "Export reviews" %}</span>
+                  </a>
+                </div>
+              </div>
+            {% else %}
+              <a class="nav-link {% if "reviews." in url_name %}active{% endif %}" href="{% url "orga:reviews.dashboard" event=request.event.slug %}">
+                <i class="fa fa-eye"></i>
+                <span class="sidebar-text">{% translate "Review" %}</span>
+              </a>
+            {% endif %}
+            {% if can_view_speakers %}
+              <div class="nav-fold">
+                <span class="has-children">
+                  <a class="nav-link nav-link-inner" href="{{ request.event.orga_urls.speakers }}">
+                    <i class="fa fa-address-card-o"></i>
+                    <span class="sidebar-text">{{ phrases.schedule.speakers }}</span>
+                  </a>
+                  <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseSpeakers" aria-controls="collapseSpeakers">
+                    <i class="fa fa-angle-down"></i>
+                  </a>
+                </span>
+                <div class="collapse in{% if "speakers." in url_name|slice:":9" %} show{% endif %}" aria-expand="true" id="collapseSpeakers">
+                  <a href="{{ request.event.orga_urls.speakers }}" class="nav-link nav-link-second-level{% if "speakers.list" in url_name or "speakers.view" in url_name %} active{% endif %}">
+                    <span>{{ phrases.schedule.speakers }}</span>
+                  </a>
+                  {% if can_see_orga_exclusive %}
+                    <a href="{{ request.event.orga_urls.information }}" class="nav-link nav-link-second-level{% if "speakers.information" in url_name %} active{% endif %}">
+                      <span>{% translate "Speaker Information" %}</span>
+                    </a>
+                  {% endif %}
+                  <a href="{{ request.event.orga_urls.speakers }}export/" class="nav-link nav-link-second-level{% if "speakers.export" in url_name %} active{% endif %}">
+                    <span>{% translate "Export" %}</span>
+                  </a>
+                </div>
+              </div>
+            {% endif %}
+          {% endif %}
+          {% if can_see_orga_exclusive %}
+
+            <div class="nav-fold">
+              <span class="has-children">
+                <a class="nav-link nav-link-inner" href="{{ request.event.orga_urls.schedule }}">
+                  <i class="fa fa-calendar-o"></i>
+                  <span class="sidebar-text">{{ phrases.schedule.schedule }}</span>
+                </a>
+                <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseSchedule" aria-controls="collapseSchedule">
+                  <i class="fa fa-angle-down"></i>
+                </a>
+              </span>
+              <div class="collapse in{% if "schedule." in url_name %} show{% endif %}" aria-expand="true" id="collapseSchedule">
+                <a href="{{ request.event.orga_urls.schedule }}" class="nav-link nav-link-second-level{% if "schedule.main" in url_name %} active{% endif %}">
+                  <span>{% translate "Editor" %}</span>
+                </a>
+                <a href="{{ request.event.orga_urls.room_settings }}" class="nav-link nav-link-second-level{% if "schedule.rooms." in url_name %} active{% endif %}">
+                  <span>{% translate "Rooms" %}</span>
+                </a>
+                <a href="{{ request.event.orga_urls.schedule_export }}" class="nav-link nav-link-second-level{% if "schedule.export" in url_name %} active{% endif %}">
+                  <span>{% translate "Export" %}</span>
+                </a>
+              </div>
+            </div>
+
+            <div class="nav-fold">
+              <span class="has-children">
+                <a class="nav-link nav-link-inner" href="{{ request.event.orga_urls.outbox }}">
+                  <i class="fa fa-envelope"></i>
+                  <span class="sidebar-text">
+                    {% translate "Mails" %}
+                    {% if request.event.pending_mails %}<span class="pending-mails">{{ request.event.pending_mails }}</span>{% endif %}
+                  </span>
+                </a>
+                <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseMails" aria-controls="collapseMails">
+                  <i class="fa fa-angle-down"></i>
+                </a>
+              </span>
+              <div class="collapse in{% if "mails." in url_name %} show{% endif %}" aria-expand="true" id="collapseMails">
+                <a href="{{ request.event.orga_urls.outbox }}" class="nav-link nav-link-second-level{% if "mails.outbox" in url_name %} {% if not form or not form.instance.sent %}active{% endif %}{% endif %}">
+                  <span>{% translate "Outbox" %}</span>
+                </a>
+                <a href="{% if can_change_teams %}{{ request.event.orga_urls.compose_mails }}{% else %}{{ request.event.orga_urls.compose_mails_sessions }}{% endif %}" class="nav-link nav-link-second-level{% if "mails.compose" in url_name %} active{% endif %}">
+                  <span>{% translate "Compose emails" %}</span>
+                </a>
+                <a href="{{ request.event.orga_urls.sent_mails }}" class="nav-link nav-link-second-level{% if "mails.sent" in url_name %} active{% elif url_name == "mails.outbox.mail.view" and form.instance.sent %} active{% endif %}">
+                  <span>{% translate "Sent emails" %}</span>
+                </a>
+                <a href="{{ request.event.orga_urls.mail_templates }}" class="nav-link nav-link-second-level{% if "mails.templates" in url_name %} active{% endif %}">
+                  <span>{% translate "Templates" %}</span>
+                </a>
+              </div>
+            </div>
+            {% for nav_element in nav_event %}
+              {% include "orga/includes/sidebar_nav.html" %}
+            {% endfor %}
+          {% endif %}
+        {% elif request.organiser %}  {# if request.event #}
+          <a class="nav-link {% if url_name == "organiser.dashboard" %} active{% endif %}" href="{{ request.organiser.orga_urls.base }}">
+            <i class="fa fa-tachometer"></i>
+            <span>{% translate "Dashboard" %}</span>
+          </a>
+          <a class="nav-link {% if "/settings/" in request.path %} active{% endif %}" href="{{ request.organiser.orga_urls.settings }}">
+            <i class="fa fa-cog"></i>
+            <span>{% translate "Settings" %}</span>
+          </a>
+          {% has_perm "orga.change_teams" request.user request.organiser as can_change_teams %}
+          {% has_perm "orga.view_organiser_speakers" request.user request.organiser as can_view_speakers %}
+          {% if can_change_teams %}
+            <a class="nav-link {% if "/teams/" in request.path %} active{% endif %}" href="{% url "orga:organiser.teams" organiser=request.organiser.slug %}">
+              <i class="fa fa-users"></i>
+              <span>{% translate "Teams" %}</span>
+            </a>
+          {% endif %}
+          {% if can_view_speakers %}
+            <a class="nav-link {% if "/speakers/" in request.path %} active{% endif %}" href="{% url "orga:organiser.speakers" organiser=request.organiser.slug %}">
+              <i class="fa fa-address-card-o"></i>
+              <span>{% translate "Speakers" %}</span>
+            </a>
+          {% endif %}
+          {% for nav_element in nav_global %}
+            {% include "orga/includes/sidebar_nav.html" %}
+          {% endfor %}
+        {% else %}  {# elif request.organiser #}
+          {% has_perm "orga.view_organiser_lists" request.user request as can_see_organiser_lists %}
+          {% if can_see_organiser_lists %}
+            <a class="nav-link {% if request.path == "/orga/event/" %} active{% endif %}" href="{% url "orga:event.list" %}">
+              <i class="fa fa-calendar-o"></i>
+              <span>{% translate "Events" %}</span>
+            </a>
+          {% endif %}
+          {% has_perm "orga.view_organisers" request.user request as can_see_organisers %}
+          {% if can_see_organisers %}
+            <a class='nav-link {% if "/orga/organiser/" in request.path %} active{% endif %}' href='{% url "orga:organiser.list" %}'>
+              <i class="fa fa-users"></i>
+              <span>{% translate "Organisers" %}</span>
+            </a>
+          {% endif %}
+          {% if request.user.is_administrator %}
+            <div class="nav-fold">
+              <span class="has-children">
+                <a class="nav-link nav-link-inner" href='{% url "orga:admin.dashboard" %}'>
+                  <i class="fa fa-cogs"></i>
+                  <span class="sidebar-text">
+                    {% translate "Administration" %}
+                  </span>
+                </a>
+                <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseAdmin" aria-controls="collapseAdmin">
+                  <i class="fa fa-angle-down"></i>
+                </a>
+              </span>
+              <div class="collapse in{% if "/orga/admin/" in request.path_info %} show{% endif %}" aria-expand="true" id="collapseAdmin">
+                <a class="nav-link nav-link-second-level {% if "/orga/admin/" == request.path_info %} active{% endif %}" href='{% url "orga:admin.dashboard" %}'>
+                  <span>{% translate "Admin information" %}</span>
+                </a>
+                <a href='{% url "orga:admin.user.list" %}' class="nav-link nav-link-second-level{% if "/orga/admin/users" in request.path_info %} active{% endif %}">
+                  <span>{% translate "Users" %}</span>
+                </a>
+                <a href='{% url "orga:admin.sso.settings" %}' class="nav-link nav-link-second-level{% if "/orga/admin/sso/settings" in request.path_info %} active{% endif %}">
+                  <span>{% translate "SSO settings" %}</span>
+                </a>
+              </div>
+            </div>
+          {% endif %}
+          {% for nav_element in nav_global %}
+            {% include "orga/includes/sidebar_nav.html" %}
+          {% endfor %}
+        {% endif %}  {# if request.event #}
+      </aside>{% endif %}  {# if not request.user.is_anonymous #}
+      <div id="page-content">
+        <main>
+          {% if messages %}
+            {% for message in messages %}
+              <div class="alert alert-{{ message.tags }}">
+                {{ message }}
+              </div>
+            {% endfor %}
+          {% endif %}
+
+          {% block content %}
+          {% endblock content %}
+        </main>
+        <footer>
+          {% include "common/powered_by.html" %}
+          {% if development_mode %}
+            <span class="text-warning">· {% translate "running in development mode" %}</span>
+          {% endif %}
+          {% if pretalx_version %}
+            <span>·
+              {% if development_mode %}<a href="https://github.com/fossasia/eventyay-talk/tree/development/"> development<!--{{ pretalx_version }}--></a>
+              {% else %}v{{ pretalx_version }}{% endif %}
+            </span>
+          {% endif %}
+        </footer>
+      </div>
+    </div>
+  </body>
 </html>

--- a/src/pretalx/orga/templates/orga/cfp/access_code_form.html
+++ b/src/pretalx/orga/templates/orga/cfp/access_code_form.html
@@ -7,49 +7,49 @@
 {% block extra_title %}{% if form.instance.pk %}{{ form.instance.code }}{% else %}{% translate "New access code" %}{% endif %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% if form.instance.pk %}
-            {% translate "Edit access code" %}
-        {% else %}
-            {% translate "New access code" %}
-        {% endif %}
-    </h2>
-    {% if form.instance.pk and form.instance.submissions.exists %}
-        <div class="alert alert-info">
-            <span>
-                {% blocktranslate trimmed %}
-                    This access code has already been used. You can’t delete it, but you can disable it by setting an expiration date.
-                {% endblocktranslate %}
-                <ul>
-                    {% for submission in form.instance.submissions.all %}
-                        <li>
-                            <a href="{{ submission.orga_urls.base }}">{{ submission.title }} –
-                                {% include "orga/includes/submission_speaker_names.html" with submission=submission %}</a>
-                        </li>
-                    {% endfor %}
-                </ul>
-            </span>
-        </div>
+  <h2>
+    {% if form.instance.pk %}
+      {% translate "Edit access code" %}
+    {% else %}
+      {% translate "New access code" %}
     {% endif %}
-    <form method="post">
-        {% csrf_token %}
-        {{ form }}
-        <div class="submit-group panel">
-            <span>
-                {% if form.instance.pk and not form.instance.submissions.exists %}
-                    <a class="btn btn-outline-danger btn-lg" href="{{ form.instance.urls.delete }}">
-                        <i class="fa fa-trash"></i>
-                        {{ phrases.base.delete_button }}
-                    </a>
-                {% endif %}
-            </span>
-            <span>
-                <button type="submit" class="btn btn-success btn-lg">
-                    <i class="fa fa-check"></i>
-                    {{ phrases.base.save }}
-                </button>
-            </span>
-        </div>
-    </form>
+  </h2>
+  {% if form.instance.pk and form.instance.submissions.exists %}
+    <div class="alert alert-info">
+      <span>
+        {% blocktranslate trimmed %}
+          This access code has already been used. You can’t delete it, but you can disable it by setting an expiration date.
+        {% endblocktranslate %}
+        <ul>
+          {% for submission in form.instance.submissions.all %}
+            <li>
+              <a href="{{ submission.orga_urls.base }}">{{ submission.title }} –
+                {% include "orga/includes/submission_speaker_names.html" with submission=submission %}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </span>
+    </div>
+  {% endif %}
+  <form method="post">
+    {% csrf_token %}
+    {{ form }}
+    <div class="submit-group panel">
+      <span>
+        {% if form.instance.pk and not form.instance.submissions.exists %}
+          <a class="btn btn-outline-danger btn-lg" href="{{ form.instance.urls.delete }}">
+            <i class="fa fa-trash"></i>
+            {{ phrases.base.delete_button }}
+          </a>
+        {% endif %}
+      </span>
+      <span>
+        <button type="submit" class="btn btn-success btn-lg">
+          <i class="fa fa-check"></i>
+          {{ phrases.base.save }}
+        </button>
+      </span>
+    </div>
+  </form>
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/access_code_send.html
+++ b/src/pretalx/orga/templates/orga/cfp/access_code_send.html
@@ -6,8 +6,8 @@
 {% block extra_title %}{% translate "Send access code" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Send access code" %}</h2>
+  <h2>{% translate "Send access code" %}</h2>
 
-    {% include "orga/includes/base_form.html" with submit_label=phrases.base.send %}
+  {% include "orga/includes/base_form.html" with submit_label=phrases.base.send %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/access_code_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/access_code_view.html
@@ -7,106 +7,106 @@
 {% load static %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/copy.js" %}"></script>
-        <script defer src="{% static "common/js/modalDialog.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/copy.js" %}"></script>
+    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{% translate "Access codes" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% translate "Access codes" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
-    <dialog class="info-dialog" id="info-dialog">
-        <div class="alert alert-info">
-            {% blocktranslate trimmed %}
-                Access codes can be used to allow proposals even when the CfP
-                is over. You can also use them for hidden tracks or hidden session
-                types, which can only be seen with a matching access code.
-            {% endblocktranslate %}
-        </div>
-    </dialog>
-    <div class="d-flex justify-content-end mb-3">
-        <span></span>
-        <a class="btn btn-info" href="{{ request.event.cfp.urls.new_access_code }}">
-            <i class="fa fa-plus"></i>
-            {% translate "New access code" %}
-        </a>
+  <h2>
+    {% translate "Access codes" %}
+    <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+      <i class="fa fa-question-circle-o text-info"></i>
+    </span>
+  </h2>
+  <dialog class="info-dialog" id="info-dialog">
+    <div class="alert alert-info">
+      {% blocktranslate trimmed %}
+        Access codes can be used to allow proposals even when the CfP
+        is over. You can also use them for hidden tracks or hidden session
+        types, which can only be seen with a matching access code.
+      {% endblocktranslate %}
     </div>
-    {% if access_codes %}
-        <div class="table-responsive-sm">
-            <table class="table table-sm table-hover table-flip table-sticky" id="access-codes">
-                <thead>
-                    <tr>
-                        <th>{% translate "Code" %}</th>
-                        {% if request.event|get_feature_flag:"use_tracks" %}
-                            <th>{% translate "Track" %}</th>
-                        {% endif %}
-                        <th>{% translate "Session type" %}</th>
-                        <th class="numeric">{% translate "Uses" %}</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for code in access_codes %}
-                        <tr>
-                            <td>{{ code.code|copyable }}</td>
-                            {% if request.event|get_feature_flag:"use_tracks" %}
-                                <td>
-                                    {% if code.track %}
-                                        <a href="{{ code.track.urls.base }}">{{ code.track.name }}</a>
-                                    {% else %}
-                                        –
-                                    {% endif %}
-                                </td>
-                            {% endif %}
-                            <td>
-                                {% if code.submission_type %}
-                                    <a href="{{ code.submission_type.urls.base }}">{{ code.submission_type.name }}</a>
-                                {% else %}–{% endif %}
-                            </td>
-                            <td class="numeric">
-                                {{ code.redeemed|default:0 }} / {{ code.maximum_uses|default:"∞" }}
-                            </td>
-                            <td class="text-right">
-                                <div data-destination="{{ code.urls.cfp_url.full }}"
-                                     role="button"
-                                     title="{% translate "Copy access code link" %}"
-                                     class="btn btn-sm btn-info copyable-text">
-                                    <i class="fa fa-copy"></i>
-                                </div>
-                                <a href="{{ code.urls.send }}"
-                                   title="{% translate "Send access code as email" %}"
-                                   class="btn btn-sm btn-info">
-                                    <i class="fa fa-envelope"></i>
-                                </a>
-                                <a href="{{ code.urls.edit }}" class="btn btn-sm btn-info">
-                                    <i class="fa fa-edit"></i>
-                                </a>
-                                {% if not code.submissions.exists %}
-                                    <a href="{{ code.urls.delete }}" class="btn btn-sm btn-danger">
-                                        <i class="fa fa-trash"></i>
-                                    </a>
-                                {% endif %}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% endif %}
+  </dialog>
+  <div class="d-flex justify-content-end mb-3">
+    <span></span>
+    <a class="btn btn-info" href="{{ request.event.cfp.urls.new_access_code }}">
+      <i class="fa fa-plus"></i>
+      {% translate "New access code" %}
+    </a>
+  </div>
+  {% if access_codes %}
+    <div class="table-responsive-sm">
+      <table class="table table-sm table-hover table-flip table-sticky" id="access-codes">
+        <thead>
+          <tr>
+            <th>{% translate "Code" %}</th>
+            {% if request.event|get_feature_flag:"use_tracks" %}
+              <th>{% translate "Track" %}</th>
+            {% endif %}
+            <th>{% translate "Session type" %}</th>
+            <th class="numeric">{% translate "Uses" %}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for code in access_codes %}
+            <tr>
+              <td>{{ code.code|copyable }}</td>
+              {% if request.event|get_feature_flag:"use_tracks" %}
+                <td>
+                  {% if code.track %}
+                    <a href="{{ code.track.urls.base }}">{{ code.track.name }}</a>
+                  {% else %}
+                    –
+                  {% endif %}
+                </td>
+              {% endif %}
+              <td>
+                {% if code.submission_type %}
+                  <a href="{{ code.submission_type.urls.base }}">{{ code.submission_type.name }}</a>
+                {% else %}–{% endif %}
+              </td>
+              <td class="numeric">
+                {{ code.redeemed|default:0 }} / {{ code.maximum_uses|default:"∞" }}
+              </td>
+              <td class="text-right">
+                <div data-destination="{{ code.urls.cfp_url.full }}"
+                     role="button"
+                     title="{% translate "Copy access code link" %}"
+                     class="btn btn-sm btn-info copyable-text">
+                  <i class="fa fa-copy"></i>
+                </div>
+                <a href="{{ code.urls.send }}"
+                   title="{% translate "Send access code as email" %}"
+                   class="btn btn-sm btn-info">
+                  <i class="fa fa-envelope"></i>
+                </a>
+                <a href="{{ code.urls.edit }}" class="btn btn-sm btn-info">
+                  <i class="fa fa-edit"></i>
+                </a>
+                {% if not code.submissions.exists %}
+                  <a href="{{ code.urls.delete }}" class="btn btn-sm btn-danger">
+                    <i class="fa fa-trash"></i>
+                  </a>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/flow.html
+++ b/src/pretalx/orga/templates/orga/cfp/flow.html
@@ -5,37 +5,37 @@
 {% load static %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/headers-uncompressed.css" %}" />
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "orga/css/flow.css" %}">
-    {% endcompress %}
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/headers-uncompressed.css" %}" />
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "orga/css/flow.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {{ current_configuration|json_script:"currentConfiguration" }}
-    {{ event_configuration|json_script:"eventConfiguration" }}
+  {{ current_configuration|json_script:"currentConfiguration" }}
+  {{ event_configuration|json_script:"eventConfiguration" }}
 
-    {% if debug %}
-        <script defer src="{% static "vendored/vue.js" %}"></script>
-    {% else %}
-        <script defer src="{% static "vendored/vue.min.js" %}"></script>
-    {% endif %}
-    <script defer src="{% static "vendored/marked.min.js" %}"></script> {# do not compress #}
-    <script defer src="{% static "vendored/purify.min.js" %}"></script>
-    <script defer src="{% static "orga/js/cfp_flow.js" %}"></script>
+  {% if debug %}
+    <script defer src="{% static "vendored/vue.js" %}"></script>
+  {% else %}
+    <script defer src="{% static "vendored/vue.min.js" %}"></script>
+  {% endif %}
+  <script defer src="{% static "vendored/marked.min.js" %}"></script> {# do not compress #}
+  <script defer src="{% static "vendored/purify.min.js" %}"></script>
+  <script defer src="{% static "orga/js/cfp_flow.js" %}"></script>
 {% endblock scripts %}
 
 {% block extra_title %}{% translate "CfP Editor" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h1>{% translate "CfP Editor" %}</h1>
-    <p>
-        {% blocktranslate trimmed %}
-            This is the {{ site_name }} CfP editor. This page allows you to change the
-            headline and information text on all of the individual CfP steps. You
-            can also add a custom help text to individual fields. Just click on the
-            item you want to change!
-        {% endblocktranslate %}
-    </p>
-    <div id="flow"></div>
+  <h1>{% translate "CfP Editor" %}</h1>
+  <p>
+    {% blocktranslate trimmed %}
+      This is the {{ site_name }} CfP editor. This page allows you to change the
+      headline and information text on all of the individual CfP steps. You
+      can also add a custom help text to individual fields. Just click on the
+      item you want to change!
+    {% endblocktranslate %}
+  </p>
+  <div id="flow"></div>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/question_detail.html
+++ b/src/pretalx/orga/templates/orga/cfp/question_detail.html
@@ -6,97 +6,97 @@
 {% load times %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" type="text/css" href="{% static "vendored/apexcharts/apexcharts.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "vendored/apexcharts/apexcharts.css" %}" />
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "vendored/apexcharts/apexcharts.min.js" %}"></script>
-        <script defer src="{% static "orga/js/question_stats.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "vendored/apexcharts/apexcharts.min.js" %}"></script>
+    <script defer src="{% static "orga/js/question_stats.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{{ quotation_open }}{{ question.question }}{{ quotation_close }} :: {% endblock extra_title %}
 
 {% block content %}
-    <h4>
-        {{ quotation_open }}{{ question.question }}{{ quotation_close }}
-        <small>({{ question.get_variant_display }})</small>
-        <a href="{{ question.urls.edit }}" class="btn btn-sm btn-outline-info">
-            <i class="fa fa-edit"></i>
-        </a>
-    </h4>
+  <h4>
+    {{ quotation_open }}{{ question.question }}{{ quotation_close }}
+    <small>({{ question.get_variant_display }})</small>
+    <a href="{{ question.urls.edit }}" class="btn btn-sm btn-outline-info">
+      <i class="fa fa-edit"></i>
+    </a>
+  </h4>
 
-    {% if answer_count %}
-        <div class="pb-4">
-            <form class="form-inline filter-form">
-                {{ filter_form }}
-                <button class="btn btn-info" type="submit">{% translate "Filter" %}</button>
-            </form>
-        </div>
-    {% endif %}
+  {% if answer_count %}
+    <div class="pb-4">
+      <form class="form-inline filter-form">
+        {{ filter_form }}
+        <button class="btn btn-info" type="submit">{% translate "Filter" %}</button>
+      </form>
+    </div>
+  {% endif %}
 
-    <p>
-        {% if question.active %}
-            {% translate "This question is currently active, it will be asked during submission." %}
-            <a class="btn btn-sm btn-danger" href="{{ question.urls.toggle }}">{% translate "Hide question" %}</a>
-        {% else %}
-            {% translate "This question is currently inactive, and will not be asked during submission." %}
-            <a class="btn btn-sm btn-success" href="{{ question.urls.toggle }}">{% translate "Activate question" %}</a>
-        {% endif %}
-    </p>
-
-    {% if not answer_count %}
-        {% translate "Nobody has answered this question at the moment." %}
+  <p>
+    {% if question.active %}
+      {% translate "This question is currently active, it will be asked during submission." %}
+      <a class="btn btn-sm btn-danger" href="{{ question.urls.toggle }}">{% translate "Hide question" %}</a>
     {% else %}
-        <p>
-            {% if missing_answers %}
-                {% blocktranslate with count=answer_count|times missing=missing_answers href=base_search_url trimmed %}
-                    This question has been answered <strong>{{ count }}</strong>, <strong>{{ missing }}</strong> answers <a href="{{ base_search_url }}unanswered=1">are still missing</a>.
-                {% endblocktranslate %}
-            {% else %}
-                {% blocktranslate with count=question.answers.count|times trimmed %}
-                    This question has been answered <strong>{{ count }}</strong>, and no answers are missing.
-                {% endblocktranslate %}
-            {% endif %}
-        </p>
-        <div id="question-data" class="d-none"
-             data-states='{{ grouped_answers_json }}'
-             data-url="{{ base_search_url }}{% if answer.answer %}answer={{ answer.answer|urlencode }}{% else %}{{ answer.options|urlencode }}{% endif %}"
-        >
-        </div>
-        <div id="question-stats" class="d-flex mt-4 pt-4">
-            {% if question.variant != "file" and grouped_answers|length < 50 %}
-                <div id="question-answers"></div>
-                <div class="table-responsive-sm">
-                    <table class="table table-flip table-sticky">
-                        <thead>
-                            <th>{% translate "Answer" %}</th>
-                            <th class="numeric">{% translate "Count" %}</th>
-                            <th class="numeric">{% translate "%" %}</th>
-                        </thead>
-                        <tbody>
-                            {% for answer in grouped_answers %}
-                                <tr>
-                                    <td>
-                                        {% if question.target != "reviewer" %}
-                                            <a href="{{ base_search_url }}{% if answer.answer %}answer={{ answer.answer|urlencode }}{% else %}answer__options={{ answer.options|urlencode }}{% endif %}">
-                                        {% endif %}
-                                        {% if answer.answer %}
-                                            {{ answer.answer|truncatechars:140 }}
-                                        {% else %}
-                                            {{ answer.options__answer|truncatechars:140 }}
-                                        {% endif %}
-                                        {% if question.target != "reviewer" %}</a>{% endif %}
-                                    </td>
-                                    <td class="numeric">{{ answer.count }}</td>
-                                    <td class="numeric">{% widthratio answer.count answer_count 100 %}&nbsp;%</td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                </div>
-            {% endif %}
+      {% translate "This question is currently inactive, and will not be asked during submission." %}
+      <a class="btn btn-sm btn-success" href="{{ question.urls.toggle }}">{% translate "Activate question" %}</a>
     {% endif %}
+  </p>
+
+  {% if not answer_count %}
+    {% translate "Nobody has answered this question at the moment." %}
+  {% else %}
+    <p>
+      {% if missing_answers %}
+        {% blocktranslate with count=answer_count|times missing=missing_answers href=base_search_url trimmed %}
+          This question has been answered <strong>{{ count }}</strong>, <strong>{{ missing }}</strong> answers <a href="{{ base_search_url }}unanswered=1">are still missing</a>.
+        {% endblocktranslate %}
+      {% else %}
+        {% blocktranslate with count=question.answers.count|times trimmed %}
+          This question has been answered <strong>{{ count }}</strong>, and no answers are missing.
+        {% endblocktranslate %}
+      {% endif %}
+    </p>
+    <div id="question-data" class="d-none"
+         data-states='{{ grouped_answers_json }}'
+         data-url="{{ base_search_url }}{% if answer.answer %}answer={{ answer.answer|urlencode }}{% else %}{{ answer.options|urlencode }}{% endif %}"
+    >
+    </div>
+    <div id="question-stats" class="d-flex mt-4 pt-4">
+      {% if question.variant != "file" and grouped_answers|length < 50 %}
+        <div id="question-answers"></div>
+        <div class="table-responsive-sm">
+          <table class="table table-flip table-sticky">
+            <thead>
+              <th>{% translate "Answer" %}</th>
+              <th class="numeric">{% translate "Count" %}</th>
+              <th class="numeric">{% translate "%" %}</th>
+            </thead>
+            <tbody>
+              {% for answer in grouped_answers %}
+                <tr>
+                  <td>
+                    {% if question.target != "reviewer" %}
+                      <a href="{{ base_search_url }}{% if answer.answer %}answer={{ answer.answer|urlencode }}{% else %}answer__options={{ answer.options|urlencode }}{% endif %}">
+                    {% endif %}
+                    {% if answer.answer %}
+                      {{ answer.answer|truncatechars:140 }}
+                    {% else %}
+                      {{ answer.options__answer|truncatechars:140 }}
+                    {% endif %}
+                    {% if question.target != "reviewer" %}</a>{% endif %}
+                  </td>
+                  <td class="numeric">{{ answer.count }}</td>
+                  <td class="numeric">{% widthratio answer.count answer_count 100 %}&nbsp;%</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        </div>
+      {% endif %}
+  {% endif %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/question_form.html
+++ b/src/pretalx/orga/templates/orga/cfp/question_form.html
@@ -8,175 +8,175 @@
 {% block extra_title %}{% if form.instance.question %}{{ form.instance.question }}{% else %}{% translate "New question" %}{% endif %} :: {% endblock extra_title %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "orga/css/dragsort.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "orga/css/dragsort.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "js/jquery.js" %}"></script>
-        <script defer src="{% static "js/jquery.formset.js" %}"></script>
-        <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
-        <script defer src="{% static "orga/js/questionForm.js" %}"></script>
-        <script defer src="{% static "orga/js/dragsort.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "js/jquery.js" %}"></script>
+    <script defer src="{% static "js/jquery.formset.js" %}"></script>
+    <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
+    <script defer src="{% static "orga/js/questionForm.js" %}"></script>
+    <script defer src="{% static "orga/js/dragsort.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block content %}
-    <h2>
-        {% if form.instance.question %}
-            {% translate "Question" %}: {{ form.instance.question }}
-        {% else %}
-            {% translate "New question" %}
-        {% endif %}
-    </h2>
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        {% include "common/forms/errors.html" %}
-        {% if action == "edit" and question.answers.count %}
-            <div class="alert alert-warning col-md-9 offset-md-3">
-                {% blocktranslate trimmed %}
-                    This question has already been answered by some speakers – please consider
-                    carefully if modifying it would render those answers obsolete. You could also
-                    deactivate this question and start a new one instead.
-                {% endblocktranslate %}
-            </div>
-        {% endif %}
+  <h2>
+    {% if form.instance.question %}
+      {% translate "Question" %}: {{ form.instance.question }}
+    {% else %}
+      {% translate "New question" %}
+    {% endif %}
+  </h2>
+  <form method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {% include "common/forms/errors.html" %}
+    {% if action == "edit" and question.answers.count %}
+      <div class="alert alert-warning col-md-9 offset-md-3">
+        {% blocktranslate trimmed %}
+          This question has already been answered by some speakers – please consider
+          carefully if modifying it would render those answers obsolete. You could also
+          deactivate this question and start a new one instead.
+        {% endblocktranslate %}
+      </div>
+    {% endif %}
 
-        {% if action != "create" %}
-            {% if question.active %}
-                <div class="alert alert-info col-md-9 offset-md-3">
-                    <span>
-                        {% translate "This question is currently active, it will be asked during submission." %}
-                        <a class="btn btn-sm btn-outline-danger"
-                           href="{{ question.urls.toggle }}">{% translate "Hide question" %}</a>
-                    </span>
-                </div>
-            {% else %}
-                <div class="alert alert-info col-md-9 offset-md-3">
-                    <span>
-                        {% translate "This question is currently inactive, and will not be asked during submission." %}
-                        <a class="btn btn-sm btn-success" href="{{ question.urls.toggle }}">{% translate "Activate question" %}</a>
-                    </span>
-                </div>
-            {% endif %}
-        {% endif %}
-
-        {{ form.target.as_field_group }}
-        {{ form.variant.as_field_group }}
-        {{ form.question.as_field_group }}
-        {{ form.help_text.as_field_group }}
-        <div class="alert alert-info col-md-9 offset-md-3" id="alert-required-boolean">
-            {% blocktranslate trimmed %}
-                If you mark a Yes/No question as required, it means that the user has to select Yes and No is not
-                accepted. If you want to allow both options, do not make this field required.
-            {% endblocktranslate %}
+    {% if action != "create" %}
+      {% if question.active %}
+        <div class="alert alert-info col-md-9 offset-md-3">
+          <span>
+            {% translate "This question is currently active, it will be asked during submission." %}
+            <a class="btn btn-sm btn-outline-danger"
+               href="{{ question.urls.toggle }}">{% translate "Hide question" %}</a>
+          </span>
         </div>
-        {{ form.is_public.as_field_group }}
-        {{ form.contains_personal_data.as_field_group }}
-        <span id="is-visible-to-reviewers">{{ form.is_visible_to_reviewers.as_field_group }}</span>
-        <fieldset class="limit-submission">
-            <legend>{% translate "Limit to specific proposals" %}</legend>
-            {% if form.tracks %}
-                <span class="limit-submission">{{ form.tracks.as_field_group }}</span>
-            {% endif %}
-            {% if form.submission_types %}
-                <span class="limit-submission">{{ form.submission_types.as_field_group }}</span>
-            {% endif %}
-        </fieldset>
-        <fieldset>
-            <legend>{% translate "Input validation" %}</legend>
-            {{ form.question_required.as_field_group }}
-            {{ form.deadline.as_field_group }}
-            {{ form.freeze_after.as_field_group }}
-            <span id="limit-length">
-                {{ form.min_length.as_field_group }}
-                {{ form.max_length.as_field_group }}
-            </span>
-            <span id="limit-number">
-                {{ form.min_number.as_field_group }}
-                {{ form.max_number.as_field_group }}
-            </span>
-            <span id="limit-date">
-                {{ form.min_date.as_field_group }}
-                {{ form.max_date.as_field_group }}
-            </span>
-            <span id="limit-datetime">
-                {{ form.min_datetime.as_field_group }}
-                {{ form.max_datetime.as_field_group }}
-            </span>
-        </fieldset>
+      {% else %}
+        <div class="alert alert-info col-md-9 offset-md-3">
+          <span>
+            {% translate "This question is currently inactive, and will not be asked during submission." %}
+            <a class="btn btn-sm btn-success" href="{{ question.urls.toggle }}">{% translate "Activate question" %}</a>
+          </span>
+        </div>
+      {% endif %}
+    {% endif %}
 
-        <fieldset id="answer-options">
-            <legend>{% translate "Answer options" %}</legend>
-            <details class="col-md-9 offset-md-3 mb-3 hide-label" {% if form.errors.options or form.errors.options_replace %}open{% endif %}>
-                <summary>{% translate "Upload answer options" %}</summary>
-                <div class="pt-3"></div>
-                {{ form.options.as_field_group }}
-                {{ form.options_replace.as_field_group }}
-                <hr>
-            </details>
-            <div class="formset" data-formset data-formset-prefix="{{ formset.prefix }}">
-                {{ formset.management_form }}
-                {{ formset.non_form_errors }}
-                <div data-formset-body dragsort-url="{{ form.instance.urls.base }}">
-                    {% for form in formset %}
-                        <div data-formset-form dragsort-id="{{ form.instance.id }}">
-                            <div class="sr-only">
-                                {{ form.id }}
-                                {{ form.DELETE }}
-                            </div>
-                            <div class="question-option-row flip ml-auto col-md-9 mb-2 d-flex hide-label">
-                                <div class="question-option-input w-100{% if action == "view" %} disabled{% endif %}">
-                                    {% include "common/forms/errors.html" %}
-                                    {{ form.answer.as_field_group }}
-                                </div>
-                                {% if action != "view" %}
-                                    <div class="question-option-delete d-flex align-items-start">
-                                        <button draggable="true" type="button" class="btn btn-primary ml-1 mr-1 dragsort-button" title="{% translate "Move item" %}">
-                                            <i class="fa fa-arrows"></i>
-                                        </button>
+    {{ form.target.as_field_group }}
+    {{ form.variant.as_field_group }}
+    {{ form.question.as_field_group }}
+    {{ form.help_text.as_field_group }}
+    <div class="alert alert-info col-md-9 offset-md-3" id="alert-required-boolean">
+      {% blocktranslate trimmed %}
+        If you mark a Yes/No question as required, it means that the user has to select Yes and No is not
+        accepted. If you want to allow both options, do not make this field required.
+      {% endblocktranslate %}
+    </div>
+    {{ form.is_public.as_field_group }}
+    {{ form.contains_personal_data.as_field_group }}
+    <span id="is-visible-to-reviewers">{{ form.is_visible_to_reviewers.as_field_group }}</span>
+    <fieldset class="limit-submission">
+      <legend>{% translate "Limit to specific proposals" %}</legend>
+      {% if form.tracks %}
+        <span class="limit-submission">{{ form.tracks.as_field_group }}</span>
+      {% endif %}
+      {% if form.submission_types %}
+        <span class="limit-submission">{{ form.submission_types.as_field_group }}</span>
+      {% endif %}
+    </fieldset>
+    <fieldset>
+      <legend>{% translate "Input validation" %}</legend>
+      {{ form.question_required.as_field_group }}
+      {{ form.deadline.as_field_group }}
+      {{ form.freeze_after.as_field_group }}
+      <span id="limit-length">
+        {{ form.min_length.as_field_group }}
+        {{ form.max_length.as_field_group }}
+      </span>
+      <span id="limit-number">
+        {{ form.min_number.as_field_group }}
+        {{ form.max_number.as_field_group }}
+      </span>
+      <span id="limit-date">
+        {{ form.min_date.as_field_group }}
+        {{ form.max_date.as_field_group }}
+      </span>
+      <span id="limit-datetime">
+        {{ form.min_datetime.as_field_group }}
+        {{ form.max_datetime.as_field_group }}
+      </span>
+    </fieldset>
 
-                                        <button type="button" class="btn btn-danger" data-formset-delete-button>
-                                            <i class="fa fa-trash"></i>
-                                        </button>
-                                    </div>
-                                {% endif %}
-                            </div>
-                        </div>
-                    {% endfor %}
+    <fieldset id="answer-options">
+      <legend>{% translate "Answer options" %}</legend>
+      <details class="col-md-9 offset-md-3 mb-3 hide-label" {% if form.errors.options or form.errors.options_replace %}open{% endif %}>
+        <summary>{% translate "Upload answer options" %}</summary>
+        <div class="pt-3"></div>
+        {{ form.options.as_field_group }}
+        {{ form.options_replace.as_field_group }}
+        <hr>
+      </details>
+      <div class="formset" data-formset data-formset-prefix="{{ formset.prefix }}">
+        {{ formset.management_form }}
+        {{ formset.non_form_errors }}
+        <div data-formset-body dragsort-url="{{ form.instance.urls.base }}">
+          {% for form in formset %}
+            <div data-formset-form dragsort-id="{{ form.instance.id }}">
+              <div class="sr-only">
+                {{ form.id }}
+                {{ form.DELETE }}
+              </div>
+              <div class="question-option-row flip ml-auto col-md-9 mb-2 d-flex hide-label">
+                <div class="question-option-input w-100{% if action == "view" %} disabled{% endif %}">
+                  {% include "common/forms/errors.html" %}
+                  {{ form.answer.as_field_group }}
                 </div>
-                <script type="form-template" data-formset-empty-form>
-                    {% escapescript %}
-                        <div data-formset-form>
-                        <div class="sr-only">
-                        {{ formset.empty_form.id }}
-                        {{ formset.empty_form.DELETE }}
-                        </div>
-                        <div class="question-option-row flip ml-auto col-md-9 mb-2 d-flex hide-label">
-                        <div class="question-option-input w-100">
-                        {{ formset.empty_form.answer.as_field_group }}
-                        </div>
-                        <div class="question-option-delete ml-2">
-                        <button type="button" class="btn btn-danger" data-formset-delete-button>
-                        <i class="fa fa-trash"></i></button>
-                        </div>
-                        </div>
-                        </div>
-                    {% endescapescript %}
-                </script>
                 {% if action != "view" %}
-                    <p class="col-md-9 flip ml-auto">
-                        <button type="button" class="btn btn-info" data-formset-add>
-                            <i class="fa fa-plus"></i> {% translate "Add a new option" %}
-                        </button>
-                    </p>
+                  <div class="question-option-delete d-flex align-items-start">
+                    <button draggable="true" type="button" class="btn btn-primary ml-1 mr-1 dragsort-button" title="{% translate "Move item" %}">
+                      <i class="fa fa-arrows"></i>
+                    </button>
+
+                    <button type="button" class="btn btn-danger" data-formset-delete-button>
+                      <i class="fa fa-trash"></i>
+                    </button>
+                  </div>
                 {% endif %}
+              </div>
             </div>
-        </fieldset>
+          {% endfor %}
+        </div>
+        <script type="form-template" data-formset-empty-form>
+          {% escapescript %}
+            <div data-formset-form>
+            <div class="sr-only">
+            {{ formset.empty_form.id }}
+            {{ formset.empty_form.DELETE }}
+            </div>
+            <div class="question-option-row flip ml-auto col-md-9 mb-2 d-flex hide-label">
+            <div class="question-option-input w-100">
+            {{ formset.empty_form.answer.as_field_group }}
+            </div>
+            <div class="question-option-delete ml-2">
+            <button type="button" class="btn btn-danger" data-formset-delete-button>
+            <i class="fa fa-trash"></i></button>
+            </div>
+            </div>
+            </div>
+          {% endescapescript %}
+        </script>
+        {% if action != "view" %}
+          <p class="col-md-9 flip ml-auto">
+            <button type="button" class="btn btn-info" data-formset-add>
+              <i class="fa fa-plus"></i> {% translate "Add a new option" %}
+            </button>
+          </p>
+        {% endif %}
+      </div>
+    </fieldset>
 
-        {% include "orga/includes/submit_row.html" %}
+    {% include "orga/includes/submit_row.html" %}
 
-    </form>
+  </form>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/question_remind.html
+++ b/src/pretalx/orga/templates/orga/cfp/question_remind.html
@@ -5,21 +5,21 @@
 {% block extra_title %}{% translate "Send out reminders" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Send out reminders" %}</h2>
-    <div>
-        <p>
-            {% blocktranslate trimmed %}
-                Here you can limit who will receive reminder emails.
-                You will be able to review emails before they are sent out.
-            {% endblocktranslate %}
-            <br>
-            <a href="{{ reminder_template.urls.base }}">
-                {% translate "Email template" %}:
-                {% translate "Unanswered questions reminder" %}
-            </a>
-        </p>
-    </div>
+  <h2>{% translate "Send out reminders" %}</h2>
+  <div>
+    <p>
+      {% blocktranslate trimmed %}
+        Here you can limit who will receive reminder emails.
+        You will be able to review emails before they are sent out.
+      {% endblocktranslate %}
+      <br>
+      <a href="{{ reminder_template.urls.base }}">
+        {% translate "Email template" %}:
+        {% translate "Unanswered questions reminder" %}
+      </a>
+    </p>
+  </div>
 
-    {% include "orga/includes/base_form.html" with submit_label=phrases.base.send %}
+  {% include "orga/includes/base_form.html" with submit_label=phrases.base.send %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/question_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/question_view.html
@@ -8,100 +8,100 @@
 
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
-        <link rel="stylesheet" href="{% static "orga/css/dragsort.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
+    <link rel="stylesheet" href="{% static "orga/css/dragsort.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/modalDialog.js" %}"></script>
-        <script defer src="{% static "orga/js/dragsort.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+    <script defer src="{% static "orga/js/dragsort.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block content %}
-    <h2>
-        {% translate "Questions" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
-    <dialog id="info-dialog">
-        <div class="alert alert-info">
-            {% blocktranslate trimmed %}
-                Questions can help you sort out additional details with speakers, such as
-                clothing sizes, special requirements such as dietary needs, or accommodation.
-                Questions can be asked either on a per-proposal level, or per speaker, as
-                you see fit.
-            {% endblocktranslate %}
-        </div>
-    </dialog>
-    <div class="submit-group">
-        <span></span>
-        <span>
-            {% if questions %}
-                <a href="{{ request.event.cfp.urls.remind_questions }}" class="btn btn-info">{% translate "Send out reminders for unanswered questions" %}</a>
-            {% endif %}
-            <a href="{{ request.event.cfp.urls.new_question }}" class="btn btn-success">
-                <i class="fa fa-plus"></i>
-                {% translate "Add a new question" %}
-            </a>
-        </span>
+  <h2>
+    {% translate "Questions" %}
+    <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+      <i class="fa fa-question-circle-o text-info"></i>
+    </span>
+  </h2>
+  <dialog id="info-dialog">
+    <div class="alert alert-info">
+      {% blocktranslate trimmed %}
+        Questions can help you sort out additional details with speakers, such as
+        clothing sizes, special requirements such as dietary needs, or accommodation.
+        Questions can be asked either on a per-proposal level, or per speaker, as
+        you see fit.
+      {% endblocktranslate %}
     </div>
+  </dialog>
+  <div class="submit-group">
+    <span></span>
+    <span>
+      {% if questions %}
+        <a href="{{ request.event.cfp.urls.remind_questions }}" class="btn btn-info">{% translate "Send out reminders for unanswered questions" %}</a>
+      {% endif %}
+      <a href="{{ request.event.cfp.urls.new_question }}" class="btn btn-success">
+        <i class="fa fa-plus"></i>
+        {% translate "Add a new question" %}
+      </a>
+    </span>
+  </div>
 
-    <div class="table-responsive-sm">
-        <table class="table table-hover table-sm table-flip-sticky">
-            <thead>
-                <tr>
-                    <th>{% translate "Question" %}</th>
-                    <th>{% translate "Target" %}</th>
-                    <th class="text-center">{% translate "required" %}</th>
-                    <th class="text-center">{% translate "active" %}</th>
-                    <th class="numeric">{% translate "Answers" %}</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody dragsort-url="{{ request.event.cfp.urls.questions }}">
-                {% for question in questions %}
-                    <tr dragsort-id="{{ question.id }}">
-                        <td>
-                            <a href="{{ question.urls.base }}">{{ question.question }}</a>
-                        </td>
-                        <td>{{ question.get_target_display }}</td>
-                        <td class="text-center">
-                            <i class="fa fa-{{ question.required|yesno:"check-circle text-success,times-circle text-danger" }}">
-                            </i>
-                            {% if question.question_required == "require after" or question.freeze_after %}
-                                <i class="fa fa-clock-o" title="{% translate "This question’s availability depends on a deadline." %}"> </i>
-                            {% endif %}
-                        </td>
-                        <td class="text-center">
-                            <i class="fa fa-{{ question.active|yesno:"check-circle text-success,times-circle text-danger" }}">
-                            </i>
-                        </td>
-                        <td class="numeric">{{ question.answer_count }}</td>
-                        <td class="text-right">
-                            <button draggable="true" class="btn btn-sm btn-primary mr-1 dragsort-button" title="{% translate "Move item" %}">
-                                <i class="fa fa-arrows"></i>
-                            </button>
-                            <a href="{{ question.urls.edit }}" class="btn btn-sm btn-info mr-1" title="{{ phrases.base.edit }}">
-                                <i class="fa fa-edit"></i>
-                            </a>
-                            <a href="{{ question.urls.delete }}" class="btn btn-sm btn-danger" title="{{ phrases.base.delete_button }}">
-                                <i class="fa fa-trash"></i>
-                            </a>
-                        </td>
-                    </tr>
+  <div class="table-responsive-sm">
+    <table class="table table-hover table-sm table-flip-sticky">
+      <thead>
+        <tr>
+          <th>{% translate "Question" %}</th>
+          <th>{% translate "Target" %}</th>
+          <th class="text-center">{% translate "required" %}</th>
+          <th class="text-center">{% translate "active" %}</th>
+          <th class="numeric">{% translate "Answers" %}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody dragsort-url="{{ request.event.cfp.urls.questions }}">
+        {% for question in questions %}
+          <tr dragsort-id="{{ question.id }}">
+            <td>
+              <a href="{{ question.urls.base }}">{{ question.question }}</a>
+            </td>
+            <td>{{ question.get_target_display }}</td>
+            <td class="text-center">
+              <i class="fa fa-{{ question.required|yesno:"check-circle text-success,times-circle text-danger" }}">
+              </i>
+              {% if question.question_required == "require after" or question.freeze_after %}
+                <i class="fa fa-clock-o" title="{% translate "This question’s availability depends on a deadline." %}"> </i>
+              {% endif %}
+            </td>
+            <td class="text-center">
+              <i class="fa fa-{{ question.active|yesno:"check-circle text-success,times-circle text-danger" }}">
+              </i>
+            </td>
+            <td class="numeric">{{ question.answer_count }}</td>
+            <td class="text-right">
+              <button draggable="true" class="btn btn-sm btn-primary mr-1 dragsort-button" title="{% translate "Move item" %}">
+                <i class="fa fa-arrows"></i>
+              </button>
+              <a href="{{ question.urls.edit }}" class="btn btn-sm btn-info mr-1" title="{{ phrases.base.edit }}">
+                <i class="fa fa-edit"></i>
+              </a>
+              <a href="{{ question.urls.delete }}" class="btn btn-sm btn-danger" title="{{ phrases.base.delete_button }}">
+                <i class="fa fa-trash"></i>
+              </a>
+            </td>
+          </tr>
 
-                {% empty %}
-                    <tr>
-                        <td colspan=4 class="w-75">{% translate "You have configured no questions yet." %}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+        {% empty %}
+          <tr>
+            <td colspan=4 class="w-75">{% translate "You have configured no questions yet." %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/submission_type_form.html
+++ b/src/pretalx/orga/templates/orga/cfp/submission_type_form.html
@@ -7,14 +7,14 @@
 {% block extra_title %}{% if form.instance.name %}{{ form.instance.name }}{% else %}{% translate "New Session Type" %}{% endif %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% if form.instance.name %}
-            {% translate "Session type" %}: {{ form.instance.name }}
-        {% else %}
-            {% translate "New Session Type" %}
-        {% endif %}
-    </h2>
+  <h2>
+    {% if form.instance.name %}
+      {% translate "Session type" %}: {{ form.instance.name }}
+    {% else %}
+      {% translate "New Session Type" %}
+    {% endif %}
+  </h2>
 
-    {% include "orga/includes/base_form.html" %}
+  {% include "orga/includes/base_form.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/submission_type_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/submission_type_view.html
@@ -6,88 +6,88 @@
 
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/modalDialog.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{% translate "Session types" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% translate "Session types" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
-    <dialog class="info-dialog" id="info-dialog">
-        <div class="alert alert-info">
-            {% blocktranslate trimmed %}
-                Different session types may help to guide speakers into different slot
-                lengths (short sessions vs long sessions) or different presentation formats
-                (talk vs workshop vs metal concert).
-            {% endblocktranslate %}
-        </div>
-    </dialog>
-    <div class="d-flex justify-content-end mb-3">
-        <a class="btn btn-info" href="{{ request.event.cfp.urls.new_type }}">
-            <i class="fa fa-plus"></i>
-            {% translate "New type" %}
-        </a>
+  <h2>
+    {% translate "Session types" %}
+    <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+      <i class="fa fa-question-circle-o text-info"></i>
+    </span>
+  </h2>
+  <dialog class="info-dialog" id="info-dialog">
+    <div class="alert alert-info">
+      {% blocktranslate trimmed %}
+        Different session types may help to guide speakers into different slot
+        lengths (short sessions vs long sessions) or different presentation formats
+        (talk vs workshop vs metal concert).
+      {% endblocktranslate %}
     </div>
-    <div class="table-responsive-sm">
-        <table class="table table-sm table-hover table-flip table-sticky">
-            <thead>
-                <tr>
-                    <th>{% translate "Session type" %}</th>
-                    <th class="numeric">{% translate "Proposals" %}</th>
-                    <th class="numeric">{% translate "Default duration" %}</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for type in types %}
-                    <tr>
-                        <td>
-                            {% if type.requires_access_code %}
-                                <i class="fa fa-lock" title="{% translate "Requires access code" %}"></i>
-                            {% endif %}
-                            <a href="{{ type.urls.edit }}">{{ type.name }}</a>
-                        </td>
-                        <td class="pl-4 numeric">
-                            <a href="{{ request.event.orga_urls.submissions }}?submission_type={{ type.id }}">{{ type.submissions.all.count }}</a>
-                        </td>
-                        <td class="numeric">{{ type.default_duration }}</td>
-                        <td class="text-right">
-                            {% if request.event.cfp.default_type == type %}
-                                <a><i class="fa fa-check"></i> {% translate "Default" %}</a>
-                            {% else %}
-                                <a href="{{ type.urls.default }}" class="btn btn-sm btn-info">Make default</a>
-                            {% endif %}
-                            <a href="{{ type.urls.prefilled_cfp.full }}"
-                               title="{% translate "Go to pre-filled CfP form" %}"
-                               class="btn btn-sm btn-info">
-                                <i class="fa fa-link"></i>
-                            </a>
-                            <a href="{{ type.urls.edit }}" class="btn btn-sm btn-info">
-                                <i class="fa fa-edit"></i>
-                            </a>
-                            <a href="{{ type.urls.delete }}" class="btn btn-sm btn-danger">
-                                <i class="fa fa-trash"></i>
-                            </a>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+  </dialog>
+  <div class="d-flex justify-content-end mb-3">
+    <a class="btn btn-info" href="{{ request.event.cfp.urls.new_type }}">
+      <i class="fa fa-plus"></i>
+      {% translate "New type" %}
+    </a>
+  </div>
+  <div class="table-responsive-sm">
+    <table class="table table-sm table-hover table-flip table-sticky">
+      <thead>
+        <tr>
+          <th>{% translate "Session type" %}</th>
+          <th class="numeric">{% translate "Proposals" %}</th>
+          <th class="numeric">{% translate "Default duration" %}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for type in types %}
+          <tr>
+            <td>
+              {% if type.requires_access_code %}
+                <i class="fa fa-lock" title="{% translate "Requires access code" %}"></i>
+              {% endif %}
+              <a href="{{ type.urls.edit }}">{{ type.name }}</a>
+            </td>
+            <td class="pl-4 numeric">
+              <a href="{{ request.event.orga_urls.submissions }}?submission_type={{ type.id }}">{{ type.submissions.all.count }}</a>
+            </td>
+            <td class="numeric">{{ type.default_duration }}</td>
+            <td class="text-right">
+              {% if request.event.cfp.default_type == type %}
+                <a><i class="fa fa-check"></i> {% translate "Default" %}</a>
+              {% else %}
+                <a href="{{ type.urls.default }}" class="btn btn-sm btn-info">Make default</a>
+              {% endif %}
+              <a href="{{ type.urls.prefilled_cfp.full }}"
+                 title="{% translate "Go to pre-filled CfP form" %}"
+                 class="btn btn-sm btn-info">
+                <i class="fa fa-link"></i>
+              </a>
+              <a href="{{ type.urls.edit }}" class="btn btn-sm btn-info">
+                <i class="fa fa-edit"></i>
+              </a>
+              <a href="{{ type.urls.delete }}" class="btn btn-sm btn-danger">
+                <i class="fa fa-trash"></i>
+              </a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/text.html
+++ b/src/pretalx/orga/templates/orga/cfp/text.html
@@ -5,225 +5,225 @@
 {% load static %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/modalDialog.js" %}"></script>
-        <script defer src="{% static "orga/js/cfp.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+    <script defer src="{% static "orga/js/cfp.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{% translate "Call for Proposals" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% translate "Call for Proposals" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
-    <dialog class="info-dialog" id="info-dialog">
-        <div class="alert alert-info">
-            <span>
-                {% translate "A good Call for Participation will engage potential speakers. Remember to include:" %}
-                <br>
-                <ul>
-                    <li>{% translate "The formats (sessions, workshops, panels) and their durations" %}</li>
-                    <li>{% translate "Topics you are looking for" %}</li>
-                    <li>{% translate "How open you are to alternative topics" %}</li>
-                    <li>{% translate "The people coming to your conference: interests, experience level …" %}</li>
-                    <li>{% translate "Link your Code of Conduct and Data Protection statements." %}</li>
-                    <li>{% translate "Do you offer financial or other support, e.g. support for first time speakers?" %}</li>
-                    <li>{% translate "Dates and location" %}</li>
-                </ul>
-            </span>
+  <h2>
+    {% translate "Call for Proposals" %}
+    <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+      <i class="fa fa-question-circle-o text-info"></i>
+    </span>
+  </h2>
+  <dialog class="info-dialog" id="info-dialog">
+    <div class="alert alert-info">
+      <span>
+        {% translate "A good Call for Participation will engage potential speakers. Remember to include:" %}
+        <br>
+        <ul>
+          <li>{% translate "The formats (sessions, workshops, panels) and their durations" %}</li>
+          <li>{% translate "Topics you are looking for" %}</li>
+          <li>{% translate "How open you are to alternative topics" %}</li>
+          <li>{% translate "The people coming to your conference: interests, experience level …" %}</li>
+          <li>{% translate "Link your Code of Conduct and Data Protection statements." %}</li>
+          <li>{% translate "Do you offer financial or other support, e.g. support for first time speakers?" %}</li>
+          <li>{% translate "Dates and location" %}</li>
+        </ul>
+      </span>
+    </div>
+  </dialog>
+  <form method="post">
+    {% csrf_token %}
+
+    {% include "common/forms/errors.html" %}
+    {% include "common/forms/errors.html" with form=sform %}
+
+    {% include "orga/includes/tablist.html" %}
+    <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="false">
+      {{ form.headline.as_field_group }}
+      {{ form.text.as_field_group }}
+      {{ form.deadline.as_field_group }}
+      {% if different_deadlines %}
+        <div class="offset-md-3 alert alert-info">
+          <div>
+            {% translate "Some of your session types have different deadlines:" %}
+            <ul class="mb-0">
+              {% for deadline, session_types in different_deadlines.items %}
+                <li>
+                  {% for session_type in session_types %}
+                    <a href="{{ session_type.urls.base }}">{{ session_type.name }}</a>{% if not forloop.last %},{% else %}:{% endif %}
+                  {% endfor %}
+                  {{ deadline }}
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
         </div>
-    </dialog>
-    <form method="post">
-        {% csrf_token %}
+      {% endif %}
+      {{ form.show_deadline.as_field_group }}
+      {{ sform.use_tracks.as_field_group }}
+      {{ sform.present_multiple_times.as_field_group }}
+      {{ sform.submission_public_review.as_field_group }}
+      {{ sform.mail_on_new_submission.as_field_group }}
+    </section>
 
-        {% include "common/forms/errors.html" %}
-        {% include "common/forms/errors.html" with form=sform %}
+    <section role="tabpanel" id="tabpanel-fields" aria-labelledby="tab-fields" tabindex="0" aria-hidden="true">
+      {{ form.count_length_in.as_field_group }}
+      <fieldset>
 
-        {% include "orga/includes/tablist.html" %}
-        <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="false">
-            {{ form.headline.as_field_group }}
-            {{ form.text.as_field_group }}
-            {{ form.deadline.as_field_group }}
-            {% if different_deadlines %}
-                <div class="offset-md-3 alert alert-info">
-                    <div>
-                        {% translate "Some of your session types have different deadlines:" %}
-                        <ul class="mb-0">
-                            {% for deadline, session_types in different_deadlines.items %}
-                                <li>
-                                    {% for session_type in session_types %}
-                                        <a href="{{ session_type.urls.base }}">{{ session_type.name }}</a>{% if not forloop.last %},{% else %}:{% endif %}
-                                    {% endfor %}
-                                    {{ deadline }}
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                </div>
+        <legend id="information"><div>
+          {% translate "Proposal information" %}
+          <span class="dialog-anchor" data-target="#proposal-info-dialog" data-toggle="dialog">
+            <i class="fa fa-question-circle-o text-info"></i>
+          </span>
+        </div></legend>
+        <dialog class="info-dialog" id="proposal-info-dialog">
+          <div class="alert alert-info"><span>
+            {% translate "Select which information should be requested and/or required during CfP proposal." %}
+            <a href="{{ request.event.cfp.urls.editor }}">{% translate "Click here to view the proposal form." %}</a>
+          </span></div>
+        </dialog>
+        <div class="table-responsive-sm offset-md-3"><table class="table table-sm table-hover table-flip table-sticky cfp-option-table">
+          <thead>
+            <tr>
+              <th></th>
+              <th></th>
+              <th>{% translate "Minimum length" %}</th>
+              <th>{% translate "Maximum length" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>{% translate "Title" %}</th>
+              <td></td>
+              <td>{{ sform.cfp_title_min_length.as_field_group }}</td>
+              <td>{{ sform.cfp_title_max_length.as_field_group }}</td>
+            </tr>
+            <tr>
+              <th>{% translate "Abstract" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_abstract.as_field_group }}</td>
+              <td>{{ sform.cfp_abstract_min_length.as_field_group }}</td>
+              <td>{{ sform.cfp_abstract_max_length.as_field_group }}</td>
+            </tr>
+            <tr>
+              <th>{% translate "Description" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_description.as_field_group }}</td>
+              <td>{{ sform.cfp_description_min_length.as_field_group }}</td>
+              <td>{{ sform.cfp_description_max_length.as_field_group }}</td>
+            </tr>
+            <tr{% if request.event.settings.use_tracks %}class="d-none"{% endif %}>
+              <th>{% translate "Track" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_track.as_field_group }}</td>
+              <td></td>
+              <td></td>
+            </tr>
+            {% if request.event.is_multilingual %}
+              <tr>
+                <th>{{ phrases.base.language }}</th>
+                <td class="hide-label">{{ sform.cfp_ask_content_locale.as_field_group }}</td>
+                <td></td>
+                <td></td>
+              </tr>
             {% endif %}
-            {{ form.show_deadline.as_field_group }}
-            {{ sform.use_tracks.as_field_group }}
-            {{ sform.present_multiple_times.as_field_group }}
-            {{ sform.submission_public_review.as_field_group }}
-            {{ sform.mail_on_new_submission.as_field_group }}
-        </section>
+            <tr>
+              <th>{% translate "Additional speakers" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_additional_speaker.as_field_group }}</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th>{% translate "Notes" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_notes.as_field_group }}</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th>{% translate "Recording opt-out" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_do_not_record.as_field_group }}</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th>{% translate "Session image" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_image.as_field_group }}</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th>{% translate "Duration" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_duration.as_field_group }}</td>
+              <td></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table></div>
+      </fieldset>
+      <fieldset>
+        <legend id="information">
+          <div>
+            {% translate "Speaker information" %}
+            <span class="dialog-anchor" data-target="#proposal-info-dialog" data-toggle="dialog">
+              <i class="fa fa-question-circle-o text-info"></i>
+            </span>
+          </div>
+        </legend>
+        <div class="table-responsive-sm offset-md-3"><table class="table table-sm table-hover table-flip table-sticky cfp-option-table">
+          <thead>
+            <tr>
+              <th></th>
+              <th></th>
+              <th>{% translate "Minimum length" %}</th>
+              <th>{% translate "Maximum length" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>{% translate "Biography" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_biography.as_field_group }}</td>
+              <td>{{ sform.cfp_biography_min_length.as_field_group }}</td>
+              <td>{{ sform.cfp_biography_max_length.as_field_group }}</td>
+            </tr>
+            <tr>
+              <th>{% translate "Profile picture" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_avatar.as_field_group }}</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th>{% translate "Availability" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_availabilities.as_field_group }}</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th>{% translate "Profile picture source" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_avatar_source.as_field_group }}</td>
+              <td>{{ sform.cfp_avatar_source_min_length.as_field_group }}</td>
+              <td>{{ sform.cfp_avatar_source_max_length.as_field_group }}</td>
+            </tr>
+            <tr>
+              <th>{% translate "Profile picture license" %}</th>
+              <td class="hide-label">{{ sform.cfp_ask_avatar_license.as_field_group }}</td>
+              <td>{{ sform.cfp_avatar_license_min_length.as_field_group }}</td>
+              <td>{{ sform.cfp_avatar_license_max_length.as_field_group }}</td>
+            </tr>
+          </tbody>
+        </table></div>
+      </fieldset>
+    </section>
 
-        <section role="tabpanel" id="tabpanel-fields" aria-labelledby="tab-fields" tabindex="0" aria-hidden="true">
-            {{ form.count_length_in.as_field_group }}
-            <fieldset>
+    {% include "orga/includes/submit_row.html" %}
 
-                <legend id="information"><div>
-                    {% translate "Proposal information" %}
-                    <span class="dialog-anchor" data-target="#proposal-info-dialog" data-toggle="dialog">
-                        <i class="fa fa-question-circle-o text-info"></i>
-                    </span>
-                </div></legend>
-                <dialog class="info-dialog" id="proposal-info-dialog">
-                    <div class="alert alert-info"><span>
-                        {% translate "Select which information should be requested and/or required during CfP proposal." %}
-                        <a href="{{ request.event.cfp.urls.editor }}">{% translate "Click here to view the proposal form." %}</a>
-                    </span></div>
-                </dialog>
-                <div class="table-responsive-sm offset-md-3"><table class="table table-sm table-hover table-flip table-sticky cfp-option-table">
-                    <thead>
-                        <tr>
-                            <th></th>
-                            <th></th>
-                            <th>{% translate "Minimum length" %}</th>
-                            <th>{% translate "Maximum length" %}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <th>{% translate "Title" %}</th>
-                            <td></td>
-                            <td>{{ sform.cfp_title_min_length.as_field_group }}</td>
-                            <td>{{ sform.cfp_title_max_length.as_field_group }}</td>
-                        </tr>
-                        <tr>
-                            <th>{% translate "Abstract" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_abstract.as_field_group }}</td>
-                            <td>{{ sform.cfp_abstract_min_length.as_field_group }}</td>
-                            <td>{{ sform.cfp_abstract_max_length.as_field_group }}</td>
-                        </tr>
-                        <tr>
-                            <th>{% translate "Description" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_description.as_field_group }}</td>
-                            <td>{{ sform.cfp_description_min_length.as_field_group }}</td>
-                            <td>{{ sform.cfp_description_max_length.as_field_group }}</td>
-                        </tr>
-                        <tr{% if request.event.settings.use_tracks %}class="d-none"{% endif %}>
-                            <th>{% translate "Track" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_track.as_field_group }}</td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                        {% if request.event.is_multilingual %}
-                            <tr>
-                                <th>{{ phrases.base.language }}</th>
-                                <td class="hide-label">{{ sform.cfp_ask_content_locale.as_field_group }}</td>
-                                <td></td>
-                                <td></td>
-                            </tr>
-                        {% endif %}
-                        <tr>
-                            <th>{% translate "Additional speakers" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_additional_speaker.as_field_group }}</td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <th>{% translate "Notes" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_notes.as_field_group }}</td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <th>{% translate "Recording opt-out" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_do_not_record.as_field_group }}</td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <th>{% translate "Session image" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_image.as_field_group }}</td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <th>{% translate "Duration" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_duration.as_field_group }}</td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                    </tbody>
-                </table></div>
-            </fieldset>
-            <fieldset>
-                <legend id="information">
-                    <div>
-                        {% translate "Speaker information" %}
-                        <span class="dialog-anchor" data-target="#proposal-info-dialog" data-toggle="dialog">
-                            <i class="fa fa-question-circle-o text-info"></i>
-                        </span>
-                    </div>
-                </legend>
-                <div class="table-responsive-sm offset-md-3"><table class="table table-sm table-hover table-flip table-sticky cfp-option-table">
-                    <thead>
-                        <tr>
-                            <th></th>
-                            <th></th>
-                            <th>{% translate "Minimum length" %}</th>
-                            <th>{% translate "Maximum length" %}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <th>{% translate "Biography" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_biography.as_field_group }}</td>
-                            <td>{{ sform.cfp_biography_min_length.as_field_group }}</td>
-                            <td>{{ sform.cfp_biography_max_length.as_field_group }}</td>
-                        </tr>
-                        <tr>
-                            <th>{% translate "Profile picture" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_avatar.as_field_group }}</td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <th>{% translate "Availability" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_availabilities.as_field_group }}</td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <th>{% translate "Profile picture source" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_avatar_source.as_field_group }}</td>
-                            <td>{{ sform.cfp_avatar_source_min_length.as_field_group }}</td>
-                            <td>{{ sform.cfp_avatar_source_max_length.as_field_group }}</td>
-                        </tr>
-                        <tr>
-                            <th>{% translate "Profile picture license" %}</th>
-                            <td class="hide-label">{{ sform.cfp_ask_avatar_license.as_field_group }}</td>
-                            <td>{{ sform.cfp_avatar_license_min_length.as_field_group }}</td>
-                            <td>{{ sform.cfp_avatar_license_max_length.as_field_group }}</td>
-                        </tr>
-                    </tbody>
-                </table></div>
-            </fieldset>
-        </section>
-
-        {% include "orga/includes/submit_row.html" %}
-
-    </form>
+  </form>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/track_form.html
+++ b/src/pretalx/orga/templates/orga/cfp/track_form.html
@@ -8,23 +8,23 @@
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "vendored/vanilla-picker/vanilla-picker.min.js" %}"></script>
-        <script defer src="{% static "orga/js/colorpicker.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "vendored/vanilla-picker/vanilla-picker.min.js" %}"></script>
+    <script defer src="{% static "orga/js/colorpicker.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{% if form.instance.name %}{{ form.instance.name }}{% else %}{% translate "New track" %}{% endif %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% if form.instance.name %}
-            {% translate "Track" %}: {{ form.instance.name }}
-        {% else %}
-            {% translate "New track" %}
-        {% endif %}
-    </h2>
+  <h2>
+    {% if form.instance.name %}
+      {% translate "Track" %}: {{ form.instance.name }}
+    {% else %}
+      {% translate "New track" %}
+    {% endif %}
+  </h2>
 
-    {% include "orga/includes/base_form.html" %}
+  {% include "orga/includes/base_form.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/cfp/track_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/track_view.html
@@ -7,88 +7,88 @@
 {% block extra_title %}{% translate "Tracks" %} :: {% endblock extra_title %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
-        <link rel="stylesheet" href="{% static "orga/css/dragsort.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
+    <link rel="stylesheet" href="{% static "orga/css/dragsort.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/modalDialog.js" %}"></script>
-        <script defer src="{% static "orga/js/dragsort.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+    <script defer src="{% static "orga/js/dragsort.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block content %}
-    <h2>
-        {% translate "Tracks" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
-    <dialog id="info-dialog">
-        <div class="alert alert-info">
-            {% blocktranslate trimmed %}
-                Tracks are used to sort your sessions into categories. You can use the
-                CfP settings to determine if speakers can select the track for their session
-                themselves. Track colors are helpful to help attendees navigate your schedule.
-            {% endblocktranslate %}
-        </div>
-    </dialog>
-    <div class="d-flex justify-content-end mb-3">
-        <a class="btn btn-info" href="{{ request.event.cfp.urls.new_track }}">
-            <i class="fa fa-plus"></i>
-            {% translate "New track" %}
-        </a>
+  <h2>
+    {% translate "Tracks" %}
+    <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+      <i class="fa fa-question-circle-o text-info"></i>
+    </span>
+  </h2>
+  <dialog id="info-dialog">
+    <div class="alert alert-info">
+      {% blocktranslate trimmed %}
+        Tracks are used to sort your sessions into categories. You can use the
+        CfP settings to determine if speakers can select the track for their session
+        themselves. Track colors are helpful to help attendees navigate your schedule.
+      {% endblocktranslate %}
     </div>
-    <div class="table-responsive-sm">
-        <table class="table table-sm table-hover table-flip table-sticky">
-            <thead>
-                <tr>
-                    <th>{% translate "Track" %}</th>
-                    <th>{% translate "Color" %}</th>
-                    <th class="numeric">{% translate "Proposals" %}</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody dragsort-url="{{ request.cfp.urls.tracks }}">
-                {% for track in tracks %}
-                    <tr dragsort-id="{{ track.id }}">
-                        <td>
-                            <a href="{{ track.urls.edit }}">{{ track.name }}</a>
-                            {% if track.requires_access_code %}
-                                <i class="fa fa-lock ml-1" title="{% translate "Requires access code" %}"></i>
-                            {% endif %}
-                        </td>
-                        <td>
-                            <div class="color-square" style="background: {{ track.color }}"></div>
-                        </td>
-                        <td class="numeric">
-                            <a href="{{ request.event.orga_urls.submissions }}?track={{ track.id }}">{{ track.submissions.all.count }}</a>
-                        </td>
-                        <td class="text-right">
-                            <button draggable="true" class="btn btn-sm btn-primary mr-1 dragsort-button" title="{% translate "Move item" %}">
-                                <i class="fa fa-arrows"></i>
-                            </button>
-                            <a href="{{ track.urls.prefilled_cfp.full }}"
-                               title="{% translate "Go to pre-filled CfP form" %}"
-                               class="btn btn-sm btn-info">
-                                <i class="fa fa-link"></i>
-                            </a>
-                            <a href="{{ track.urls.edit }}" class="btn btn-sm btn-info">
-                                <i class="fa fa-edit"></i>
-                            </a>
-                            <a href="{{ track.urls.delete }}" class="btn btn-sm btn-danger">
-                                <i class="fa fa-trash"></i>
-                            </a>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+  </dialog>
+  <div class="d-flex justify-content-end mb-3">
+    <a class="btn btn-info" href="{{ request.event.cfp.urls.new_track }}">
+      <i class="fa fa-plus"></i>
+      {% translate "New track" %}
+    </a>
+  </div>
+  <div class="table-responsive-sm">
+    <table class="table table-sm table-hover table-flip table-sticky">
+      <thead>
+        <tr>
+          <th>{% translate "Track" %}</th>
+          <th>{% translate "Color" %}</th>
+          <th class="numeric">{% translate "Proposals" %}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody dragsort-url="{{ request.cfp.urls.tracks }}">
+        {% for track in tracks %}
+          <tr dragsort-id="{{ track.id }}">
+            <td>
+              <a href="{{ track.urls.edit }}">{{ track.name }}</a>
+              {% if track.requires_access_code %}
+                <i class="fa fa-lock ml-1" title="{% translate "Requires access code" %}"></i>
+              {% endif %}
+            </td>
+            <td>
+              <div class="color-square" style="background: {{ track.color }}"></div>
+            </td>
+            <td class="numeric">
+              <a href="{{ request.event.orga_urls.submissions }}?track={{ track.id }}">{{ track.submissions.all.count }}</a>
+            </td>
+            <td class="text-right">
+              <button draggable="true" class="btn btn-sm btn-primary mr-1 dragsort-button" title="{% translate "Move item" %}">
+                <i class="fa fa-arrows"></i>
+              </button>
+              <a href="{{ track.urls.prefilled_cfp.full }}"
+                 title="{% translate "Go to pre-filled CfP form" %}"
+                 class="btn btn-sm btn-info">
+                <i class="fa fa-link"></i>
+              </a>
+              <a href="{{ track.urls.edit }}" class="btn btn-sm btn-info">
+                <i class="fa fa-edit"></i>
+              </a>
+              <a href="{{ track.urls.delete }}" class="btn btn-sm btn-danger">
+                <i class="fa fa-trash"></i>
+              </a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/event/dashboard.html
+++ b/src/pretalx/orga/templates/orga/event/dashboard.html
@@ -6,120 +6,120 @@
 {% load static %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "orga/css/dashboard.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "orga/css/dashboard.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block content %}
-    {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
-    {% has_perm "orga.change_settings" request.user request.event as can_change_settings %}
-    {% if "congratulations" in request.GET %}
-        <div class="alert alert-success congratulations">
-            <span></span>
-            {% blocktranslate trimmed %}
-                Your event has been created and you’re ready to go! Check out the
-                event settings, set up your Call for Papers with session types and questions,
-                and you’re ready to go!
-            {% endblocktranslate %}
-        </div>
-    {% endif %}
-    <h2 id="main-title">
-        <span>
-            {{ request.event.name }}
-            <small class="text-muted small">{{ request.event.get_date_range_display }}</small>
-        </span>
-    </h2>
-    <div id="timeline-steps" class="stages">
-        {% for stp in timeline %}
-            <div {% if stp.phase == "done" and stp.url %}href="{{ stp.url }}"{% endif %} class="step step-{{ stp.phase }}">
-                <div class="step-icon">
-                    <span class="fa {% if stp.icon %}fa-{{ stp.icon }}{% else %}fa-check{% endif %}"></span>
-                </div>
-                <div class="step-label">
-                    {{ stp.label }}
-                </div>
-                {% if stp.links and can_change_settings %}
-                    <div class="step-links">
-                        <ul>
-                            {% for link in stp.links %}
-                                <li>
-                                    <a {% if link.url %}href="{{ link.url }}"{% endif %}>
-                                        {{ link.title }}
-                                    </a>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                {% endif %}
-            </div>
-        {% endfor %}
+  {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
+  {% has_perm "orga.change_settings" request.user request.event as can_change_settings %}
+  {% if "congratulations" in request.GET %}
+    <div class="alert alert-success congratulations">
+      <span></span>
+      {% blocktranslate trimmed %}
+        Your event has been created and you’re ready to go! Check out the
+        event settings, set up your Call for Papers with session types and questions,
+        and you’re ready to go!
+      {% endblocktranslate %}
     </div>
-
-    <div class="dashboard-list">
-        <a href="{{ request.event.orga_urls.live }}" class="dashboard-block">
-            <div class="dashboard-live-text">
-                {% translate "Your event is currently" %}
-            </div>
-            {% if request.event.is_public %}
-                <div class="dashboard-live text-success">
-                    <i class="fa fa-check-circle"></i>
-                    {% translate "live" %}
-                </div>
-            {% else %}
-                <div class="dashboard-live text-danger">
-                    <i class="fa fa-times-circle"></i>
-                    {% translate "not live" %}
-                </div>
-            {% endif %}
-            <div class="dashboard-live-text">
-                {% translate "Click here to change" %}
-            </div>
-        </a>
-        {% for tile in tiles %}
-            <div class="dashboard-block-wrapper">
-                <{% if tile.url %}a href="{{ tile.url }}"{% else %}div{% endif %} class="dashboard-block{% if tile.left or tile.right %} dashboard-block-extended{% endif %}">
-                <h1>{{ tile.large }}</h1>
-                <div class="dashboard-description">
-                    {{ tile.small }}
-                </div>
-            </{% if tile.url %}a{% else %}div{% endif %}>
-            {% if tile.left or tile.right %}
-                <div class="dashboard-block-extension">
-                    {% if tile.left %}
-                        <{% if tile.left.url %}a href="{{ tile.left.url }}"{% else %}div{% endif %} class="dashboard-block-addon{% if tile.left.color %} dashboard-block-addon-{{ tile.left.color }}{% endif %}">
-                        {{ tile.left.text }}
-
-                        </{% if tile.left.url %}a{% else %}div{% endif %}>
-                    {% endif %}
-                    {% if tile.right %}
-                        <{% if tile.right.url %}a href="{{ tile.right.url }}"{% else %}div{% endif %} class="dashboard-block-addon{% if tile.right.color %} dashboard-block-addon-{{ tile.right.color }}{% endif %}">
-                        {{ tile.right.text }}
-
-                        </{% if tile.right.url %}a{% else %}div{% endif %}>
-                    {% endif %}
-                </div>
-            {% endif %}
-            </div>
-
-        {% endfor %}
-    </div>
-
-    {% if history and can_view_speakers %}
-        <div class="dashboard-history">
-            <div class="d-flex">
-                <h2>{% translate "History" %}</h2>
-                {% if can_change_settings %}
-                    <small>
-                        <a href="{{ request.event.orga_urls.history }}" class="text-muted ml-2">
-                            ({% translate "Full history" %})
-                        </a>
-                    </small>
-                {% endif %}
-            </div>
-
-            {% include "common/logs.html" with entries=history %}
-
+  {% endif %}
+  <h2 id="main-title">
+    <span>
+      {{ request.event.name }}
+      <small class="text-muted small">{{ request.event.get_date_range_display }}</small>
+    </span>
+  </h2>
+  <div id="timeline-steps" class="stages">
+    {% for stp in timeline %}
+      <div {% if stp.phase == "done" and stp.url %}href="{{ stp.url }}"{% endif %} class="step step-{{ stp.phase }}">
+        <div class="step-icon">
+          <span class="fa {% if stp.icon %}fa-{{ stp.icon }}{% else %}fa-check{% endif %}"></span>
         </div>
-    {% endif %}
+        <div class="step-label">
+          {{ stp.label }}
+        </div>
+        {% if stp.links and can_change_settings %}
+          <div class="step-links">
+            <ul>
+              {% for link in stp.links %}
+                <li>
+                  <a {% if link.url %}href="{{ link.url }}"{% endif %}>
+                    {{ link.title }}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+
+  <div class="dashboard-list">
+    <a href="{{ request.event.orga_urls.live }}" class="dashboard-block">
+      <div class="dashboard-live-text">
+        {% translate "Your event is currently" %}
+      </div>
+      {% if request.event.is_public %}
+        <div class="dashboard-live text-success">
+          <i class="fa fa-check-circle"></i>
+          {% translate "live" %}
+        </div>
+      {% else %}
+        <div class="dashboard-live text-danger">
+          <i class="fa fa-times-circle"></i>
+          {% translate "not live" %}
+        </div>
+      {% endif %}
+      <div class="dashboard-live-text">
+        {% translate "Click here to change" %}
+      </div>
+    </a>
+    {% for tile in tiles %}
+      <div class="dashboard-block-wrapper">
+        <{% if tile.url %}a href="{{ tile.url }}"{% else %}div{% endif %} class="dashboard-block{% if tile.left or tile.right %} dashboard-block-extended{% endif %}">
+        <h1>{{ tile.large }}</h1>
+        <div class="dashboard-description">
+          {{ tile.small }}
+        </div>
+      </{% if tile.url %}a{% else %}div{% endif %}>
+      {% if tile.left or tile.right %}
+        <div class="dashboard-block-extension">
+          {% if tile.left %}
+            <{% if tile.left.url %}a href="{{ tile.left.url }}"{% else %}div{% endif %} class="dashboard-block-addon{% if tile.left.color %} dashboard-block-addon-{{ tile.left.color }}{% endif %}">
+            {{ tile.left.text }}
+
+            </{% if tile.left.url %}a{% else %}div{% endif %}>
+          {% endif %}
+          {% if tile.right %}
+            <{% if tile.right.url %}a href="{{ tile.right.url }}"{% else %}div{% endif %} class="dashboard-block-addon{% if tile.right.color %} dashboard-block-addon-{{ tile.right.color }}{% endif %}">
+            {{ tile.right.text }}
+
+            </{% if tile.right.url %}a{% else %}div{% endif %}>
+          {% endif %}
+        </div>
+      {% endif %}
+      </div>
+
+    {% endfor %}
+  </div>
+
+  {% if history and can_view_speakers %}
+    <div class="dashboard-history">
+      <div class="d-flex">
+        <h2>{% translate "History" %}</h2>
+        {% if can_change_settings %}
+          <small>
+            <a href="{{ request.event.orga_urls.history }}" class="text-muted ml-2">
+              ({% translate "Full history" %})
+            </a>
+          </small>
+        {% endif %}
+      </div>
+
+      {% include "common/logs.html" with entries=history %}
+
+    </div>
+  {% endif %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/event/history.html
+++ b/src/pretalx/orga/templates/orga/event/history.html
@@ -5,11 +5,11 @@
 {% block extra_title %}{% translate "Event History" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Event History" %}</h2>
-    <div class="dashboard-history">
+  <h2>{% translate "Event History" %}</h2>
+  <div class="dashboard-history">
 
-        {% include "common/logs.html" with entries=log_entries %}
-        {% include "orga/includes/pagination.html" %}
+    {% include "common/logs.html" with entries=log_entries %}
+    {% include "orga/includes/pagination.html" %}
 
-    </div>
+  </div>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/event/live.html
+++ b/src/pretalx/orga/templates/orga/event/live.html
@@ -5,61 +5,61 @@
 {% block extra_title %}{% if request.event.is_public %}{% translate "Deactivate event" %}{% else %}{% translate "Go live" %}{% endif %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% if request.event.is_public %}
-            {% translate "Deactivate event" %}
-        {% else %}
-            {% translate "Go live" %}
-        {% endif %}
-    </h2>
-
+  <h2>
     {% if request.event.is_public %}
-        {% blocktranslate trimmed %}
-            Your event is currently live and publicly visible.
-            If you take it down, it will only be visible to you and your team.
-        {% endblocktranslate %}
+      {% translate "Deactivate event" %}
     {% else %}
-        {% blocktranslate trimmed %}
-            Your event is currently only visible to you and your team.
-            By going live, it will be publicly visible.
-        {% endblocktranslate %}
-
-        {% if warnings %}
-            <p>
-                <h4>{% translate "Your event may not be ready for release yet!" %}</h4>
-                <ul>
-                    {% for warning in warnings %}
-                        <li>
-                            {{ warning.text }} <a class="btn btn-sm btn-outline-info" href="{{ warning.url }}">{% translate "Fix me" %}</a>
-                        </li>
-                    {% endfor %}
-                </ul>
-            </p>
-        {% endif %}
-        {% if suggestions %}
-            <p>
-                <h4>{% translate "There may be easy ways to improve your event before its release!" %}</h4>
-                <ul>
-                    {% for suggestion in suggestions %}
-                        <li>
-                            {{ suggestion.text }} <a class="btn btn-sm btn-outline-info" href="{{ suggestion.url }}">{% translate "Fix me" %}</a>
-                        </li>
-                    {% endfor %}
-                </ul>
-            </p>
-        {% endif %}
+      {% translate "Go live" %}
     {% endif %}
-    <p>
-        <div class="submit-group">
-            <span></span>
-            <form method="post">
-                {% csrf_token %}
-                {% if request.event.is_public %}
-                    <button class="btn btn-lg btn-danger" type="submit" name="action" value="deactivate">{% translate "Go offline" %}</button>
-                {% else %}
-                    <button class="btn btn-lg btn-success" type="submit" name="action" value="activate">{% translate "Go live" %}</button>
-                {% endif %}
-            </form>
-        </div>
-    </p>
+  </h2>
+
+  {% if request.event.is_public %}
+    {% blocktranslate trimmed %}
+      Your event is currently live and publicly visible.
+      If you take it down, it will only be visible to you and your team.
+    {% endblocktranslate %}
+  {% else %}
+    {% blocktranslate trimmed %}
+      Your event is currently only visible to you and your team.
+      By going live, it will be publicly visible.
+    {% endblocktranslate %}
+
+    {% if warnings %}
+      <p>
+        <h4>{% translate "Your event may not be ready for release yet!" %}</h4>
+        <ul>
+          {% for warning in warnings %}
+            <li>
+              {{ warning.text }} <a class="btn btn-sm btn-outline-info" href="{{ warning.url }}">{% translate "Fix me" %}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </p>
+    {% endif %}
+    {% if suggestions %}
+      <p>
+        <h4>{% translate "There may be easy ways to improve your event before its release!" %}</h4>
+        <ul>
+          {% for suggestion in suggestions %}
+            <li>
+              {{ suggestion.text }} <a class="btn btn-sm btn-outline-info" href="{{ suggestion.url }}">{% translate "Fix me" %}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </p>
+    {% endif %}
+  {% endif %}
+  <p>
+    <div class="submit-group">
+      <span></span>
+      <form method="post">
+        {% csrf_token %}
+        {% if request.event.is_public %}
+          <button class="btn btn-lg btn-danger" type="submit" name="action" value="deactivate">{% translate "Go offline" %}</button>
+        {% else %}
+          <button class="btn btn-lg btn-success" type="submit" name="action" value="activate">{% translate "Go live" %}</button>
+        {% endif %}
+      </form>
+    </div>
+  </p>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/event/wizard/base.html
+++ b/src/pretalx/orga/templates/orga/event/wizard/base.html
@@ -5,28 +5,28 @@
 {% block extra_title %}{% translate "New event" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <form method="post"><fieldset>
-        <legend>
-            <span>
-                {% translate "New event" %}
-                <small class="text-muted">{% blocktranslate with total=wizard.steps.count current=wizard.steps.step1 trimmed %}
-                    Step {{ current }} of {{ total }}
-                {% endblocktranslate %}</small>
-            </span>
-        </legend>
-        {% block wizard_content %}{% endblock wizard_content %}
-        {% csrf_token %}
-        {{ wizard.management_form }}
-        {% block wizard_form %}
-            {{ wizard.form }}
-        {% endblock %}
-        <div class="submit-group flex-row-reverse">
-            <button type="submit" class="btn btn-success btn-lg float-right flip ml-auto">{% translate "Next step" %}</button>
-            {% if wizard.steps.prev %}
-                <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}" class="btn btn-lg btn-info">{% translate "Previous step" %}</button>
-            {% else %}
-                <span></span>
-            {% endif %}
-        </div>
-    </fieldset></form>
+  <form method="post"><fieldset>
+    <legend>
+      <span>
+        {% translate "New event" %}
+        <small class="text-muted">{% blocktranslate with total=wizard.steps.count current=wizard.steps.step1 trimmed %}
+          Step {{ current }} of {{ total }}
+        {% endblocktranslate %}</small>
+      </span>
+    </legend>
+    {% block wizard_content %}{% endblock wizard_content %}
+    {% csrf_token %}
+    {{ wizard.management_form }}
+    {% block wizard_form %}
+      {{ wizard.form }}
+    {% endblock %}
+    <div class="submit-group flex-row-reverse">
+      <button type="submit" class="btn btn-success btn-lg float-right flip ml-auto">{% translate "Next step" %}</button>
+      {% if wizard.steps.prev %}
+        <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}" class="btn btn-lg btn-info">{% translate "Previous step" %}</button>
+      {% else %}
+        <span></span>
+      {% endif %}
+    </div>
+  </fieldset></form>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/event/wizard/basics.html
+++ b/src/pretalx/orga/templates/orga/event/wizard/basics.html
@@ -4,5 +4,5 @@
 {% load static %}
 
 {% block scripts %}
-    {% compress js %}<script src="{% static "orga/js/event_wizard.js" %}" defer></script>{% endcompress %}
+  {% compress js %}<script src="{% static "orga/js/event_wizard.js" %}" defer></script>{% endcompress %}
 {% endblock scripts %}

--- a/src/pretalx/orga/templates/orga/event/wizard/copy.html
+++ b/src/pretalx/orga/templates/orga/event/wizard/copy.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block wizard_content %}
-    <div class="alert alert-info col-md-9 offset-md-3">
-        {% translate "You can copy settings from previous events here, such as mail settings, session types, and email templates. Please check those settings once the event has been created!" %}
-    </div>
+  <div class="alert alert-info col-md-9 offset-md-3">
+    {% translate "You can copy settings from previous events here, such as mail settings, session types, and email templates. Please check those settings once the event has been created!" %}
+  </div>
 {% endblock wizard_content %}

--- a/src/pretalx/orga/templates/orga/event/wizard/display.html
+++ b/src/pretalx/orga/templates/orga/event/wizard/display.html
@@ -5,18 +5,18 @@
 {% load static %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/headers-uncompressed.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/headers-uncompressed.css" %}" />
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "vendored/vanilla-picker/vanilla-picker.min.js" %}"></script>
-        <script defer src="{% static "orga/js/colorpicker.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "vendored/vanilla-picker/vanilla-picker.min.js" %}"></script>
+    <script defer src="{% static "orga/js/colorpicker.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block wizard_content %}
-    <div class="alert alert-info col-md-9 offset-md-3">
-        {% translate "Choose your inital customisations here – you can always change them later, or enhance them with custom CSS." %}
-    </div>
+  <div class="alert alert-info col-md-9 offset-md-3">
+    {% translate "Choose your inital customisations here – you can always change them later, or enhance them with custom CSS." %}
+  </div>
 {% endblock wizard_content %}

--- a/src/pretalx/orga/templates/orga/event_list.html
+++ b/src/pretalx/orga/templates/orga/event_list.html
@@ -8,54 +8,54 @@
 {% block extra_title %}{% translate "Dashboard" %} :: {% endblock extra_title %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "orga/css/dashboard.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "orga/css/dashboard.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block content %}
-    {% has_perm "orga.create_events" request.user request.user as can_create_event %}
+  {% has_perm "orga.create_events" request.user request.user as can_create_event %}
 
-    {% if current_orga_events or past_orga_events or can_create_event %}
-        <form class="mb-4 m-2">
-            <input type="text" name="q" class="form-control" value="{% if request.GET.q %}{{ request.GET.q }}{% endif %}" placeholder="{% translate "Search" %}">
-        </form>
-        {% if current_orga_events or can_create_event %}
-            <h2>{% translate "Your upcoming events" %}</h2>
-            <div class="dashboard-list">
-                {% for event in current_orga_events %}
-                    {% include "orga/includes/dashboard_block_event.html" %}
-                {% endfor %}
-                {% if can_create_event %}
-                    <a class="dashboard-block symbol" href="{% url "orga:event.create" %}">
-                        <i class="fa fa-plus-circle" title="{% translate "Create a new event" %}"></i>
-                    </a>
-                {% endif %}
-            </div>
+  {% if current_orga_events or past_orga_events or can_create_event %}
+    <form class="mb-4 m-2">
+      <input type="text" name="q" class="form-control" value="{% if request.GET.q %}{{ request.GET.q }}{% endif %}" placeholder="{% translate "Search" %}">
+    </form>
+    {% if current_orga_events or can_create_event %}
+      <h2>{% translate "Your upcoming events" %}</h2>
+      <div class="dashboard-list">
+        {% for event in current_orga_events %}
+          {% include "orga/includes/dashboard_block_event.html" %}
+        {% endfor %}
+        {% if can_create_event %}
+          <a class="dashboard-block symbol" href="{% url "orga:event.create" %}">
+            <i class="fa fa-plus-circle" title="{% translate "Create a new event" %}"></i>
+          </a>
         {% endif %}
-        {% if past_orga_events %}
-            <h2>{% translate "Your most recent events" %}</h2>
-            <div class="dashboard-list">
-                {% for event in past_orga_events %}
-                    {% include "orga/includes/dashboard_block_event.html" %}
-                {% endfor %}
-            </div>
+      </div>
+    {% endif %}
+    {% if past_orga_events %}
+      <h2>{% translate "Your most recent events" %}</h2>
+      <div class="dashboard-list">
+        {% for event in past_orga_events %}
+          {% include "orga/includes/dashboard_block_event.html" %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endif %}
+  {% if not hide_speaker_events and speaker_events %}
+    <div class="alert alert-info">
+      <div>
+        {% translate "You are currently in the organiser area of eventyay. To view your submitted proposals, please go directly to the event page:" %}
+        {% if speaker_events|length == 1 %}
+          <a href="{{ event.urls.user_submissions.full }}">{{ event.name }}</a>
+        {% else %}
+          <ul class="mb-0">
+            {% for event in speaker_events %}
+              <li><a href="{{ event.urls.user_submissions.full }}">{{ event.name }}</a></li>
+            {% endfor %}
+          </ul>
         {% endif %}
-    {% endif %}
-    {% if not hide_speaker_events and speaker_events %}
-        <div class="alert alert-info">
-            <div>
-                {% translate "You are currently in the organiser area of eventyay. To view your submitted proposals, please go directly to the event page:" %}
-                {% if speaker_events|length == 1 %}
-                    <a href="{{ event.urls.user_submissions.full }}">{{ event.name }}</a>
-                {% else %}
-                    <ul class="mb-0">
-                        {% for event in speaker_events %}
-                            <li><a href="{{ event.urls.user_submissions.full }}">{{ event.name }}</a></li>
-                        {% endfor %}
-                    </ul>
-                {% endif %}
-            </div>
-        </div>
-    {% endif %}
+      </div>
+    </div>
+  {% endif %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/includes/base_form.html
+++ b/src/pretalx/orga/templates/orga/includes/base_form.html
@@ -1,5 +1,5 @@
 <form method="post" {% if form.is_multipart %}enctype="multipart/form-data"{% endif %}>
-    {% csrf_token %}
-    {{ form }}
-    {% include "orga/includes/submit_row.html" %}
+  {% csrf_token %}
+  {{ form }}
+  {% include "orga/includes/submit_row.html" %}
 </form>

--- a/src/pretalx/orga/templates/orga/includes/dashboard_block_event.html
+++ b/src/pretalx/orga/templates/orga/includes/dashboard_block_event.html
@@ -1,30 +1,30 @@
 {% load i18n %}
 <div class="dashboard-block-wrapper">
-    <a class="dashboard-block dashboard-block-extended" href="{{ event.orga_urls.base }}">
-        <h2 class="name">{{ event.name }}</h2>
-        <div class="dashboard-description">
-            <div class="date">{{ event.get_date_range_display }}</div>
-        </div>
-    </a>
-    <div class="dashboard-block-extension">
-        <a href="{{ event.orga_urls.submissions }}" class="dashboard-block-addon dashboard-block-addon-{% if event.submission_count %}info{% else %}secondary{% endif %}">
-            {% if event.submission_count %}
-                {{ event.submission_count }}
-                {% blocktranslate trimmed count count=event.submission_count %}
-                    proposal
-                {% plural %}
-                    proposals
-                {% endblocktranslate %}
-            {% else %}
-                {% translate "No proposals yet" %}
-            {% endif %}
-        </a>
-        <a href="{{ event.orga_urls.base }}" class="dashboard-block-addon dashboard-block-addon-{% if event.is_public %}success{% else %}secondary{% endif %}">
-            {% if event.is_public %}
-                <div class="state active">{% translate "live" %}</div>
-            {% else %}
-                <div class="state inactive">{% translate "Not public" %}</div>
-            {% endif %}
-        </a>
+  <a class="dashboard-block dashboard-block-extended" href="{{ event.orga_urls.base }}">
+    <h2 class="name">{{ event.name }}</h2>
+    <div class="dashboard-description">
+      <div class="date">{{ event.get_date_range_display }}</div>
     </div>
+  </a>
+  <div class="dashboard-block-extension">
+    <a href="{{ event.orga_urls.submissions }}" class="dashboard-block-addon dashboard-block-addon-{% if event.submission_count %}info{% else %}secondary{% endif %}">
+      {% if event.submission_count %}
+        {{ event.submission_count }}
+        {% blocktranslate trimmed count count=event.submission_count %}
+          proposal
+        {% plural %}
+          proposals
+        {% endblocktranslate %}
+      {% else %}
+        {% translate "No proposals yet" %}
+      {% endif %}
+    </a>
+    <a href="{{ event.orga_urls.base }}" class="dashboard-block-addon dashboard-block-addon-{% if event.is_public %}success{% else %}secondary{% endif %}">
+      {% if event.is_public %}
+        <div class="state active">{% translate "live" %}</div>
+      {% else %}
+        <div class="state inactive">{% translate "Not public" %}</div>
+      {% endif %}
+    </a>
+  </div>
 </div>

--- a/src/pretalx/orga/templates/orga/includes/mail_template_role.html
+++ b/src/pretalx/orga/templates/orga/includes/mail_template_role.html
@@ -1,10 +1,10 @@
 {% load i18n %}
 {% if template.role == "submission.state.accepted" %}
-    <span class="badge color-success">{% translate "Accept email" %}</span>
+  <span class="badge color-success">{% translate "Accept email" %}</span>
 {% elif template.role == "submission.state.rejected" %}
-    <span class="badge color-danger">{% translate "Reject email" %}</span>
+  <span class="badge color-danger">{% translate "Reject email" %}</span>
 {% elif template.role == "schedule.new" %}
-    <span class="badge color-info">{% translate "Schedule update" %}</span>
+  <span class="badge color-info">{% translate "Schedule update" %}</span>
 {% elif template.role == "question.reminder" %}
-    <span class="badge color-info">{% translate "Unanswered questions reminder" %}</span>
+  <span class="badge color-info">{% translate "Unanswered questions reminder" %}</span>
 {% endif %}

--- a/src/pretalx/orga/templates/orga/includes/pagination.html
+++ b/src/pretalx/orga/templates/orga/includes/pagination.html
@@ -2,54 +2,54 @@
 {% load i18n %}
 
 {% if is_paginated or page_obj.paginator.count > 1 %}
-    <nav class="text-center">
-        <ul class="pagination justify-content-center mb-0">
-            {% if is_paginated %}
-                {% if page_obj.has_previous %}
-                    <li class="page-item">
-                        <a rel="prev" href="{% querystring page=page_obj.previous_page_number %}" class="page-link">
-                            <span>«</span>
-                        </a>
-                    </li>
-                {% endif %}
-                <li class="page-current page-item disabled">
-                    <a class="page-link">
-                        {% blocktranslate trimmed with page=page_obj.number of=page_obj.paginator.num_pages count=page_obj.paginator.count %}
-                            Page {{ page }} of {{ of }} ({{ count }} elements)
-                        {% endblocktranslate %}
-                    </a>
-                </li>
-                {% if page_obj.has_next %}
-                    <li class="page-item">
-                        <a rel="next" href="{% querystring page=page_obj.next_page_number %}" class="page-link">
-                            <span>»</span>
-                        </a>
-                    </li>
-                {% endif %}
-            {% else %}
-                {% if page_obj.paginator.count > 1 %}
-                    <li class="page-current page-item">
-                        <a class="page-link">
-                            {% blocktranslate trimmed with count=page_obj.paginator.count|intcomma context "Shown at the bottom of lists, always > 1 elements." %}
-                                {{ count }} elements
-                            {% endblocktranslate %}
-                        </a>
-                    </li>
-                {% endif %}
-            {% endif %}
-        </ul>
-        {% if page_size and page_obj.paginator.count > 25 %}
-            <div>
-                <small>
-                    {% trans "Show per page:" context "Allows users to select how many lines/elements are shown in lists." %}
-                </small>
-                {% for pagination_size in pagination_sizes %}
-
-                    {% include "orga/includes/pagination_size.html" %}
-
-                    {% if not forloop.last %}|{% endif %}
-                {% endfor %}
-            </div>
+  <nav class="text-center">
+    <ul class="pagination justify-content-center mb-0">
+      {% if is_paginated %}
+        {% if page_obj.has_previous %}
+          <li class="page-item">
+            <a rel="prev" href="{% querystring page=page_obj.previous_page_number %}" class="page-link">
+              <span>«</span>
+            </a>
+          </li>
         {% endif %}
-    </nav>
+        <li class="page-current page-item disabled">
+          <a class="page-link">
+            {% blocktranslate trimmed with page=page_obj.number of=page_obj.paginator.num_pages count=page_obj.paginator.count %}
+              Page {{ page }} of {{ of }} ({{ count }} elements)
+            {% endblocktranslate %}
+          </a>
+        </li>
+        {% if page_obj.has_next %}
+          <li class="page-item">
+            <a rel="next" href="{% querystring page=page_obj.next_page_number %}" class="page-link">
+              <span>»</span>
+            </a>
+          </li>
+        {% endif %}
+      {% else %}
+        {% if page_obj.paginator.count > 1 %}
+          <li class="page-current page-item">
+            <a class="page-link">
+              {% blocktranslate trimmed with count=page_obj.paginator.count|intcomma context "Shown at the bottom of lists, always > 1 elements." %}
+                {{ count }} elements
+              {% endblocktranslate %}
+            </a>
+          </li>
+        {% endif %}
+      {% endif %}
+    </ul>
+    {% if page_size and page_obj.paginator.count > 25 %}
+      <div>
+        <small>
+          {% trans "Show per page:" context "Allows users to select how many lines/elements are shown in lists." %}
+        </small>
+        {% for pagination_size in pagination_sizes %}
+
+          {% include "orga/includes/pagination_size.html" %}
+
+          {% if not forloop.last %}|{% endif %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  </nav>
 {% endif %}

--- a/src/pretalx/orga/templates/orga/includes/pagination_size.html
+++ b/src/pretalx/orga/templates/orga/includes/pagination_size.html
@@ -2,9 +2,9 @@
 
 <a href="{% querystring page_size=pagination_size page="1" %}"
    {% if page_size == pagination_size %}class="font-weight-bold"{% endif %}>
-    {% if pagination_size == 100_000 %}
-        {{ phrases.base.all_choices }}
-    {% else %}
-        {{ pagination_size }}
-    {% endif %}
+  {% if pagination_size == 100_000 %}
+    {{ phrases.base.all_choices }}
+  {% else %}
+    {{ pagination_size }}
+  {% endif %}
 </a>

--- a/src/pretalx/orga/templates/orga/includes/review_filter_form.html
+++ b/src/pretalx/orga/templates/orga/includes/review_filter_form.html
@@ -4,10 +4,10 @@
 {% block form_attrs %} id="review-filter-form"{% endblock form_attrs %}
 
 {% block extra_filter_fields %}
-    {% if max_review_count and max_review_count > 1 %}
-        <div id="range-wrapper">
-            <input type="text" id="review-count" name="review-count" data-max="{{ max_review_count }}"/>
-            <label for="review-count" class="pt-0">{% translate "Number of reviews" %}</label>
-        </div>
-    {% endif %}
+  {% if max_review_count and max_review_count > 1 %}
+    <div id="range-wrapper">
+      <input type="text" id="review-count" name="review-count" data-max="{{ max_review_count }}"/>
+      <label for="review-count" class="pt-0">{% translate "Number of reviews" %}</label>
+    </div>
+  {% endif %}
 {% endblock extra_filter_fields %}

--- a/src/pretalx/orga/templates/orga/includes/sidebar_nav.html
+++ b/src/pretalx/orga/templates/orga/includes/sidebar_nav.html
@@ -1,34 +1,34 @@
 {% load static %}
 {% if nav_element.children %}
-    <div class="nav-fold">
-        <span class="has-children">
-            <a class="nav-link nav-link-inner" href="{{ nav_element.url }}">
-                {% if nav_element.icon and "." in nav_element.icon %}
-                    <img loading="lazy" src="{% static nav_element.icon %}" class="fa-img" alt="{{ nav_element.label }}">
-                {% elif nav_element.icon %}
-                    <i class="fa fa-{{ nav_element.icon }}"></i>
-                {% endif %}
-                <span class="sidebar-text">{{ nav_element.label }}</span>
-            </a>
-            <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseSidebar{{ forloop.counter }}" aria-controls="collapse{{ forloop.counter }}">
-                <i class="fa fa-angle-down"></i>
-            </a>
-        </span>
-        <div class="collapse in{% if nav_element.active %} show{% endif %}" aria-expand="true" id="collapseSidebar{{ forloop.counter }}">
-            {% for child in nav_element.children %}
-                <a href="{{ child.url }}" class="nav-link nav-link-second-level{% if child.active %} active{% endif %}">
-                    <span>{{ child.label }}</span>
-                </a>
-            {% endfor %}
-        </div>
-    </div>
-{% else %}
-    <a class="nav-link {% if nav_element.active %} active{% endif %}" href="{{ nav_element.url }}">
+  <div class="nav-fold">
+    <span class="has-children">
+      <a class="nav-link nav-link-inner" href="{{ nav_element.url }}">
         {% if nav_element.icon and "." in nav_element.icon %}
-            <img loading="lazy" src="{% static nav_element.icon %}" class="fa-img" alt="{{ nav_element.label }}">
+          <img loading="lazy" src="{% static nav_element.icon %}" class="fa-img" alt="{{ nav_element.label }}">
         {% elif nav_element.icon %}
-            <i class="fa fa-{{ nav_element.icon }}"></i>
+          <i class="fa fa-{{ nav_element.icon }}"></i>
         {% endif %}
         <span class="sidebar-text">{{ nav_element.label }}</span>
-    </a>
+      </a>
+      <a class="arrow nav-link" data-toggle="collapse" data-target="#collapseSidebar{{ forloop.counter }}" aria-controls="collapse{{ forloop.counter }}">
+        <i class="fa fa-angle-down"></i>
+      </a>
+    </span>
+    <div class="collapse in{% if nav_element.active %} show{% endif %}" aria-expand="true" id="collapseSidebar{{ forloop.counter }}">
+      {% for child in nav_element.children %}
+        <a href="{{ child.url }}" class="nav-link nav-link-second-level{% if child.active %} active{% endif %}">
+          <span>{{ child.label }}</span>
+        </a>
+      {% endfor %}
+    </div>
+  </div>
+{% else %}
+  <a class="nav-link {% if nav_element.active %} active{% endif %}" href="{{ nav_element.url }}">
+    {% if nav_element.icon and "." in nav_element.icon %}
+      <img loading="lazy" src="{% static nav_element.icon %}" class="fa-img" alt="{{ nav_element.label }}">
+    {% elif nav_element.icon %}
+      <i class="fa fa-{{ nav_element.icon }}"></i>
+    {% endif %}
+    <span class="sidebar-text">{{ nav_element.label }}</span>
+  </a>
 {% endif %}

--- a/src/pretalx/orga/templates/orga/includes/submission_filter_form.html
+++ b/src/pretalx/orga/templates/orga/includes/submission_filter_form.html
@@ -1,35 +1,35 @@
 {% load i18n %}
 
 <div class="submit-group search-submit-group">
-    <form class="search-form"{% block form_attrs %}{% endblock %} role="search">
-        {{ filter_form.q.as_field_group }}
-        {% if show_submission_types and filter_form.submission_type %}{{ filter_form.submission_type.as_field_group }}{% endif %}
-        <div class="d-flex flex-column form-group">
-            {{ filter_form.state.as_field_group }}
-            <div id="pending" class="ml-1 d-none">{{ filter_form.pending_state__isnull.as_field_group }}</div>
-        </div>
-        {% if filter_form.track %}{{ filter_form.track.as_field_group }}{% endif %}
-        {% if filter_form.tags %}{{ filter_form.tags.as_field_group }}{% endif %}
-        {% if filter_form.content_locale %}{{ filter_form.content_locale.as_field_group }}{% endif %}
-        {% block extra_filter_fields %}{% endblock extra_filter_fields %}
+  <form class="search-form"{% block form_attrs %}{% endblock %} role="search">
+    {{ filter_form.q.as_field_group }}
+    {% if show_submission_types and filter_form.submission_type %}{{ filter_form.submission_type.as_field_group }}{% endif %}
+    <div class="d-flex flex-column form-group">
+      {{ filter_form.state.as_field_group }}
+      <div id="pending" class="ml-1 d-none">{{ filter_form.pending_state__isnull.as_field_group }}</div>
+    </div>
+    {% if filter_form.track %}{{ filter_form.track.as_field_group }}{% endif %}
+    {% if filter_form.tags %}{{ filter_form.tags.as_field_group }}{% endif %}
+    {% if filter_form.content_locale %}{{ filter_form.content_locale.as_field_group }}{% endif %}
+    {% block extra_filter_fields %}{% endblock extra_filter_fields %}
         {# These fields are hidden, but included to keep question search intact #}
-        {% if request.GET.question %} <input type="hidden" name="question" value="{{ request.GET.question }}"> {% endif %}
-        {% if request.GET.answer__options %} <input type="hidden" name="answer__options" value="{{ request.GET.answer__options }}"> {% endif %}
-        {% if request.GET.answer %} <input type="hidden" name="answer" value="{{ request.GET.answer }}"> {% endif %}
-        {% if request.GET.unanswered %} <input type="hidden" name="unanswered" value="{{ request.GET.unanswered }}"> {% endif %}
+    {% if request.GET.question %} <input type="hidden" name="question" value="{{ request.GET.question }}"> {% endif %}
+    {% if request.GET.answer__options %} <input type="hidden" name="answer__options" value="{{ request.GET.answer__options }}"> {% endif %}
+    {% if request.GET.answer %} <input type="hidden" name="answer" value="{{ request.GET.answer }}"> {% endif %}
+    {% if request.GET.unanswered %} <input type="hidden" name="unanswered" value="{{ request.GET.unanswered }}"> {% endif %}
 
-        <button class="btn btn-success" type="submit">{% translate "Search" %}</button>
-    </form>
-    {% if filter_form.is_valid and filter_form.cleaned_data.question %}
-        <p class="text-muted ml-2">
-            <span class="fa fa-filter"></span>
-            {% blocktranslate trimmed with question=filter_form.cleaned_data.question.question %}
-                List filtered by answers to question “{{ question }}”.
-            {% endblocktranslate %}
-            <a href="{% querystring question="" answer="" answer__options="" %}" class="text-muted">
-                <span class="fa fa-times"></span>
-                {% translate "Remove filter" %}
-            </a>
-        </p>
-    {% endif %}
+    <button class="btn btn-success" type="submit">{% translate "Search" %}</button>
+  </form>
+  {% if filter_form.is_valid and filter_form.cleaned_data.question %}
+    <p class="text-muted ml-2">
+      <span class="fa fa-filter"></span>
+      {% blocktranslate trimmed with question=filter_form.cleaned_data.question.question %}
+        List filtered by answers to question “{{ question }}”.
+      {% endblocktranslate %}
+      <a href="{% querystring question="" answer="" answer__options="" %}" class="text-muted">
+        <span class="fa fa-times"></span>
+        {% translate "Remove filter" %}
+      </a>
+    </p>
+  {% endif %}
 </div>

--- a/src/pretalx/orga/templates/orga/includes/submit_row.html
+++ b/src/pretalx/orga/templates/orga/includes/submit_row.html
@@ -1,19 +1,19 @@
 {% load i18n %}
 
 <div class="submit-group panel">
-    <span></span>
-    <span>
-        <button
-            type="submit" class="btn btn-success btn-lg"
-            {% if submit_value %}value="{{ submit_value }}"{% endif %}
-            {% if submit_name %}name="{{ submit_name }}"{% endif %}
-        >
-            <i class="fa fa-check"></i>
-            {% if submit_label %}
-                {{ submit_label }}
-            {% else %}
-                {{ phrases.base.save }}
-            {% endif %}
-        </button>
-    </span>
+  <span></span>
+  <span>
+    <button
+      type="submit" class="btn btn-success btn-lg"
+      {% if submit_value %}value="{{ submit_value }}"{% endif %}
+      {% if submit_name %}name="{{ submit_name }}"{% endif %}
+    >
+      <i class="fa fa-check"></i>
+      {% if submit_label %}
+        {{ submit_label }}
+      {% else %}
+        {{ phrases.base.save }}
+      {% endif %}
+    </button>
+  </span>
 </div>

--- a/src/pretalx/orga/templates/orga/invitation.html
+++ b/src/pretalx/orga/templates/orga/invitation.html
@@ -3,48 +3,48 @@
 
 {% block extra_title %}{% translate "Invitation" %} :: {{ invitation.team.name }} :: {% endblock extra_title %}
 {% block content %}
-    <h2 class="col-md-6 ml-auto mr-auto">
-        {% blocktranslate with organiser=invitation.team.organiser.name name=invitation.team.name trimmed %}
-            Invitation to the {{ organiser }} team “{{ name }}”
+  <h2 class="col-md-6 ml-auto mr-auto">
+    {% blocktranslate with organiser=invitation.team.organiser.name name=invitation.team.name trimmed %}
+      Invitation to the {{ organiser }} team “{{ name }}”
+    {% endblocktranslate %}
+  </h2>
+
+  {% if request.user.is_anonymous %}
+    <div class="col-md-6 ml-auto mr-auto">
+      <p>
+        {% blocktranslate trimmed with name=invitation.team.name link=request.path %}
+          You have been invited to join the organiser team {{ name }}.
         {% endblocktranslate %}
-    </h2>
+      </p>
+      <p>
+        {% blocktranslate trimmed with domain=request.get_host %}
+          If you already have an account – either as a speaker or an organiser – at <a href="{{ domain }}">{{ domain }}</a>, please log in now. Otherwise, create a new account to join the team!
+        {% endblocktranslate %}
+      </p>
+    </div>
+    <hr>
 
-    {% if request.user.is_anonymous %}
-        <div class="col-md-6 ml-auto mr-auto">
-            <p>
-                {% blocktranslate trimmed with name=invitation.team.name link=request.path %}
-                    You have been invited to join the organiser team {{ name }}.
-                {% endblocktranslate %}
-            </p>
-            <p>
-                {% blocktranslate trimmed with domain=request.get_host %}
-                    If you already have an account – either as a speaker or an organiser – at <a href="{{ domain }}">{{ domain }}</a>, please log in now. Otherwise, create a new account to join the team!
-                {% endblocktranslate %}
-            </p>
-        </div>
-        <hr>
+    {% include "common/auth.html" with next_url=request.get_full_path %}
 
-        {% include "common/auth.html" with next_url=request.get_full_path %}
-
-    {% else %}
-        <form method="post" class="col-md-6 ml-auto mr-auto">
-            {% csrf_token %}
-            <p></p>
-            <p>
-                {% blocktranslate trimmed with name=invitation.team.name %}
-                    You have been invited to join the organiser team {{ name }}.
-                {% endblocktranslate %}
-                {% blocktranslate trimmed with link=request.path %}
-                    To accept the invitation with the account you’re currently active, please use the button below. If you want to accept the invitation with a different account, you can <a href="/orga/logout/?next={{ link }}">log out</a> and log in with the other account.
-                    </p><p>
-                        If you believe to have received this invitation by mistake, please contact the organiser directly.
-                {% endblocktranslate %}
-            </p>
-            <p></p>
-            <button type="submit" class="btn btn-block btn-success font-weight-bold">
-                {% translate "Join the team!" %}
-            </button>
-        </form>
-    {% endif %}
+  {% else %}
+    <form method="post" class="col-md-6 ml-auto mr-auto">
+      {% csrf_token %}
+      <p></p>
+      <p>
+        {% blocktranslate trimmed with name=invitation.team.name %}
+          You have been invited to join the organiser team {{ name }}.
+        {% endblocktranslate %}
+        {% blocktranslate trimmed with link=request.path %}
+          To accept the invitation with the account you’re currently active, please use the button below. If you want to accept the invitation with a different account, you can <a href="/orga/logout/?next={{ link }}">log out</a> and log in with the other account.
+          </p><p>
+            If you believe to have received this invitation by mistake, please contact the organiser directly.
+        {% endblocktranslate %}
+      </p>
+      <p></p>
+      <button type="submit" class="btn btn-block btn-success font-weight-bold">
+        {% translate "Join the team!" %}
+      </button>
+    </form>
+  {% endif %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/mails/_mail_editor.html
+++ b/src/pretalx/orga/templates/orga/mails/_mail_editor.html
@@ -6,128 +6,128 @@
 {% block extra_title %}{% translate "Email editor" %} :: {% endblock extra_title %}
 
 {% block mail_content %}
-    <script defer src="{% static "common/js/tabs.js" %}"></script>
-    <form method="post" class="form-with-placeholder">
-        {% csrf_token %}
-        <div class="mb-2">
-            <h2 class="d-inline">
-                {% block email_editor_title %}
-                    {% translate "Email editor" %}
-                {% endblock email_editor_title %}
-            </h2>
-            <h3 class="d-inline ml-1">
-                <small class="text-muted">
-                    {% block email_editor_title_detail %}{% endblock email_editor_title_detail %}
-                </small>
-            </h3>
-            {% include "common/forms/errors.html" %}
-        </div>
-        <div id="placeholder-neighbour">
-            <div role="tablist">
-                <input role="tab" type="radio" id="tab-recipients" name="tablist" aria-controls="tabpanel-recipients" aria-selected="true" checked>
-                <label for="tab-recipients">{% translate "Recipients" %}</label>
+  <script defer src="{% static "common/js/tabs.js" %}"></script>
+  <form method="post" class="form-with-placeholder">
+    {% csrf_token %}
+    <div class="mb-2">
+      <h2 class="d-inline">
+        {% block email_editor_title %}
+          {% translate "Email editor" %}
+        {% endblock email_editor_title %}
+      </h2>
+      <h3 class="d-inline ml-1">
+        <small class="text-muted">
+          {% block email_editor_title_detail %}{% endblock email_editor_title_detail %}
+        </small>
+      </h3>
+      {% include "common/forms/errors.html" %}
+    </div>
+    <div id="placeholder-neighbour">
+      <div role="tablist">
+        <input role="tab" type="radio" id="tab-recipients" name="tablist" aria-controls="tabpanel-recipients" aria-selected="true" checked>
+        <label for="tab-recipients">{% translate "Recipients" %}</label>
 
-                <input role="tab" type="radio" id="tab-content" name="tablist" aria-controls="tabpanel-content" aria-selected="false">
-                <label for="tab-content">{% translate "Content" %}</label>
+        <input role="tab" type="radio" id="tab-content" name="tablist" aria-controls="tabpanel-content" aria-selected="false">
+        <label for="tab-content">{% translate "Content" %}</label>
+      </div>
+
+      <section id="tabpanel-recipients" role="tabpanel" aria-labelledby="tab-recipients" tabindex="0" aria-hidden="false">
+        <fieldset>
+          {% block recipient_form %}{% endblock recipient_form %}
+          <details class="card">
+            <summary class="card-header">{% translate "Advanced settings" %}</summary>
+            <div class="card-body">
+              {% block advanced_recipient_form %}
+                {{ form.reply_to.as_field_group }}
+                {{ form.bcc.as_field_group }}
+              {% endblock advanced_recipient_form %}
             </div>
+          </details>
+        </fieldset>
+      </section>
 
-            <section id="tabpanel-recipients" role="tabpanel" aria-labelledby="tab-recipients" tabindex="0" aria-hidden="false">
-                <fieldset>
-                    {% block recipient_form %}{% endblock recipient_form %}
-                    <details class="card">
-                        <summary class="card-header">{% translate "Advanced settings" %}</summary>
-                        <div class="card-body">
-                            {% block advanced_recipient_form %}
-                                {{ form.reply_to.as_field_group }}
-                                {{ form.bcc.as_field_group }}
-                            {% endblock advanced_recipient_form %}
-                        </div>
-                    </details>
-                </fieldset>
-            </section>
+      <section id="tabpanel-content" role="tabpanel" aria-labelledby="tab-content" aria-hidden="true">
+        <fieldset>
+          {{ form.subject.as_field_group }}
+          {{ form.text.as_field_group }}
+        </fieldset>
+      </section>
+      <div class="col col-md-2" id="placeholder-column">
+        <legend>{% translate "Placeholders" %}</legend>
 
-            <section id="tabpanel-content" role="tabpanel" aria-labelledby="tab-content" aria-hidden="true">
-                <fieldset>
-                    {{ form.subject.as_field_group }}
-                    {{ form.text.as_field_group }}
-                </fieldset>
-            </section>
-            <div class="col col-md-2" id="placeholder-column">
-                <legend>{% translate "Placeholders" %}</legend>
+        {% include "orga/mails/_placeholder_group.html" with placeholders=form.grouped_placeholders.submission tag="submission" %}
+        {% include "orga/mails/_placeholder_group.html" with placeholders=form.grouped_placeholders.slot tag="slot" %}
+        {% include "orga/mails/_placeholder_group.html" with placeholders=form.grouped_placeholders.user tag="user" %}
+        {% include "orga/mails/_placeholder_group.html" with placeholders=form.grouped_placeholders.event tag="event" %}
+        {% include "orga/mails/_placeholder_group.html" with placeholders=form.grouped_placeholders.other tag="other" %}
+      </div>
+    </div>
 
-                {% include "orga/mails/_placeholder_group.html" with placeholders=form.grouped_placeholders.submission tag="submission" %}
-                {% include "orga/mails/_placeholder_group.html" with placeholders=form.grouped_placeholders.slot tag="slot" %}
-                {% include "orga/mails/_placeholder_group.html" with placeholders=form.grouped_placeholders.user tag="user" %}
-                {% include "orga/mails/_placeholder_group.html" with placeholders=form.grouped_placeholders.event tag="event" %}
-                {% include "orga/mails/_placeholder_group.html" with placeholders=form.grouped_placeholders.other tag="other" %}
-            </div>
-        </div>
-
-        {% block email_editor_preview %}
-            {% if request.method == "POST" %}
-                <fieldset class="mt-4">
-                    <legend>{% translate "Email preview" %}</legend>
-                    <div class="alert alert-info">
-                        {% blocktranslate trimmed with count=mail_count %}
-                            Roughly {{ count }} emails will be generated.
-                        {% endblocktranslate %}
-                    </div>
-                    {% if form.warnings %}
-                        <div class="alert alert-warning">
-                            <span>
-                                {% blocktranslate trimmed %}
-                                    You have placeholders in your email that are either not valid or not valid for every email!
-                                {% endblocktranslate %}
-                                <ul>
+    {% block email_editor_preview %}
+      {% if request.method == "POST" %}
+        <fieldset class="mt-4">
+          <legend>{% translate "Email preview" %}</legend>
+          <div class="alert alert-info">
+            {% blocktranslate trimmed with count=mail_count %}
+              Roughly {{ count }} emails will be generated.
+            {% endblocktranslate %}
+          </div>
+          {% if form.warnings %}
+            <div class="alert alert-warning">
+              <span>
+                {% blocktranslate trimmed %}
+                  You have placeholders in your email that are either not valid or not valid for every email!
+                {% endblocktranslate %}
+                <ul>
                                     {# &#123; is the HTML entity for {, which would break django template syntax #}
-                                    {% for w in form.warnings %}<li>&#123;{{ w }}}</li>{% endfor %}
-                                </ul>
-                                {% blocktranslate trimmed %}
-                                    Emails where placeholders are invalid will <b>not</b> be created!
-                                    For example, if you are using {session_room}, but some proposals don’t have a room yet, only emails for proposals with a scheduled room will be created.
-                                {% endblocktranslate %}
-                            </span>
-                        </div>
-                    {% endif %}
-                    <div class="tab-pane mail-preview-group">
-                        {% for locale, out in output.items %}
-                            <div lang="{{ locale }}" class="mail-preview">
-                                <strong>{{ out.subject|safe }}</strong>
-                                <br>
-                                <br>
-                                {{ out.html|safe }}
-                            </div>
-                        {% endfor %}
-                    </div>
-                </fieldset>
-            {% endif %}
-        {% endblock email_editor_preview %}
-
-        {% block skip_queue %}
-            {% if form.skip_queue and request.method == "POST" %}
-                <hr />
-                {{ form.skip_queue.as_field_group }}
-            {% endif %}
-        {% endblock skip_queue %}
-
-        {% block email_editor_actions %}
-            <div class="submit-group mt-3">
-                <span></span>
-                <span>
-                    <button type="submit" class="btn btn-lg btn-outline-info btn-save mr-2" name="action" value="preview">
-                        {% translate "Preview email" %}
-                    </button>
-                    {% if request.method == "POST" %}
-                        <button type="submit" class="btn btn-lg btn-success">
-                            {% block send_button_label %}
-                                {% translate "Send to outbox" %}
-                            {% endblock send_button_label %}
-                        </button>
-                    {% endif %}
-                </span>
+                  {% for w in form.warnings %}<li>&#123;{{ w }}}</li>{% endfor %}
+                </ul>
+                {% blocktranslate trimmed %}
+                  Emails where placeholders are invalid will <b>not</b> be created!
+                  For example, if you are using {session_room}, but some proposals don’t have a room yet, only emails for proposals with a scheduled room will be created.
+                {% endblocktranslate %}
+              </span>
             </div>
-        {% endblock email_editor_actions %}
-    </form>
+          {% endif %}
+          <div class="tab-pane mail-preview-group">
+            {% for locale, out in output.items %}
+              <div lang="{{ locale }}" class="mail-preview">
+                <strong>{{ out.subject|safe }}</strong>
+                <br>
+                <br>
+                {{ out.html|safe }}
+              </div>
+            {% endfor %}
+          </div>
+        </fieldset>
+      {% endif %}
+    {% endblock email_editor_preview %}
 
-    <script src="{% static "orga/js/placeholder.js" %}" defer></script>
+    {% block skip_queue %}
+      {% if form.skip_queue and request.method == "POST" %}
+        <hr />
+        {{ form.skip_queue.as_field_group }}
+      {% endif %}
+    {% endblock skip_queue %}
+
+    {% block email_editor_actions %}
+      <div class="submit-group mt-3">
+        <span></span>
+        <span>
+          <button type="submit" class="btn btn-lg btn-outline-info btn-save mr-2" name="action" value="preview">
+            {% translate "Preview email" %}
+          </button>
+          {% if request.method == "POST" %}
+            <button type="submit" class="btn btn-lg btn-success">
+              {% block send_button_label %}
+                {% translate "Send to outbox" %}
+              {% endblock send_button_label %}
+            </button>
+          {% endif %}
+        </span>
+      </div>
+    {% endblock email_editor_actions %}
+  </form>
+
+  <script src="{% static "orga/js/placeholder.js" %}" defer></script>
 {% endblock mail_content %}

--- a/src/pretalx/orga/templates/orga/mails/base.html
+++ b/src/pretalx/orga/templates/orga/mails/base.html
@@ -1,5 +1,5 @@
 {% extends "orga/base.html" %}
 
 {% block content %}
-    {% block mail_content %}{% endblock mail_content %}
+  {% block mail_content %}{% endblock mail_content %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/mails/compose_reviewer_mail_form.html
+++ b/src/pretalx/orga/templates/orga/mails/compose_reviewer_mail_form.html
@@ -3,21 +3,21 @@
 {% load i18n %}
 
 {% block email_editor_title_detail %}
-    {% translate "Reviewers and team members" %}
+  {% translate "Reviewers and team members" %}
 {% endblock email_editor_title_detail %}
 
 {% block skip_queue %}
-    <div class="alert alert-danger mt-3" role="alert">
-        {% blocktranslate trimmed %}
-            Emails to reviewers and other team members are always sent out directly,
-            and are not placed in the outbox first.
-            They also do not show up in the list of sent mails.
-        {% endblocktranslate %}
-    </div>
+  <div class="alert alert-danger mt-3" role="alert">
+    {% blocktranslate trimmed %}
+      Emails to reviewers and other team members are always sent out directly,
+      and are not placed in the outbox first.
+      They also do not show up in the list of sent mails.
+    {% endblocktranslate %}
+  </div>
 {% endblock skip_queue %}
 
 {% block recipient_form %}
-    {{ form.recipients.as_field_group }}
+  {{ form.recipients.as_field_group }}
 {% endblock recipient_form %}
 
 {% block send_button_label %}{{ phrases.base.send }}{% endblock send_button_label %}

--- a/src/pretalx/orga/templates/orga/mails/outbox_form.html
+++ b/src/pretalx/orga/templates/orga/mails/outbox_form.html
@@ -5,99 +5,99 @@
 {% block extra_title %}{% translate "Mail Editor" %} :: {% endblock extra_title %}
 
 {% block mail_content %}
-    {% if form.instance.sent %}
-        <div class="alert alert-info">
-            {% blocktranslate trimmed with timestamp=form.instance.sent %}
-                This email was sent on {{ timestamp }}.
-            {% endblocktranslate %}
+  {% if form.instance.sent %}
+    <div class="alert alert-info">
+      {% blocktranslate trimmed with timestamp=form.instance.sent %}
+        This email was sent on {{ timestamp }}.
+      {% endblocktranslate %}
+    </div>
+  {% endif %}
+  <form method="post">
+    {% csrf_token %}
+    <h2>{% translate "Mail Editor" %}</h2>
+
+    {% if not form.read_only %}
+      {{ form }}
+    {% else %}
+      <div class="d-flex flex-column">
+        <div class="row form-group">
+          <div class="col col-md-3 flip text-right font-weight-bold">
+            <div class="font-weight-bold">To</div>
+          </div>
+          <div class="col col-md-9">{{ form.instance.to|default:"-" }}</div>
         </div>
-    {% endif %}
-    <form method="post">
-        {% csrf_token %}
-        <h2>{% translate "Mail Editor" %}</h2>
 
-        {% if not form.read_only %}
-            {{ form }}
-        {% else %}
-            <div class="d-flex flex-column">
-                <div class="row form-group">
-                    <div class="col col-md-3 flip text-right font-weight-bold">
-                        <div class="font-weight-bold">To</div>
-                    </div>
-                    <div class="col col-md-9">{{ form.instance.to|default:"-" }}</div>
-                </div>
-
-                {% if form.to_users %}
-                    <div class="row form-group">
-                        <div class="col col-md-3 flip text-right font-weight-bold">
-                            <div class="font-weight-bold">To Users</div>
-                        </div>
-                        <div class="col col-md-9">
-                            {% for user in form.instance.to_users.all %}
-                                {% if user in request.event.submitters %}
-                                    <a href="{% url "orga:speakers.view" event=request.event.slug code=user.code %}">{{ user }}</a>
-                                {% else %}
-                                    {{ user }}{% endif %}{% if not forloop.last %},
-                                    {% endif %}
-                            {% endfor %}
-                        </div>
-                    </div>
-                {% endif %}
-
-                <div class="row form-group">
-                    <div class="col col-md-3 flip text-right font-weight-bold">
-                        <div class="font-weight-bold">Reply-To</div>
-                    </div>
-                    <div class="col col-md-9">{{ form.instance.reply_to|default:"-" }}</div>
-                </div>
-
-                <div class="row form-group">
-                    <div class="col col-md-3 flip text-right font-weight-bold">
-                        <div class="font-weight-bold">CC</div>
-                    </div>
-                    <div class="col col-md-9">{{ form.instance.cc|default:"-" }}</div>
-                </div>
-
-                <div class="row form-group">
-                    <div class="col col-md-3 flip text-right font-weight-bold">
-                        <div class="font-weight-bold">BCC</div>
-                    </div>
-                    <div class="col col-md-9">{{ form.instance.bcc|default:"-" }}</div>
-                </div>
-
-                <div class="row form-group">
-                    <div class="col col-md-3 flip text-right font-weight-bold">
-                        <div class="font-weight-bold">Subject</div>
-                    </div>
-                    <div class="col col-md-9">{{ form.instance.subject }}</div>
-                </div>
-
-                <div class="row form-group">
-                    <div class="col col-md-3 flip text-right font-weight-bold">
-                        <div class="font-weight-bold">Text</div>
-                    </div>
-                    <div class="col col-md-9">{{ form.instance.text|rich_text }}</div>
-                </div>
+        {% if form.to_users %}
+          <div class="row form-group">
+            <div class="col col-md-3 flip text-right font-weight-bold">
+              <div class="font-weight-bold">To Users</div>
             </div>
+            <div class="col col-md-9">
+              {% for user in form.instance.to_users.all %}
+                {% if user in request.event.submitters %}
+                  <a href="{% url "orga:speakers.view" event=request.event.slug code=user.code %}">{{ user }}</a>
+                {% else %}
+                  {{ user }}{% endif %}{% if not forloop.last %},
+                  {% endif %}
+              {% endfor %}
+            </div>
+          </div>
         {% endif %}
 
-        <div class="submit-group">
-            {% if action == "edit" %}
-                <a class="btn btn-lg btn-danger mr-1" href={{ form.instance.urls.delete }}>{% translate "Discard" %}</a>
-                <a class="btn btn-lg btn-outline-danger flip mr-auto" href="{{ form.instance.urls.delete }}?all">{% translate "Discard all from this template" %}</a>
-                <span></span>
-                <button type="submit" class="btn btn-lg btn-success mr-1" name="form" value="save">
-                    {{ phrases.base.save }}
-                </button>
-                <button class="btn btn-lg btn-info" name="form" value="send">{% translate "Save and send" %}</button>
-            {% elif action == "view" %}
-                {% if form.instance.sent %}
-                    <a class="btn btn-lg btn-success ml-auto flip" href="{% if form.instance.template %}{{ request.event.orga_urls.compose_mails_sessions }}?template={{ form.instance.template.pk }}{% else %}{{ form.instance.urls.copy }}{% endif %}">
-                        {% translate "Copy to draft" %}
-                    </a>
-                {% endif %}
-            {% endif %}
+        <div class="row form-group">
+          <div class="col col-md-3 flip text-right font-weight-bold">
+            <div class="font-weight-bold">Reply-To</div>
+          </div>
+          <div class="col col-md-9">{{ form.instance.reply_to|default:"-" }}</div>
         </div>
-    </form>
+
+        <div class="row form-group">
+          <div class="col col-md-3 flip text-right font-weight-bold">
+            <div class="font-weight-bold">CC</div>
+          </div>
+          <div class="col col-md-9">{{ form.instance.cc|default:"-" }}</div>
+        </div>
+
+        <div class="row form-group">
+          <div class="col col-md-3 flip text-right font-weight-bold">
+            <div class="font-weight-bold">BCC</div>
+          </div>
+          <div class="col col-md-9">{{ form.instance.bcc|default:"-" }}</div>
+        </div>
+
+        <div class="row form-group">
+          <div class="col col-md-3 flip text-right font-weight-bold">
+            <div class="font-weight-bold">Subject</div>
+          </div>
+          <div class="col col-md-9">{{ form.instance.subject }}</div>
+        </div>
+
+        <div class="row form-group">
+          <div class="col col-md-3 flip text-right font-weight-bold">
+            <div class="font-weight-bold">Text</div>
+          </div>
+          <div class="col col-md-9">{{ form.instance.text|rich_text }}</div>
+        </div>
+      </div>
+    {% endif %}
+
+    <div class="submit-group">
+      {% if action == "edit" %}
+        <a class="btn btn-lg btn-danger mr-1" href={{ form.instance.urls.delete }}>{% translate "Discard" %}</a>
+        <a class="btn btn-lg btn-outline-danger flip mr-auto" href="{{ form.instance.urls.delete }}?all">{% translate "Discard all from this template" %}</a>
+        <span></span>
+        <button type="submit" class="btn btn-lg btn-success mr-1" name="form" value="save">
+          {{ phrases.base.save }}
+        </button>
+        <button class="btn btn-lg btn-info" name="form" value="send">{% translate "Save and send" %}</button>
+      {% elif action == "view" %}
+        {% if form.instance.sent %}
+          <a class="btn btn-lg btn-success ml-auto flip" href="{% if form.instance.template %}{{ request.event.orga_urls.compose_mails_sessions }}?template={{ form.instance.template.pk }}{% else %}{{ form.instance.urls.copy }}{% endif %}">
+            {% translate "Copy to draft" %}
+          </a>
+        {% endif %}
+      {% endif %}
+    </div>
+  </form>
 
 {% endblock mail_content %}

--- a/src/pretalx/orga/templates/orga/mails/outbox_list.html
+++ b/src/pretalx/orga/templates/orga/mails/outbox_list.html
@@ -3,114 +3,114 @@
 {% load i18n %}
 
 {% block mail_content %}
-    <h2>
-        <span>
-            {{ page_obj.paginator.count }}
-            {% blocktranslate trimmed count count=page_obj.paginator.count %}
-                pending mail
-            {% plural %}
-                pending mails
-            {% endblocktranslate %}
-        </span>
-    </h2>
-    <div class="submit-group">
-        <div>
-            {% include "common/includes/search_form.html" with omit_wrapper=True %}
-        </div>
-        <div class="d-flex flex-column align-items-end">
-            <div>
-                {% if is_paginated and page_obj.paginator.num_pages > 1 %}
-                    <a href="{{ request.event.orga_urls.send_outbox }}?pks={% for mail in mails %}{{ mail.pk }}{% if not forloop.last %},{% endif %}{% endfor %}">
-                        <button class="btn btn-outline-success">{% translate "Send all on this page" %}</button>
-                    </a>
-                {% endif %}
-                <a href="{{ request.event.orga_urls.send_outbox }}?{{ request.GET.urlencode }}" class="btn btn-success">
-                    {% translate "Send all" %}
-                </a>
-                <a href="{{ request.event.orga_urls.purge_outbox }}?{{ request.GET.urlencode }}" class="btn btn-danger">
-                    {% translate "Discard all" %}
-                </a>
-            </div>
-            <div>
-                {% if is_filtered %}
-                    <div class="text-right text-muted mt-2">
-                        <i class="fa fa-filter"></i>
-                        {% translate "The current filters will be used when sending/discarding emails." %}
+  <h2>
+    <span>
+      {{ page_obj.paginator.count }}
+      {% blocktranslate trimmed count count=page_obj.paginator.count %}
+        pending mail
+      {% plural %}
+        pending mails
+      {% endblocktranslate %}
+    </span>
+  </h2>
+  <div class="submit-group">
+    <div>
+      {% include "common/includes/search_form.html" with omit_wrapper=True %}
+    </div>
+    <div class="d-flex flex-column align-items-end">
+      <div>
+        {% if is_paginated and page_obj.paginator.num_pages > 1 %}
+          <a href="{{ request.event.orga_urls.send_outbox }}?pks={% for mail in mails %}{{ mail.pk }}{% if not forloop.last %},{% endif %}{% endfor %}">
+            <button class="btn btn-outline-success">{% translate "Send all on this page" %}</button>
+          </a>
+        {% endif %}
+        <a href="{{ request.event.orga_urls.send_outbox }}?{{ request.GET.urlencode }}" class="btn btn-success">
+          {% translate "Send all" %}
+        </a>
+        <a href="{{ request.event.orga_urls.purge_outbox }}?{{ request.GET.urlencode }}" class="btn btn-danger">
+          {% translate "Discard all" %}
+        </a>
+      </div>
+      <div>
+        {% if is_filtered %}
+          <div class="text-right text-muted mt-2">
+            <i class="fa fa-filter"></i>
+            {% translate "The current filters will be used when sending/discarding emails." %}
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="table-responsive-sm">
+    <table class="table table-sm table-hover table-flip table-sticky">
+      <thead>
+        <tr>
+          <th>
+            {{ phrases.base.email_subject }}
+            <a href="{% querystring sort="subject" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
+            <a href="{% querystring sort="-subject" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
+          </th>
+          <th>
+            {% translate "To" %}
+            <a href="{% querystring sort="to" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
+            <a href="{% querystring sort="-to" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
+          </th>
+          <th></th>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for mail in mails %}
+          <tr>
+            <td>
+              <a href="{{ mail.urls.base }}">{{ mail.subject }}</a>
+            </td>
+            <td>
+              {% for user in mail.to_users.all %}
+                {% if user in request.event.submitters %}
+                  <a href="{% url "orga:speakers.view" event=request.event.slug code=user.code %}">
+                    {{ user }}
+                  </a>{% else %}{{ user }}{% endif %}{% if not forloop.last or mail.to %}, {% endif %}
+              {% endfor %}
+              {% if mail.to %}{{ mail.to }}{% endif %}
+            </td>
+            <td>
+              {% for submission in mail.submissions.all %}
+                <div class="d-flex align-items-center">
+                  {% if show_tracks and submission.track %}
+                    <div class="color-square" style="background-color: {{ submission.track.color }}" title="{{ submission.track.name }}">
                     </div>
-                {% endif %}
-            </div>
-        </div>
-    </div>
-    <div class="table-responsive-sm">
-        <table class="table table-sm table-hover table-flip table-sticky">
-            <thead>
-                <tr>
-                    <th>
-                        {{ phrases.base.email_subject }}
-                        <a href="{% querystring sort="subject" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
-                        <a href="{% querystring sort="-subject" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
-                    </th>
-                    <th>
-                        {% translate "To" %}
-                        <a href="{% querystring sort="to" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
-                        <a href="{% querystring sort="-to" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
-                    </th>
-                    <th></th>
-                    <th></th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for mail in mails %}
-                    <tr>
-                        <td>
-                            <a href="{{ mail.urls.base }}">{{ mail.subject }}</a>
-                        </td>
-                        <td>
-                            {% for user in mail.to_users.all %}
-                                {% if user in request.event.submitters %}
-                                    <a href="{% url "orga:speakers.view" event=request.event.slug code=user.code %}">
-                                        {{ user }}
-                                    </a>{% else %}{{ user }}{% endif %}{% if not forloop.last or mail.to %}, {% endif %}
-                            {% endfor %}
-                            {% if mail.to %}{{ mail.to }}{% endif %}
-                        </td>
-                        <td>
-                            {% for submission in mail.submissions.all %}
-                                <div class="d-flex align-items-center">
-                                    {% if show_tracks and submission.track %}
-                                        <div class="color-square" style="background-color: {{ submission.track.color }}" title="{{ submission.track.name }}">
-                                        </div>
-                                    {% endif %}
-                                    <a href="{{ submission.orga_urls.base }}">
-                                        {{ submission.title }}
-                                    </a>
-                                </div>
-                            {% endfor %}
-                        </td>
-                        <td class="text-right">
-                            {% if mail.attachments %}
-                                <i class="fa fa-paperclip" title="{% translate "Contains an attachment" %}"></i>
-                            {% endif %}
-                            {% include "orga/includes/mail_template_role.html" with template=mail.template %}
-                        </td>
-                        <td class="action-column">
-                            <a href="{{ mail.urls.send }}" title="{{ phrases.base.send }}" class="btn btn-sm btn-success">
-                                <i class="fa fa-mail-forward"></i>
-                            </a>
-                            <a href="{{ mail.urls.edit }}" title="{{ phrases.base.edit }}" class="btn btn-sm btn-info">
-                                <i class="fa fa-edit"></i>
-                            </a>
-                            <a href="{{ mail.urls.delete }}" title="{{ phrases.base.delete_button }}" class="btn btn-sm btn-danger">
-                                <i class="fa fa-trash"></i>
-                            </a>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+                  {% endif %}
+                  <a href="{{ submission.orga_urls.base }}">
+                    {{ submission.title }}
+                  </a>
+                </div>
+              {% endfor %}
+            </td>
+            <td class="text-right">
+              {% if mail.attachments %}
+                <i class="fa fa-paperclip" title="{% translate "Contains an attachment" %}"></i>
+              {% endif %}
+              {% include "orga/includes/mail_template_role.html" with template=mail.template %}
+            </td>
+            <td class="action-column">
+              <a href="{{ mail.urls.send }}" title="{{ phrases.base.send }}" class="btn btn-sm btn-success">
+                <i class="fa fa-mail-forward"></i>
+              </a>
+              <a href="{{ mail.urls.edit }}" title="{{ phrases.base.edit }}" class="btn btn-sm btn-info">
+                <i class="fa fa-edit"></i>
+              </a>
+              <a href="{{ mail.urls.delete }}" title="{{ phrases.base.delete_button }}" class="btn btn-sm btn-danger">
+                <i class="fa fa-trash"></i>
+              </a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock mail_content %}

--- a/src/pretalx/orga/templates/orga/mails/send_draft_reminders.html
+++ b/src/pretalx/orga/templates/orga/mails/send_draft_reminders.html
@@ -3,16 +3,16 @@
 {% load i18n %}
 
 {% block mail_content %}
-    <h2>{% translate "Send reminder to unsubmitted proposal drafts" %}</h2>
-    <div class="alert alert-warning">
-        {% blocktranslate trimmed %}
-            These emails will be sent out immediately! They will not be
-            saved to the outbox or logged first, to protect the privacy of
-            the draft authors.
-        {% endblocktranslate %}
-    </div>
+  <h2>{% translate "Send reminder to unsubmitted proposal drafts" %}</h2>
+  <div class="alert alert-warning">
+    {% blocktranslate trimmed %}
+      These emails will be sent out immediately! They will not be
+      saved to the outbox or logged first, to protect the privacy of
+      the draft authors.
+    {% endblocktranslate %}
+  </div>
 
-    {% include "orga/includes/base_form.html" with submit_label=phrases.base.send %}
+  {% include "orga/includes/base_form.html" with submit_label=phrases.base.send %}
 
-    </form>
+  </form>
 {% endblock mail_content %}

--- a/src/pretalx/orga/templates/orga/mails/sent_list.html
+++ b/src/pretalx/orga/templates/orga/mails/sent_list.html
@@ -3,75 +3,75 @@
 {% load i18n %}
 
 {% block mail_content %}
-    <h2>
-        {{ page_obj.paginator.count }}
-        {% translate "Sent Mails" %}
-    </h2>
-    {% include "common/includes/search_form.html" %}
-    <div class="table-responsive-sm">
-        <table class="table table-sm table-hover table-flip table-sticky">
-            <thead>
-                <tr>
-                    <th>
-                        {{ phrases.base.email_subject }}
-                        <a href="{% querystring sort="subject" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
-                        <a href="{% querystring sort="-subject" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
-                    </th>
-                    <th>
-                        {% translate "To" %}
-                        <a href="{% querystring sort="to" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
-                        <a href="{% querystring sort="-to" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
-                    </th>
-                    <th></th>
-                    <th></th>
-                    <th class="numeric">
-                        {% translate "Sent" %}
-                        <a href="{% querystring sort="-sent" %}"><i class="fa fa-caret-down" title="{% translate "Sort (latest first)" %}"></i></a>
-                        <a href="{% querystring sort="sent" %}"><i class="fa fa-caret-up" title="{% translate "Sort (oldest first)" %}"></i></a>
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for mail in mails %}
-                    <tr>
-                        <td>
-                            <a href="{{ mail.urls.base }}">{{ mail.subject }}</a>
-                        </td>
-                        <td>
-                            {% for user in mail.to_users.all %}
-                                {% if user in request.event.submitters %}
-                                    <a href="{% url "orga:speakers.view" event=request.event.slug code=user.code %}">
-                                        {{ user }}
-                                    </a>{% else %}{{ user }}{% endif %}{% if not forloop.last or mail.to %}, {% endif %}
-                            {% endfor %}
-                            {% if mail.to %}{{ mail.to }}{% endif %}
-                        </td>
-                        <td>
-                            {% for submission in mail.submissions.all %}
-                                <div class="d-flex align-items-center">
-                                    {% if show_tracks and submission.track %}
-                                        <div class="color-square" style="background-color: {{ submission.track.color }}" title="{{ submission.track.name }}">
-                                        </div>
-                                    {% endif %}
-                                    <a href="{{ submission.orga_urls.base }}">
-                                        {{ submission.title }}
-                                    </a>
-                                </div>
-                            {% endfor %}
-                        </td>
-                        <td class="text-right d-flex align-items-center">
-                            {% if mail.attachments %}
-                                <i class="fa fa-paperclip mr-2" title="{% translate "Contains an attachment" %}"></i>
-                            {% endif %}
-                            {% include "orga/includes/mail_template_role.html" with template=mail.template %}
-                        </td>
-                        <td class="numeric">{{ mail.sent }}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+  <h2>
+    {{ page_obj.paginator.count }}
+    {% translate "Sent Mails" %}
+  </h2>
+  {% include "common/includes/search_form.html" %}
+  <div class="table-responsive-sm">
+    <table class="table table-sm table-hover table-flip table-sticky">
+      <thead>
+        <tr>
+          <th>
+            {{ phrases.base.email_subject }}
+            <a href="{% querystring sort="subject" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
+            <a href="{% querystring sort="-subject" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
+          </th>
+          <th>
+            {% translate "To" %}
+            <a href="{% querystring sort="to" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
+            <a href="{% querystring sort="-to" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
+          </th>
+          <th></th>
+          <th></th>
+          <th class="numeric">
+            {% translate "Sent" %}
+            <a href="{% querystring sort="-sent" %}"><i class="fa fa-caret-down" title="{% translate "Sort (latest first)" %}"></i></a>
+            <a href="{% querystring sort="sent" %}"><i class="fa fa-caret-up" title="{% translate "Sort (oldest first)" %}"></i></a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for mail in mails %}
+          <tr>
+            <td>
+              <a href="{{ mail.urls.base }}">{{ mail.subject }}</a>
+            </td>
+            <td>
+              {% for user in mail.to_users.all %}
+                {% if user in request.event.submitters %}
+                  <a href="{% url "orga:speakers.view" event=request.event.slug code=user.code %}">
+                    {{ user }}
+                  </a>{% else %}{{ user }}{% endif %}{% if not forloop.last or mail.to %}, {% endif %}
+              {% endfor %}
+              {% if mail.to %}{{ mail.to }}{% endif %}
+            </td>
+            <td>
+              {% for submission in mail.submissions.all %}
+                <div class="d-flex align-items-center">
+                  {% if show_tracks and submission.track %}
+                    <div class="color-square" style="background-color: {{ submission.track.color }}" title="{{ submission.track.name }}">
+                    </div>
+                  {% endif %}
+                  <a href="{{ submission.orga_urls.base }}">
+                    {{ submission.title }}
+                  </a>
+                </div>
+              {% endfor %}
+            </td>
+            <td class="text-right d-flex align-items-center">
+              {% if mail.attachments %}
+                <i class="fa fa-paperclip mr-2" title="{% translate "Contains an attachment" %}"></i>
+              {% endif %}
+              {% include "orga/includes/mail_template_role.html" with template=mail.template %}
+            </td>
+            <td class="numeric">{{ mail.sent }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock mail_content %}

--- a/src/pretalx/orga/templates/orga/mails/template_list.html
+++ b/src/pretalx/orga/templates/orga/mails/template_list.html
@@ -5,74 +5,74 @@
 {% load static %}
 
 {% block scripts %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
-    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
+  <script defer src="{% static "common/js/modalDialog.js" %}"></script>
 {% endblock scripts %}
 
 {% block mail_content %}
-    <h2 class="d-flex">
-        {% translate "Templates" %}
-        <span class="dialog-anchor ml-2" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-        <a href="{{ request.event.orga_urls.new_template }}" class="btn btn-success flip ml-auto">
-            <i class="fa fa-plus"></i>
-            {% translate "New custom template" %}
-        </a>
-    </h2>
-    <dialog class="info-dialog" id="info-dialog">
-        <div class="alert alert-info">
-            <div>
-                <p>
-                    {% blocktranslate trimmed %}
-                        You can edit the default templates and your custom templates for emails here.
-                        If you want to send emails to some or all of your speakers, head over to the
-                        “Send Emails” tab. Mails queued for sending are in the “Outbox” tab.
-                    {% endblocktranslate %}
-                </p>
-                <p>
-                    {% blocktranslate trimmed %}
-                        There are different placeholders available depending on the template type.
-                        They are explained in detail once you start editing a template.
-                    {% endblocktranslate %}
-                </p>
-            </div>
-        </div>
-    </dialog>
+  <h2 class="d-flex">
+    {% translate "Templates" %}
+    <span class="dialog-anchor ml-2" data-target="#info-dialog" data-toggle="dialog">
+      <i class="fa fa-question-circle-o text-info"></i>
+    </span>
+    <a href="{{ request.event.orga_urls.new_template }}" class="btn btn-success flip ml-auto">
+      <i class="fa fa-plus"></i>
+      {% translate "New custom template" %}
+    </a>
+  </h2>
+  <dialog class="info-dialog" id="info-dialog">
+    <div class="alert alert-info">
+      <div>
+        <p>
+          {% blocktranslate trimmed %}
+            You can edit the default templates and your custom templates for emails here.
+            If you want to send emails to some or all of your speakers, head over to the
+            “Send Emails” tab. Mails queued for sending are in the “Outbox” tab.
+          {% endblocktranslate %}
+        </p>
+        <p>
+          {% blocktranslate trimmed %}
+            There are different placeholders available depending on the template type.
+            They are explained in detail once you start editing a template.
+          {% endblocktranslate %}
+        </p>
+      </div>
+    </div>
+  </dialog>
 
 
     {# HACK: This isn"t really a form, but we want to make the templates look like normal forms #}
-    <div class="accordion form" id="template-accordion">
-        {% for form in template_forms %}
-            <div class="card">
-                <div class="card-header" id="heading{{ form.instance.id }}">
-                    <h2 class="d-flex">
-                        <button class="btn btn-block text-left" data-toggle="collapse" data-target="#collapse{{ form.instance.id }}" aria-expanded="false" aria-controls="collapse{{ form.instance.id }}">
-                            {% if not form.instance.role %}
-                                {% translate "Custom Mail" %}:
-                                {{ form.instance.subject }}
-                            {% else %}
-                                {{ form.instance.get_role_display }}
-                            {% endif %}
-                            <i class="fa fa-2x ml-auto"></i>
-                        </button>
-                        <div class="d-flex">
-                            {% if not form.instance.role %}
-                                <a href="{{ form.instance.urls.delete }}" class="btn btn-danger flip mr-1 nowrap">{% translate "Delete template" %}</a>
-                                <a href="{{ request.event.orga_urls.compose_mails_sessions }}?template={{ form.instance.pk }}" class="btn btn-success mr-1 nowrap">{% translate "Send mails" %}</a>
-                            {% endif %}
-                            <a href="{{ form.instance.urls.edit }}#tab-content" class="btn btn-info flip nowrap">{% translate "Edit template" %}</a>
-                        </div>
-                    </h2>
-                </div>
-                <div id="collapse{{ form.instance.id }}" class="collapse" aria-labelledby="heading{{ form.instance.id }}" data-parent="#template-accordion">
-                    <div class="card-body">
-                        {{ form }}
-                    </div>
-                </div>
+  <div class="accordion form" id="template-accordion">
+    {% for form in template_forms %}
+      <div class="card">
+        <div class="card-header" id="heading{{ form.instance.id }}">
+          <h2 class="d-flex">
+            <button class="btn btn-block text-left" data-toggle="collapse" data-target="#collapse{{ form.instance.id }}" aria-expanded="false" aria-controls="collapse{{ form.instance.id }}">
+              {% if not form.instance.role %}
+                {% translate "Custom Mail" %}:
+                {{ form.instance.subject }}
+              {% else %}
+                {{ form.instance.get_role_display }}
+              {% endif %}
+              <i class="fa fa-2x ml-auto"></i>
+            </button>
+            <div class="d-flex">
+              {% if not form.instance.role %}
+                <a href="{{ form.instance.urls.delete }}" class="btn btn-danger flip mr-1 nowrap">{% translate "Delete template" %}</a>
+                <a href="{{ request.event.orga_urls.compose_mails_sessions }}?template={{ form.instance.pk }}" class="btn btn-success mr-1 nowrap">{% translate "Send mails" %}</a>
+              {% endif %}
+              <a href="{{ form.instance.urls.edit }}#tab-content" class="btn btn-info flip nowrap">{% translate "Edit template" %}</a>
             </div>
-        {% endfor %}
-    </div>
+          </h2>
+        </div>
+        <div id="collapse{{ form.instance.id }}" class="collapse" aria-labelledby="heading{{ form.instance.id }}" data-parent="#template-accordion">
+          <div class="card-body">
+            {{ form }}
+          </div>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
 {% endblock mail_content %}

--- a/src/pretalx/orga/templates/orga/organiser/detail.html
+++ b/src/pretalx/orga/templates/orga/organiser/detail.html
@@ -3,25 +3,25 @@
 {% load rules %}
 {% block extra_title %}{% translate "Organiser" %} :: {{ request.organiser.name }} :: {% endblock extra_title %}
 {% block content %}
-    <h2>{% translate "Settings" %}</h2>
-    <form method="post">
-        {% csrf_token %}
-        {{ form }}
-        <div class="submit-group panel">
-            <span>
-                {% has_perm "person.is_administrator" request.user request.organiser as can_delete_event %}
-                {% if can_delete_event %}
-                    <a class="btn-outline-danger btn-lg" role="button" href="{{ request.organiser.orga_urls.delete }}">
-                        {% translate "Delete organiser" %}
-                    </a>
-                {% endif %}
-            </span>
-            <span>
-                <button type="submit" class="btn-success btn-lg">
-                    <i class="fa fa-check"></i>
-                    {{ phrases.base.save }}
-                </button>
-            </span>
-        </div>
-    </form>
+  <h2>{% translate "Settings" %}</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form }}
+    <div class="submit-group panel">
+      <span>
+        {% has_perm "person.is_administrator" request.user request.organiser as can_delete_event %}
+        {% if can_delete_event %}
+          <a class="btn-outline-danger btn-lg" role="button" href="{{ request.organiser.orga_urls.delete }}">
+            {% translate "Delete organiser" %}
+          </a>
+        {% endif %}
+      </span>
+      <span>
+        <button type="submit" class="btn-success btn-lg">
+          <i class="fa fa-check"></i>
+          {{ phrases.base.save }}
+        </button>
+      </span>
+    </div>
+  </form>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/organiser/list.html
+++ b/src/pretalx/orga/templates/orga/organiser/list.html
@@ -8,47 +8,47 @@
 {% block extra_title %}{% translate "Teams" %} :: {% endblock extra_title %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "orga/css/dashboard.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "orga/css/dashboard.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block content %}
-    <form class="mb-4 m-2">
-        <input type="text" name="q" class="form-control" value="{% if request.GET.q %}{{ request.GET.q }}{% endif %}" placeholder="{% translate "Search" %}">
-    </form>
-    {% has_perm "orga.change_organiser_settings" request.user None as can_create_organiser %}
-    <div class="dashboard-list event-blocks">
-        {% if can_create_organiser %}
-            <a class="dashboard-block symbol" href="{% url "orga:organiser.create" %}">
-                <i class="fa fa-plus-circle"></i>
-            </a>
-        {% endif %}
-        {% for organiser in organisers %}
-            <a class="event-block dashboard-block" href="{{ organiser.orga_urls.base }}">
-                <h2 class="name">{{ organiser.name }}</h2>
-                <div class="stats">
-                    <div class="submissions">
-                        {{ organiser.event_count }}
-                        {% blocktranslate trimmed count count=organiser.event_count %}
-                            Event
-                        {% plural %}
-                            Events
-                        {% endblocktranslate %}
-                    </div>
-                    <div class="state inactive">
-                        {{ organiser.team_count }}
-                        {% blocktranslate trimmed count count=organiser.team_count context "number of teams" %}
-                            Team
-                        {% plural %}
-                            Teams
-                        {% endblocktranslate %}
-                    </div>
-                </div>
-            </a>
-        {% endfor %}
-    </div>
-    {% if not organisers and not can_create_organiser %}
-        <div class="alert alert-info">{% translate "There are no organisers you can edit." %}</div>
+  <form class="mb-4 m-2">
+    <input type="text" name="q" class="form-control" value="{% if request.GET.q %}{{ request.GET.q }}{% endif %}" placeholder="{% translate "Search" %}">
+  </form>
+  {% has_perm "orga.change_organiser_settings" request.user None as can_create_organiser %}
+  <div class="dashboard-list event-blocks">
+    {% if can_create_organiser %}
+      <a class="dashboard-block symbol" href="{% url "orga:organiser.create" %}">
+        <i class="fa fa-plus-circle"></i>
+      </a>
     {% endif %}
+    {% for organiser in organisers %}
+      <a class="event-block dashboard-block" href="{{ organiser.orga_urls.base }}">
+        <h2 class="name">{{ organiser.name }}</h2>
+        <div class="stats">
+          <div class="submissions">
+            {{ organiser.event_count }}
+            {% blocktranslate trimmed count count=organiser.event_count %}
+              Event
+            {% plural %}
+              Events
+            {% endblocktranslate %}
+          </div>
+          <div class="state inactive">
+            {{ organiser.team_count }}
+            {% blocktranslate trimmed count count=organiser.team_count context "number of teams" %}
+              Team
+            {% plural %}
+              Teams
+            {% endblocktranslate %}
+          </div>
+        </div>
+      </a>
+    {% endfor %}
+  </div>
+  {% if not organisers and not can_create_organiser %}
+    <div class="alert alert-info">{% translate "There are no organisers you can edit." %}</div>
+  {% endif %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/organiser/speaker_list.html
+++ b/src/pretalx/orga/templates/orga/organiser/speaker_list.html
@@ -6,67 +6,67 @@
 {% block extra_title %}{{ page_obj.paginator.count }} {% blocktranslate trimmed count count=page_obj.paginator.count %}speaker{% plural %}speakers{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/lightbox.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/lightbox.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block content %}
-    <h2>
-        {{ page_obj.paginator.count }}
-        {% blocktranslate trimmed count count=page_obj.paginator.count %}
-            speaker
-        {% plural %}
-            speakers
-        {% endblocktranslate %}
-    </h2>
+  <h2>
+    {{ page_obj.paginator.count }}
+    {% blocktranslate trimmed count count=page_obj.paginator.count %}
+      speaker
+    {% plural %}
+      speakers
+    {% endblocktranslate %}
+  </h2>
 
-    {% include "common/includes/search_form.html" %}
+  {% include "common/includes/search_form.html" %}
 
-    <div class="table-responsive-md">
-        <table class="table table-sm table-hover table-flip table-sticky">
-            <thead>
-                <tr>
-                    <th>
-                        {% translate "Name" %}
-                        <a href="{% querystring sort="name" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
-                        <a href="{% querystring sort="-name" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
-                    </th>
-                    <th>
-                        {% translate "Email" %}
-                        <a href="{% querystring sort="email" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
-                        <a href="{% querystring sort="-email" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
-                    </th>
-                    <th class="numeric">
-                        {% translate "Accepted Proposals" %}
-                        <a href="{% querystring sort="-accepted_submission_count" %}"><i class="fa fa-caret-down" title="{% translate "Sort (high-low)" %}"></i></a>
-                        <a href="{% querystring sort="accepted_submission_count" %}"><i class="fa fa-caret-up" title="{% translate "Sort (low-high)" %}"></i></a>
-                    </th>
-                    <th class="numeric">
-                        {% translate "Proposals" %}
-                        <a href="{% querystring sort="-submission_count" %}"><i class="fa fa-caret-down" title="{% translate "Sort (high-low)" %}"></i></a>
-                        <a href="{% querystring sort="submission_count" %}"><i class="fa fa-caret-up" title="{% translate "Sort (low-high)" %}"></i></a>
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for speaker in speakers %}
-                    <tr>
-                        <td>{% include "orga/includes/user_name.html" with user=speaker lightbox=True %}</td>
-                        <td><a href="mailto:{{ speaker.email }}">{{ speaker.email }}</a></td>
-                        <td class="numeric">{{ speaker.accepted_submission_count }}</td>
-                        <td class="numeric">{{ speaker.submission_count }}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+  <div class="table-responsive-md">
+    <table class="table table-sm table-hover table-flip table-sticky">
+      <thead>
+        <tr>
+          <th>
+            {% translate "Name" %}
+            <a href="{% querystring sort="name" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
+            <a href="{% querystring sort="-name" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
+          </th>
+          <th>
+            {% translate "Email" %}
+            <a href="{% querystring sort="email" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
+            <a href="{% querystring sort="-email" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
+          </th>
+          <th class="numeric">
+            {% translate "Accepted Proposals" %}
+            <a href="{% querystring sort="-accepted_submission_count" %}"><i class="fa fa-caret-down" title="{% translate "Sort (high-low)" %}"></i></a>
+            <a href="{% querystring sort="accepted_submission_count" %}"><i class="fa fa-caret-up" title="{% translate "Sort (low-high)" %}"></i></a>
+          </th>
+          <th class="numeric">
+            {% translate "Proposals" %}
+            <a href="{% querystring sort="-submission_count" %}"><i class="fa fa-caret-down" title="{% translate "Sort (high-low)" %}"></i></a>
+            <a href="{% querystring sort="submission_count" %}"><i class="fa fa-caret-up" title="{% translate "Sort (low-high)" %}"></i></a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for speaker in speakers %}
+          <tr>
+            <td>{% include "orga/includes/user_name.html" with user=speaker lightbox=True %}</td>
+            <td><a href="mailto:{{ speaker.email }}">{{ speaker.email }}</a></td>
+            <td class="numeric">{{ speaker.accepted_submission_count }}</td>
+            <td class="numeric">{{ speaker.submission_count }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/organiser/team_list.html
+++ b/src/pretalx/orga/templates/orga/organiser/team_list.html
@@ -5,57 +5,57 @@
 {% block extra_title %}{% translate "Teams" %} :: {{ request.organiser.name }} :: {% endblock extra_title %}
 
 {% block content %}
-    <fieldset>
-        <legend>{% translate "Teams" %}</legend>
-        <div class="table-responsive-sm">
-            <table class="table table-hover table-sm table-flip table-sticky">
-                <thead>
-                    <tr>
-                        <th>{% translate "Team" %}</th>
-                        <th class="numeric">{% translate "Members" %}</th>
-                        <th>{% translate "All events" %}</th>
-                        <th>{% translate "Reviewer" %}</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% if teams %}{% for team in teams %}
-                        <tr>
-                            <td>
-                                <a href="{{ team.orga_urls.base }}">
-                                    {{ team.name }}
-                                    {% if request.user in team.members.all %}
-                                        <i class="fa fa-star text-warning" title="{% translate "You are a member of this team" %}"></i>
-                                    {% endif %}
-                                </a>
-                            </td>
-                            <td class="numeric">{{ team.members.count }}</td>
-                            <td>
-                                <i class="fa fa-{{ team.all_events|yesno:"check-circle text-success,times-circle text-danger" }}"></i>
-                            </td>
-                            <td>
-                                <i class="fa fa-{{ team.is_reviewer|yesno:"check-circle text-success,times-circle text-danger" }}"></i>
-                            </td>
-                            <td>
-                                <a href="{{ team.orga_urls.base }}" class="btn btn-sm btn-info" title="{{ phrases.base.edit }}">
-                                    <i class="fa fa-edit"></i>
-                                </a>
-                                <a href="{{ team.orga_urls.delete }}" class="btn btn-sm btn-danger" title="{{ phrases.base.delete_button }}">
-                                    <i class="fa fa-trash"></i>
-                                </a>
-                            </td>
-                        </tr>
-                    {% endfor %}{% endif %}
-                </tbody>
-            </table>
-        </div>
-        <div class="submit-group">
-            <span></span>
-            <span>
-                <a href="{{ request.organiser.orga_urls.new_team }}" class="btn btn-info">
-                    <i class="fa fa-plus"></i> {% translate "New team" %}
+  <fieldset>
+    <legend>{% translate "Teams" %}</legend>
+    <div class="table-responsive-sm">
+      <table class="table table-hover table-sm table-flip table-sticky">
+        <thead>
+          <tr>
+            <th>{% translate "Team" %}</th>
+            <th class="numeric">{% translate "Members" %}</th>
+            <th>{% translate "All events" %}</th>
+            <th>{% translate "Reviewer" %}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if teams %}{% for team in teams %}
+            <tr>
+              <td>
+                <a href="{{ team.orga_urls.base }}">
+                  {{ team.name }}
+                  {% if request.user in team.members.all %}
+                    <i class="fa fa-star text-warning" title="{% translate "You are a member of this team" %}"></i>
+                  {% endif %}
                 </a>
-            </span>
-        </div>
-    </fieldset>
+              </td>
+              <td class="numeric">{{ team.members.count }}</td>
+              <td>
+                <i class="fa fa-{{ team.all_events|yesno:"check-circle text-success,times-circle text-danger" }}"></i>
+              </td>
+              <td>
+                <i class="fa fa-{{ team.is_reviewer|yesno:"check-circle text-success,times-circle text-danger" }}"></i>
+              </td>
+              <td>
+                <a href="{{ team.orga_urls.base }}" class="btn btn-sm btn-info" title="{{ phrases.base.edit }}">
+                  <i class="fa fa-edit"></i>
+                </a>
+                <a href="{{ team.orga_urls.delete }}" class="btn btn-sm btn-danger" title="{{ phrases.base.delete_button }}">
+                  <i class="fa fa-trash"></i>
+                </a>
+              </td>
+            </tr>
+          {% endfor %}{% endif %}
+        </tbody>
+      </table>
+    </div>
+    <div class="submit-group">
+      <span></span>
+      <span>
+        <a href="{{ request.organiser.orga_urls.new_team }}" class="btn btn-info">
+          <i class="fa fa-plus"></i> {% translate "New team" %}
+        </a>
+      </span>
+    </div>
+  </fieldset>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/plugins.html
+++ b/src/pretalx/orga/templates/orga/plugins.html
@@ -4,53 +4,53 @@
 
 {% block extra_title %}{% translate "Plugins" %} :: {% endblock extra_title %}
 {% block content %}
-    <h2>{% translate "Plugins" %}</h2>
+  <h2>{% translate "Plugins" %}</h2>
 
-    {% if grouped_plugins %}
-        {% include "orga/includes/tablist.html" %}
-        <form method="post" class="form-horizontal">
-            {% csrf_token %}
-            {% for category, plugins in grouped_plugins.items %}
-                <section role="tabpanel" id="tabpanel-{{ category.0 }}" aria-labelledby="tab-{{ category.0 }}" tabindex="0" aria-hidden="false">
-                    <div class="form-plugins">
+  {% if grouped_plugins %}
+    {% include "orga/includes/tablist.html" %}
+    <form method="post" class="form-horizontal">
+      {% csrf_token %}
+      {% for category, plugins in grouped_plugins.items %}
+        <section role="tabpanel" id="tabpanel-{{ category.0 }}" aria-labelledby="tab-{{ category.0 }}" tabindex="0" aria-hidden="false">
+          <div class="form-plugins">
 
-                        {% for plugin in plugins %}
-                            <div class="card plugin-card">
-                                <div class="card-header">
-                                    {{ plugin.name }}
-                                    {% if plugin.module in plugins_active %}
-                                        <button class="btn btn-outline-danger btn-block" name="plugin:{{ plugin.module }}" value="disable">{% translate "Disable" %}</button>
-                                    {% else %}
-                                        <button class="btn btn-success btn-block" name="plugin:{{ plugin.module }}" value="enable">{% translate "Enable" %}</button>
-                                    {% endif %}
-                                </div>
-                                <ul class="list-group list-group-flush">
-                                    <li class="list-group-item">
-                                        {% if plugin.author %}
-                                            <p class="meta">
-                                                {% blocktranslate trimmed with v=plugin.version a=plugin.author %}
-                                                    Version {{ v }} by <em>{{ a }}</em>
-                                                {% endblocktranslate %}
-                                            </p>
-                                        {% else %}
-                                            <p class="meta">
-                                                {% blocktranslate trimmed with v=plugin.version a=plugin.author %}
-                                                    Version {{ v }}
-                                                {% endblocktranslate %}
-                                            </p>
-                                        {% endif %}
-                                        {{ plugin.description }}
-                                    </li>
-                                </ul>
-                            </div>
-                        {% endfor %}
-                    </div>
-                </section>
+            {% for plugin in plugins %}
+              <div class="card plugin-card">
+                <div class="card-header">
+                  {{ plugin.name }}
+                  {% if plugin.module in plugins_active %}
+                    <button class="btn btn-outline-danger btn-block" name="plugin:{{ plugin.module }}" value="disable">{% translate "Disable" %}</button>
+                  {% else %}
+                    <button class="btn btn-success btn-block" name="plugin:{{ plugin.module }}" value="enable">{% translate "Enable" %}</button>
+                  {% endif %}
+                </div>
+                <ul class="list-group list-group-flush">
+                  <li class="list-group-item">
+                    {% if plugin.author %}
+                      <p class="meta">
+                        {% blocktranslate trimmed with v=plugin.version a=plugin.author %}
+                          Version {{ v }} by <em>{{ a }}</em>
+                        {% endblocktranslate %}
+                      </p>
+                    {% else %}
+                      <p class="meta">
+                        {% blocktranslate trimmed with v=plugin.version a=plugin.author %}
+                          Version {{ v }}
+                        {% endblocktranslate %}
+                      </p>
+                    {% endif %}
+                    {{ plugin.description }}
+                  </li>
+                </ul>
+              </div>
             {% endfor %}
-        </form>
-    {% else %}
-        <div class="alert alert-info">
-            {% translate "This instance does currently not have any plugins installed." %}
-        </div>
-    {% endif %}
+          </div>
+        </section>
+      {% endfor %}
+    </form>
+  {% else %}
+    <div class="alert alert-info">
+      {% translate "This instance does currently not have any plugins installed." %}
+    </div>
+  {% endif %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/review/assignment-import.html
+++ b/src/pretalx/orga/templates/orga/review/assignment-import.html
@@ -8,14 +8,14 @@
 {% block extra_title %}{% translate "Assign reviewers" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Assign reviewers" %}</h2>
-    <p>
-        {% blocktranslate trimmed with href="#" %}
-            You can upload your reviewer assignments from a JSON file here. You can either have the proposal codes (e.g. “UX3N1”) as keys, and user identification as values, or the other way around. User identification can be either the reviewer’s email address or their user code (e.g. “34KJN”). You can find an example file <a href="{{ href }}">here</a>.
-        {% endblocktranslate %}
-    </p>
+  <h2>{% translate "Assign reviewers" %}</h2>
+  <p>
+    {% blocktranslate trimmed with href="#" %}
+      You can upload your reviewer assignments from a JSON file here. You can either have the proposal codes (e.g. “UX3N1”) as keys, and user identification as values, or the other way around. User identification can be either the reviewer’s email address or their user code (e.g. “34KJN”). You can find an example file <a href="{{ href }}">here</a>.
+    {% endblocktranslate %}
+  </p>
 
-    {% translate "Import" as button_label %}
-    {% include "orga/includes/base_form.html" with submit_label=button_label %}
+  {% translate "Import" as button_label %}
+  {% include "orga/includes/base_form.html" with submit_label=button_label %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/review/assignment.html
+++ b/src/pretalx/orga/templates/orga/review/assignment.html
@@ -8,146 +8,146 @@
 {% block extra_title %}{% translate "Assign reviewers" %} :: {% endblock extra_title %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/lightbox.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/lightbox.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block content %}
-    {% compress js %}
-        <script defer src="{% static "orga/js/reviewAssignment.js" %}"></script>
-    {% endcompress %}
-    <h2>{% translate "Assign reviewers" %}</h2>
+  {% compress js %}
+    <script defer src="{% static "orga/js/reviewAssignment.js" %}"></script>
+  {% endcompress %}
+  <h2>{% translate "Assign reviewers" %}</h2>
 
-    {% include "orga/includes/tablist.html" %}
+  {% include "orga/includes/tablist.html" %}
 
-    <section role="tabpanel" id="tabpanel-group" aria-labelledby="tab-group" tabindex="0" aria-hidden="false">
-        <p>
-            {% blocktranslate trimmed %}
-                Reviewers can be assigned to tracks by way of review teams. If you require more
-                granular assignments, you can also assign reviewers to proposals individually.
-            {% endblocktranslate %}
-        </p>
-        <div class="alert alert-info">
-            {% blocktranslate trimmed %}
-                As teams can belong to multiple events, teams are managed in your organiser settings.
-            {% endblocktranslate %}
-        </div>
-        <div class="d-flex justify-content-end mb-2">
-            <a href="{{ request.event.organiser.orga_urls.new_team }}" class="btn btn-info">
-                <i class="fa fa-plus"></i> {% translate "New team" %}
-            </a>
-        </div>
-        <table class="table table-sm table-hover table-flip">
-            <thead>
-                <tr>
-                    <th class="col col-md-4">{% translate "Team" %}</th>
-                    <th class="col col-md-3">{% translate "Members" %}</th>
-                    {% if request.event|get_feature_flag:"use_tracks" %}
-                        <th class="col col-md-3">{% translate "Limited to tracks" %}</th>
-                    {% endif %}
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for team in review_teams %}
-                    <tr>
-                        <td>
-                            <a href="{{ team.orga_urls.base }}?next={{ request.path }}">
-                                {{ team.name }}
-                                {% if request.user in team.members.all %}
-                                    <i class="fa fa-star text-warning" title="{% translate "You are a member of this team" %}"></i>
-                                {% endif %}
-                            </a>
-                        </td>
-                        <td>
-                            {% if team.members.count %}
-                                <details>
-                                    <summary>{{ team.members.count }}</summary>
-                                    <ul>
-                                        {% for member in team.members.all %}
-                                            <li>{% include "orga/includes/user_name.html" with user=member lightbox=True %}</li>
-                                        {% endfor %}
-                                    </ul>
-                                </details>
-                            {% else %}
-                                -
-                            {% endif %}
-                        </td>
-                        {% if request.event|get_feature_flag:"use_tracks" %}
-                            <td>
-                                {% for track in team.limit_tracks.all %}
-                                    <span class="badge color-secondary">{{ track.name }}</span>
-                                {% empty %}
-                                    -
-                                {% endfor %}
-                            </td>
-                        {% endif %}
-                        <td class="text-right">
-                            <a href="{{ team.orga_urls.base }}?next={{ request.path }}" class="btn btn-sm btn-info" title="{{ phrases.base.edit }}">
-                                <i class="fa fa-edit"></i>
-                            </a>
-                            <a href="{{ team.orga_urls.delete }}?next={{ request.path }}" class="btn btn-sm btn-danger" title="{{ phrases.base.delete_button }}">
-                                <i class="fa fa-trash"></i>
-                            </a>
-                        </td>
-                    </tr>
+  <section role="tabpanel" id="tabpanel-group" aria-labelledby="tab-group" tabindex="0" aria-hidden="false">
+    <p>
+      {% blocktranslate trimmed %}
+        Reviewers can be assigned to tracks by way of review teams. If you require more
+        granular assignments, you can also assign reviewers to proposals individually.
+      {% endblocktranslate %}
+    </p>
+    <div class="alert alert-info">
+      {% blocktranslate trimmed %}
+        As teams can belong to multiple events, teams are managed in your organiser settings.
+      {% endblocktranslate %}
+    </div>
+    <div class="d-flex justify-content-end mb-2">
+      <a href="{{ request.event.organiser.orga_urls.new_team }}" class="btn btn-info">
+        <i class="fa fa-plus"></i> {% translate "New team" %}
+      </a>
+    </div>
+    <table class="table table-sm table-hover table-flip">
+      <thead>
+        <tr>
+          <th class="col col-md-4">{% translate "Team" %}</th>
+          <th class="col col-md-3">{% translate "Members" %}</th>
+          {% if request.event|get_feature_flag:"use_tracks" %}
+            <th class="col col-md-3">{% translate "Limited to tracks" %}</th>
+          {% endif %}
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for team in review_teams %}
+          <tr>
+            <td>
+              <a href="{{ team.orga_urls.base }}?next={{ request.path }}">
+                {{ team.name }}
+                {% if request.user in team.members.all %}
+                  <i class="fa fa-star text-warning" title="{% translate "You are a member of this team" %}"></i>
+                {% endif %}
+              </a>
+            </td>
+            <td>
+              {% if team.members.count %}
+                <details>
+                  <summary>{{ team.members.count }}</summary>
+                  <ul>
+                    {% for member in team.members.all %}
+                      <li>{% include "orga/includes/user_name.html" with user=member lightbox=True %}</li>
+                    {% endfor %}
+                  </ul>
+                </details>
+              {% else %}
+                -
+              {% endif %}
+            </td>
+            {% if request.event|get_feature_flag:"use_tracks" %}
+              <td>
+                {% for track in team.limit_tracks.all %}
+                  <span class="badge color-secondary">{{ track.name }}</span>
+                {% empty %}
+                  -
                 {% endfor %}
-            </tbody>
-        </table>
-    </section>
-    <section role="tabpanel" id="tabpanel-individual" aria-labelledby="tab-individual" tabindex="0" aria-hidden="false">
-
-        <div class="alert alert-info"><p>
-            {% if request.event.active_review_phase.proposal_visibility == "assigned" %}
-                {% blocktranslate trimmed with href=request.event.orga_urls.review_settings %}
-                    Reviewers will be able to see and review <b>only their assigned</b> proposals.
-                    You can change this in your <a href="{{ href }}">review settings</a>.
-                {% endblocktranslate %}
-            {% else %}
-                {% blocktranslate trimmed with href=request.event.orga_urls.review_settings %}
-                    Reviewers will be able to see and review <b>all proposals</b>,
-                    but their assigned reviews will appear highlighted, and they
-                    will be directed to them first. You can change this in your <a
-                        href="{{ href }}">review settings</a>.
-                {% endblocktranslate %}
+              </td>
             {% endif %}
-        </p></div>
-        <p>
-            {% blocktranslate trimmed %}
-                This is where you can assign reviewers to specific proposals! Please use this drop-down to
-                switch between the two assignment modes (assigning reviewers to proposals or proposals to reviewers).
-            {% endblocktranslate %}
-            {% blocktranslate trimmed %}
-                You can also use the Actions menu above to import your assignments from a prepared file.
-            {% endblocktranslate %}
-        </p>
-        <div class="float-right">
-            <details class="dropdown" aria-haspopup="menu" role="menu">
-                <summary class="btn btn-info" id="review-actions">
-                    {% translate "Actions" %} <i class="fa fa-caret-down"></i>
-                </summary>
+            <td class="text-right">
+              <a href="{{ team.orga_urls.base }}?next={{ request.path }}" class="btn btn-sm btn-info" title="{{ phrases.base.edit }}">
+                <i class="fa fa-edit"></i>
+              </a>
+              <a href="{{ team.orga_urls.delete }}?next={{ request.path }}" class="btn btn-sm btn-danger" title="{{ phrases.base.delete_button }}">
+                <i class="fa fa-trash"></i>
+              </a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+  <section role="tabpanel" id="tabpanel-individual" aria-labelledby="tab-individual" tabindex="0" aria-hidden="false">
 
-                <div class="dropdown-content dropdown-front dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
-                    <a class="dropdown-item" href="{{ request.path }}import" target="_blank" rel="noopener" role="menuitem" tabindex="-1">
-                        <i class="fa fa-upload"></i> {% translate "Import assignments" %}
-                    </a>
-                </ul>
-            </details>
-        </div>
-        <div class="ml-auto mr-auto col-md-4">
-            <form id="direction">
-                {{ direction_form }}
-            </form>
-        </div>
+    <div class="alert alert-info"><p>
+      {% if request.event.active_review_phase.proposal_visibility == "assigned" %}
+        {% blocktranslate trimmed with href=request.event.orga_urls.review_settings %}
+          Reviewers will be able to see and review <b>only their assigned</b> proposals.
+          You can change this in your <a href="{{ href }}">review settings</a>.
+        {% endblocktranslate %}
+      {% else %}
+        {% blocktranslate trimmed with href=request.event.orga_urls.review_settings %}
+          Reviewers will be able to see and review <b>all proposals</b>,
+          but their assigned reviews will appear highlighted, and they
+          will be directed to them first. You can change this in your <a
+            href="{{ href }}">review settings</a>.
+        {% endblocktranslate %}
+      {% endif %}
+    </p></div>
+    <p>
+      {% blocktranslate trimmed %}
+        This is where you can assign reviewers to specific proposals! Please use this drop-down to
+        switch between the two assignment modes (assigning reviewers to proposals or proposals to reviewers).
+      {% endblocktranslate %}
+      {% blocktranslate trimmed %}
+        You can also use the Actions menu above to import your assignments from a prepared file.
+      {% endblocktranslate %}
+    </p>
+    <div class="float-right">
+      <details class="dropdown" aria-haspopup="menu" role="menu">
+        <summary class="btn btn-info" id="review-actions">
+          {% translate "Actions" %} <i class="fa fa-caret-down"></i>
+        </summary>
 
-        {% include "orga/includes/base_form.html" %}
+        <div class="dropdown-content dropdown-front dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
+          <a class="dropdown-item" href="{{ request.path }}import" target="_blank" rel="noopener" role="menuitem" tabindex="-1">
+            <i class="fa fa-upload"></i> {% translate "Import assignments" %}
+          </a>
+        </ul>
+      </details>
+    </div>
+    <div class="ml-auto mr-auto col-md-4">
+      <form id="direction">
+        {{ direction_form }}
+      </form>
+    </div>
 
-    </section>
+    {% include "orga/includes/base_form.html" %}
+
+  </section>
 {% endblock content %}
 

--- a/src/pretalx/orga/templates/orga/review/bulk.html
+++ b/src/pretalx/orga/templates/orga/review/bulk.html
@@ -7,83 +7,83 @@
 {% load static %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/lightbox.js" %}"></script>
-        <script src="{% static "orga/js/submission_filter.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/lightbox.js" %}"></script>
+    <script src="{% static "orga/js/submission_filter.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{% translate "Reviews" %} :: {% endblock extra_title %}
 
 {% block content %}
-    {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
-    <div class="alert alert-info">
-        {% if next_submission %}
-            {% blocktranslate trimmed count count=missing_reviews %}
-                Or review the missing proposal here.
-            {% plural %}
-                Or review the missing {{ count }} proposals one-by-one.
-            {% endblocktranslate %}
-            <a href="{{ next_submission.orga_urls.reviews }}" class="btn btn-outline-info btn-xs ml-2">
-                <i class="fa fa-arrow-right"></i>
-            </a>
-        {% else %}
-            {% translate "You’ve got no proposals left to review!" %}
-        {% endif %}
+  {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
+  <div class="alert alert-info">
+    {% if next_submission %}
+      {% blocktranslate trimmed count count=missing_reviews %}
+        Or review the missing proposal here.
+      {% plural %}
+        Or review the missing {{ count }} proposals one-by-one.
+      {% endblocktranslate %}
+      <a href="{{ next_submission.orga_urls.reviews }}" class="btn btn-outline-info btn-xs ml-2">
+        <i class="fa fa-arrow-right"></i>
+      </a>
+    {% else %}
+      {% translate "You’ve got no proposals left to review!" %}
+    {% endif %}
+  </div>
+
+  {% include "orga/includes/review_filter_form.html" %}
+
+  <form method="post">
+    {% csrf_token %}
+    <div class="table-responsive-sm">
+      <table class="table table-sm table-hover table-flip table-sticky">
+        <thead>
+          <tr>
+            <th>{% translate "Title" %}</th>
+            {% if can_view_speakers %}<th>{{ phrases.schedule.speakers }}</th>{% endif %}
+            {% for category in categories %}<th>{{ category.name }}</th>{% endfor %}
+            <th>{% translate "Comment" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in table %}
+            <tr>
+              <td>
+                <a href="{{ row.submission.orga_urls.base }}">{{ row.submission.title }}</a>
+              </td>
+              {% if can_view_speakers %}
+                <td>
+                  {% for speaker in row.submission.speakers.all %}
+                    {% include "orga/includes/user_name.html" with user=speaker lightbox=True %}<br>
+                  {% endfor %}
+                </td>
+              {% endif %}
+              {% for score in row.score_fields %}
+                <td class="pt-2">
+                  {% if score %}
+                    {{ score.as_field_group }}
+                  {% endif %}
+                </td>
+              {% endfor %}
+              <td class="pt-2">
+                {{ row.form.text.as_field_group }}
+              </td>
+            </tr>
+          {% empty %}
+            <tr>
+              <td colspan=10>{% translate "You don’t seem to have any proposals yet." %}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
-
-    {% include "orga/includes/review_filter_form.html" %}
-
-    <form method="post">
-        {% csrf_token %}
-        <div class="table-responsive-sm">
-            <table class="table table-sm table-hover table-flip table-sticky">
-                <thead>
-                    <tr>
-                        <th>{% translate "Title" %}</th>
-                        {% if can_view_speakers %}<th>{{ phrases.schedule.speakers }}</th>{% endif %}
-                        {% for category in categories %}<th>{{ category.name }}</th>{% endfor %}
-                        <th>{% translate "Comment" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for row in table %}
-                        <tr>
-                            <td>
-                                <a href="{{ row.submission.orga_urls.base }}">{{ row.submission.title }}</a>
-                            </td>
-                            {% if can_view_speakers %}
-                                <td>
-                                    {% for speaker in row.submission.speakers.all %}
-                                        {% include "orga/includes/user_name.html" with user=speaker lightbox=True %}<br>
-                                    {% endfor %}
-                                </td>
-                            {% endif %}
-                            {% for score in row.score_fields %}
-                                <td class="pt-2">
-                                    {% if score %}
-                                        {{ score.as_field_group }}
-                                    {% endif %}
-                                </td>
-                            {% endfor %}
-                            <td class="pt-2">
-                                {{ row.form.text.as_field_group }}
-                            </td>
-                        </tr>
-                    {% empty %}
-                        <tr>
-                            <td colspan=10>{% translate "You don’t seem to have any proposals yet." %}</td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-        <div id="submitBar">
-            <button type="submit" class="btn btn-success">{{ phrases.base.save }}</button>
-        </div>
-    </form>
+    <div id="submitBar">
+      <button type="submit" class="btn btn-success">{{ phrases.base.save }}</button>
+    </div>
+  </form>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/review/dashboard.html
+++ b/src/pretalx/orga/templates/orga/review/dashboard.html
@@ -7,319 +7,319 @@
 {% load static %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" type="text/css" href="{% static "vendored/rslider/rSlider.min.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
+  <link rel="stylesheet" type="text/css" href="{% static "vendored/rslider/rSlider.min.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "vendored/rslider/rSlider.min.js" %}"></script>
-        <script defer src="{% static "orga/js/submission_filter.js" %}"></script>
-        <script defer src="{% static "orga/js/review.js" %}"></script>
-        <script defer src="{% static "common/js/lightbox.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "vendored/rslider/rSlider.min.js" %}"></script>
+    <script defer src="{% static "orga/js/submission_filter.js" %}"></script>
+    <script defer src="{% static "orga/js/review.js" %}"></script>
+    <script defer src="{% static "common/js/lightbox.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{% translate "Reviews" %} :: {% endblock extra_title %}
 
 {% block content %}
-    {% has_perm "orga.perform_reviews" request.user request.event as can_review %}
-    {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
-    <div class="alert alert-info">
-        <div>
-            {% if can_review and next_submission %}
-                {% blocktranslate trimmed count count=missing_reviews %}
-                    {{ count }} proposal is waiting for your review.
-                {% plural %}
-                    {{ count }} proposals are waiting for your review.
-                {% endblocktranslate %}
-                <a href="{{ next_submission.orga_urls.reviews }}">{% translate "Click here to get started!" %}</a>
-                <br>
-                <small><a href="{{ request.event.orga_urls.reviews }}bulk/">{% translate "Or review all proposals at once." %}</a></small>
-            {% elif can_review %}
-                {% translate "You’ve got no proposals left to review!" %}
-            {% else %}
-                {% if not reviews_open %}
-                    {% translate "Reviews are currently closed." %}
-                {% else %}
-                    {% translate "You don’t have reviewer permissions for this event." %}
-                {% endif %}
+  {% has_perm "orga.perform_reviews" request.user request.event as can_review %}
+  {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
+  <div class="alert alert-info">
+    <div>
+      {% if can_review and next_submission %}
+        {% blocktranslate trimmed count count=missing_reviews %}
+          {{ count }} proposal is waiting for your review.
+        {% plural %}
+          {{ count }} proposals are waiting for your review.
+        {% endblocktranslate %}
+        <a href="{{ next_submission.orga_urls.reviews }}">{% translate "Click here to get started!" %}</a>
+        <br>
+        <small><a href="{{ request.event.orga_urls.reviews }}bulk/">{% translate "Or review all proposals at once." %}</a></small>
+      {% elif can_review %}
+        {% translate "You’ve got no proposals left to review!" %}
+      {% else %}
+        {% if not reviews_open %}
+          {% translate "Reviews are currently closed." %}
+        {% else %}
+          {% translate "You don’t have reviewer permissions for this event." %}
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="ml-auto mb-2 d-flex">
+    <details class="dropdown flip ml-auto fix-height mr-2" aria-haspopup="menu" role="menu">
+      <summary class="btn btn-secondary">
+        {% translate "Columns" %} <i class="fa fa-caret-down"></i>
+      </summary>
+      <div id="column-select" class="dropdown-content dropdown-content-s{% if rtl %}w{% else %}e{% endif %}">
+        {% if can_see_all_reviews %}
+          <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
+            <input type="checkbox" id="col-score-avg" checked autocomplete=off>
+            <label for="col-score-avg">{% translate "Score" %}</label>
+          </li>
+        {% endif %}
+        {% if can_review or submissions_reviewed %}
+          <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
+            <input type="checkbox" id="col-score-user" checked autocomplete=off>
+            <label for="col-score-user">{% translate "Your score" %}</label>
+          </li>
+        {% endif %}
+        {% if can_review or submissions_reviewed %}
+          <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
+            <input type="checkbox" id="col-review-count" checked autocomplete=off>
+            <label for="col-review-count">{% translate "Reviews" %}</label>
+          </li>
+        {% endif %}
+        {% if can_view_speakers %}
+          <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
+            <input type="checkbox" id="col-speakers" checked autocomplete=off>
+            <label for="col-speakers">{{ phrases.schedule.speakers }}</label>
+          </li>
+        {% endif %}
+        {% for question in short_questions %}
+          <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
+            <input type="checkbox" id="col-question-{{ question.id }}" autocomplete=off>
+            <label for="col-question-{{ question.id }}">{% translate "Question" %}: {{ question.question }}</label>
+          </li>
+        {% endfor %}
+        <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
+          <input type="checkbox" id="col-track" checked autocomplete=off>
+          <label for="col-track">{% translate "Track" %}</label>
+        </li>
+        <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
+          <input type="checkbox" id="col-duration" autocomplete=off>
+          <label for="col-duration">{% translate "Duration" %}</label>
+        </li>
+        <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
+          <input type="checkbox" id="col-subtype" autocomplete=off>
+          <label for="col-subtype">{% translate "Session type" %}</label>
+        </li>
+        {% if filter_form.tags %}
+          <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
+            <input type="checkbox" id="col-tags" checked autocomplete=off>
+            <label for="col-tags">{% translate "Tags" %}</label>
+          </li>
+        {% endif %}
+        <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
+          <input type="checkbox" id="col-state" checked autocomplete=off>
+          <label for="col-state">{% translate "State" %}</label>
+        </li>
+      </div>
+    </details>
+    <details class="dropdown flip fix-height" role="menu">
+      <summary class="btn btn-info">
+        {% translate "Actions" %} <i class="fa fa-caret-down"></i>
+      </summary>
+      <div class="dropdown-content dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
+        <a class="dropdown-item" href="{{ request.event.orga_urls.reviews }}regenerate" role="menuitem" tabindex="-1">
+          <i class="fa fa-link"></i> {% translate "Regenerate decision emails" %}
+        </a>
+        <a class="dropdown-item" href="{{ request.event.orga_urls.apply_pending }}?next={{ request.path }}" role="menuitem" tabindex="-1">
+          <i class="fa fa-link"></i> {% translate "Apply pending changes" %}
+        </a>
+      </div>
+    </details>
+  </div>
+
+  {% include "orga/includes/review_filter_form.html" %}
+
+  <form method="post">
+    {% csrf_token %}
+    <div class="table-responsive-sm">
+      <table class="table table-sm review-table table-hover table-flip table-sticky">
+        <colgroup>
+          {% if can_see_all_reviews %}
+            <col class="col-score-avg nowrap numeric">
+            {% for category in independent_categories %}<col class="col-score-avg nowrap numeric">{% endfor %}
+          {% endif %}
+          {% if can_review or submissions_reviewed %}
+            <col class="nowrap col-score-user numeric">
+            {% if independent_categories and not can_see_all_reviews %}
+              {% for category in independent_categories %}<col class="col-score-avg nowrap numeric">{% endfor %}
             {% endif %}
-        </div>
-    </div>
-
-    <div class="ml-auto mb-2 d-flex">
-        <details class="dropdown flip ml-auto fix-height mr-2" aria-haspopup="menu" role="menu">
-            <summary class="btn btn-secondary">
-                {% translate "Columns" %} <i class="fa fa-caret-down"></i>
-            </summary>
-            <div id="column-select" class="dropdown-content dropdown-content-s{% if rtl %}w{% else %}e{% endif %}">
-                {% if can_see_all_reviews %}
-                    <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
-                        <input type="checkbox" id="col-score-avg" checked autocomplete=off>
-                        <label for="col-score-avg">{% translate "Score" %}</label>
-                    </li>
-                {% endif %}
-                {% if can_review or submissions_reviewed %}
-                    <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
-                        <input type="checkbox" id="col-score-user" checked autocomplete=off>
-                        <label for="col-score-user">{% translate "Your score" %}</label>
-                    </li>
-                {% endif %}
-                {% if can_review or submissions_reviewed %}
-                    <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
-                        <input type="checkbox" id="col-review-count" checked autocomplete=off>
-                        <label for="col-review-count">{% translate "Reviews" %}</label>
-                    </li>
-                {% endif %}
-                {% if can_view_speakers %}
-                    <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
-                        <input type="checkbox" id="col-speakers" checked autocomplete=off>
-                        <label for="col-speakers">{{ phrases.schedule.speakers }}</label>
-                    </li>
-                {% endif %}
-                {% for question in short_questions %}
-                    <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
-                        <input type="checkbox" id="col-question-{{ question.id }}" autocomplete=off>
-                        <label for="col-question-{{ question.id }}">{% translate "Question" %}: {{ question.question }}</label>
-                    </li>
-                {% endfor %}
-                <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
-                    <input type="checkbox" id="col-track" checked autocomplete=off>
-                    <label for="col-track">{% translate "Track" %}</label>
-                </li>
-                <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
-                    <input type="checkbox" id="col-duration" autocomplete=off>
-                    <label for="col-duration">{% translate "Duration" %}</label>
-                </li>
-                <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
-                    <input type="checkbox" id="col-subtype" autocomplete=off>
-                    <label for="col-subtype">{% translate "Session type" %}</label>
-                </li>
-                {% if filter_form.tags %}
-                    <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
-                        <input type="checkbox" id="col-tags" checked autocomplete=off>
-                        <label for="col-tags">{% translate "Tags" %}</label>
-                    </li>
-                {% endif %}
-                <li class="dropdown-item form-check" role="menuitem" tabindex="-1">
-                    <input type="checkbox" id="col-state" checked autocomplete=off>
-                    <label for="col-state">{% translate "State" %}</label>
-                </li>
-            </div>
-        </details>
-        <details class="dropdown flip fix-height" role="menu">
-            <summary class="btn btn-info">
-                {% translate "Actions" %} <i class="fa fa-caret-down"></i>
-            </summary>
-            <div class="dropdown-content dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
-                <a class="dropdown-item" href="{{ request.event.orga_urls.reviews }}regenerate" role="menuitem" tabindex="-1">
-                    <i class="fa fa-link"></i> {% translate "Regenerate decision emails" %}
-                </a>
-                <a class="dropdown-item" href="{{ request.event.orga_urls.apply_pending }}?next={{ request.path }}" role="menuitem" tabindex="-1">
-                    <i class="fa fa-link"></i> {% translate "Apply pending changes" %}
-                </a>
-            </div>
-        </details>
-    </div>
-
-    {% include "orga/includes/review_filter_form.html" %}
-
-    <form method="post">
-        {% csrf_token %}
-        <div class="table-responsive-sm">
-            <table class="table table-sm review-table table-hover table-flip table-sticky">
-                <colgroup>
-                    {% if can_see_all_reviews %}
-                        <col class="col-score-avg nowrap numeric">
-                        {% for category in independent_categories %}<col class="col-score-avg nowrap numeric">{% endfor %}
-                    {% endif %}
-                    {% if can_review or submissions_reviewed %}
-                        <col class="nowrap col-score-user numeric">
-                        {% if independent_categories and not can_see_all_reviews %}
-                            {% for category in independent_categories %}<col class="col-score-avg nowrap numeric">{% endfor %}
-                        {% endif %}
-                    {% endif %}
-                    <col class="nowrap col-review-count numeric">
-                    <col class="w-75">
+          {% endif %}
+          <col class="nowrap col-review-count numeric">
+          <col class="w-75">
                     {# Title #}
-                    {% if can_view_speakers %}<col class="w-25 col-speakers">{% endif %}
-                    {% for question in short_questions %}<col class="col-question-{{ question.id }} d-none">{% endfor %}
-                    {% if filter_form.track %}<col class="nowrap col-track">{% endif %}
-                    {% if filter_form.tags %}<col class="nowrap col-tags">{% endif %}
-                    <col class="nowrap d-none col-duration">
-                    {% if show_submission_types %}<col class="nowrap d-none col-subtype">{% endif %}
-                    <col class="nowrap col-state">
-                    <col class="nowrap">
-                </colgroup>
-                <thead>
-                    <tr>
-                        {% if can_see_all_reviews %}
-                            <th class="col-score-avg numeric">
-                                {% if request.event.review_settings.aggregate_method == "median" %}
-                                    {% translate "Median" %}
-                                {% else %}
-                                    {% translate "Average" %}
-                                {% endif %}
-                                <a href="{% querystring sort="score" %}"><i class="fa fa-caret-down" title="{% translate "Sort (high-low)" %}"></i></a>
-                                <a href="{% querystring sort="-score" %}"><i class="fa fa-caret-up" title="{% translate "Sort (low-high)" %}"></i></a>
-                            </th>
-                            {% if independent_categories %}
-                                {% for category in independent_categories %}
-                                    <th class="col-score-avg numeric"> {{ category.name }}</th>
-                                {% endfor %}
-                            {% endif %}
-                        {% endif %}
-                        {% if can_review or submissions_reviewed %}
-                            <th class="col-score-user numeric">
-                                {% translate "Your score" %}
-                                <a href="{% querystring sort="my_score" %}"><i class="fa fa-caret-down" title="{% translate "Sort (high-low)" %}"></i></a>
-                                <a href="{% querystring sort="-my_score" %}"><i class="fa fa-caret-up" title="{% translate "Sort (low-high)" %}"></i></a>
-                            </th>
-                            {% if independent_categories and not can_see_all_reviews %}
-                                {% for category in independent_categories %}
-                                    <th class="col-score-user numeric"> {{ category.name }}</th>
-                                {% endfor %}
-                            {% endif %}
-                        {% endif %}
-                        <th class="col-review-count numeric">
-                            {% translate "Reviews" %}
-                            <a href="{% querystring sort="count" %}"><i class="fa fa-caret-down" title="{% translate "Sort (high-low)" %}"></i></a>
-                            <a href="{% querystring sort="-count" %}"><i class="fa fa-caret-up" title="{% translate "Sort (low-high)" %}"></i></a>
-                        </th>
-                        <th>{% translate "Title" %}</th>
-                        {% if can_view_speakers %}<th class="col-speakers">{{ phrases.schedule.speakers }}</th>{% endif %}
-                        {% for question in short_questions %}
-                            <th class="col-question-{{ question.id }} d-none">{{ question.question }}</th>
-                        {% endfor %}
-                        {% if filter_form.track %}<th class="col-track">{% translate "Track" %}</th>{% endif %}
-                        <th class="d-none col-duration">{% translate "Duration" %}</th>
-                        {% if show_submission_types %}<th class="col-subtype d-none">{% translate "Type" %}</th>{% endif %}
-                        {% if filter_form.tags %}<th class="col-tags">{% translate "Tags" %}</th>{% endif %}
-                        <th class="col-state">{% translate "State" %}</th>
-                        <th><span class="action-row d-flex justify-space-around">
-                            {% if can_accept_submissions %}
-                                <div class="radio form-check accept">
-                                    <input type="radio" id="a-all" name="s-all" value="accept">
-                                    <label for="a-all" title="{% translate "Accept all" %}"></label>
-                                </div>
-                                <div class="radio form-check reject">
-                                    <input type="radio" id="r-all" name="s-all" value="reject">
-                                    <label for="r-all" title="{% translate "Reject all" %}"></label>
-                                </div>
-                                <div class="unmark-radio always-active" id="u-all" title="{% translate "Unset accept/reject vote for all" %}"><i class="fa fa-ban"></i></div>
-                            {% endif %}
-                        </span></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for submission in submissions %}
-                        <tr class="{{ submission.state }}">
-                            {% if can_see_all_reviews %}
-                                <td class="text-center col-score-avg numeric">
-                                    {% review_score submission %}
-                                </td>
-                                {% if independent_categories %}
-                                    {% for score in submission.independent_scores %}
-                                        <td class="col-score-avg numeric"> {% if score is None %}-{% else %}{{ score }}{% endif %}</td>
-                                    {% endfor %}
-                                {% endif %}
-                            {% endif %}
-                            {% if can_review or submissions_reviewed %}
-                                <td class="text-center col-score-user numeric">
-                                    {% review_score submission True %}
-                                </td>
-                                {% if not can_see_all_reviews and independent_categories %}
-                                    {% for score in submission.independent_scores %}
-                                        <td class="col-score-user numeric"> {% if score is None %}-{% else %}{{ score }}{% endif %}</td>
-                                    {% endfor %}
-                                {% endif %}
-                            {% endif %}
-                            <td class="text-center col-review-count numeric">
-                                {{ submission.review_nonnull_count|default:"-" }}
-                                {% if submission.review_count != submission.review_nonnull_count %}({{ submission.review_count|default:"-" }}){% endif %}
-                                {% if submission.pk in submissions_reviewed %}
-                                    <i class="fa fa-check text-success" title="{% translate "You have reviewed this proposal" %}"></i>
-                                {% elif request.user in submission.speakers.all %}
-                                    <i class="fa fa-check text-muted" title="{% translate "You cannot review this proposal" %}"></i>
-                                {% endif %}
-                                {% if submission.is_assigned %}
-                                    <i class="fa fa-star text-warning" title="{% translate "You have been assigned to this proposal" %}"></i>
-                                {% endif %}
-                            </td>
-                            <td>
-                                <a href="{% if can_review %}{{ submission.orga_urls.reviews }}{% else %}{{ submission.orga_urls.base }}{% endif %}">
-                                    {% if can_view_speakers %}{{ submission.title }}{% else %}{{ submission.anonymised.title|default:submission.title }}{% endif %}
-                                </a>
-                            </td>
-                            {% if can_view_speakers %}<td class="col-speakers">
-                                {% for speaker in submission.speakers.all %}
-                                    {% include "orga/includes/user_name.html" with user=speaker lightbox=True %}<br>
-                                {% endfor %}
-                            </td>{% endif %}
-                            {% if short_questions %}
-                                {% for answer in submission.short_answers %}
-                                    <td class="col-question-{{ answer.question_id }} d-none">
-                                        {{ answer.answer_string }}
-                                    </td>
-                                {% endfor %}
-                            {% endif %}
-                            {% if filter_form.track %}<td class="col-track">{{ submission.track.name }}</td>{% endif %}
-                            <td class="d-none col-duration">{{ submission.export_duration }}</td>
-                            {% if show_submission_types %}<td class="col-subtype d-none">{{ submission.submission_type.name }}</td>{% endif %}
-                            {% if filter_form.tags %}<td class="col-tags">
-                                <div class="d-flex flex-column">
-                                    {% for tag in submission.tags.all %}
-                                        {{ tag.tag }}
-                                    {% endfor %}
-                                </div>
-                            </td>{% endif %}
-                            <td class="nowrap col-state">
-                                {% include "cfp/event/fragment_state.html" with state=submission.state %}
-                                {% if submission.pending_state %}<br>
-                                    ({% translate "pending" %} {% include "cfp/event/fragment_state.html" with state=submission.pending_state %})
-                                {% endif %}
-                            </td>
-                            <td><div class="action-row d-flex justify-space-around">
-                                {% if submission.state == "submitted" and can_accept_submissions %}
-                                    <div class="radio form-check accept">
-                                        <input type="radio" id="a-{{ submission.code }}" name="s-{{ submission.code }}" value="accept">
+          {% if can_view_speakers %}<col class="w-25 col-speakers">{% endif %}
+          {% for question in short_questions %}<col class="col-question-{{ question.id }} d-none">{% endfor %}
+          {% if filter_form.track %}<col class="nowrap col-track">{% endif %}
+          {% if filter_form.tags %}<col class="nowrap col-tags">{% endif %}
+          <col class="nowrap d-none col-duration">
+          {% if show_submission_types %}<col class="nowrap d-none col-subtype">{% endif %}
+          <col class="nowrap col-state">
+          <col class="nowrap">
+        </colgroup>
+        <thead>
+          <tr>
+            {% if can_see_all_reviews %}
+              <th class="col-score-avg numeric">
+                {% if request.event.review_settings.aggregate_method == "median" %}
+                  {% translate "Median" %}
+                {% else %}
+                  {% translate "Average" %}
+                {% endif %}
+                <a href="{% querystring sort="score" %}"><i class="fa fa-caret-down" title="{% translate "Sort (high-low)" %}"></i></a>
+                <a href="{% querystring sort="-score" %}"><i class="fa fa-caret-up" title="{% translate "Sort (low-high)" %}"></i></a>
+              </th>
+              {% if independent_categories %}
+                {% for category in independent_categories %}
+                  <th class="col-score-avg numeric"> {{ category.name }}</th>
+                {% endfor %}
+              {% endif %}
+            {% endif %}
+            {% if can_review or submissions_reviewed %}
+              <th class="col-score-user numeric">
+                {% translate "Your score" %}
+                <a href="{% querystring sort="my_score" %}"><i class="fa fa-caret-down" title="{% translate "Sort (high-low)" %}"></i></a>
+                <a href="{% querystring sort="-my_score" %}"><i class="fa fa-caret-up" title="{% translate "Sort (low-high)" %}"></i></a>
+              </th>
+              {% if independent_categories and not can_see_all_reviews %}
+                {% for category in independent_categories %}
+                  <th class="col-score-user numeric"> {{ category.name }}</th>
+                {% endfor %}
+              {% endif %}
+            {% endif %}
+            <th class="col-review-count numeric">
+              {% translate "Reviews" %}
+              <a href="{% querystring sort="count" %}"><i class="fa fa-caret-down" title="{% translate "Sort (high-low)" %}"></i></a>
+              <a href="{% querystring sort="-count" %}"><i class="fa fa-caret-up" title="{% translate "Sort (low-high)" %}"></i></a>
+            </th>
+            <th>{% translate "Title" %}</th>
+            {% if can_view_speakers %}<th class="col-speakers">{{ phrases.schedule.speakers }}</th>{% endif %}
+            {% for question in short_questions %}
+              <th class="col-question-{{ question.id }} d-none">{{ question.question }}</th>
+            {% endfor %}
+            {% if filter_form.track %}<th class="col-track">{% translate "Track" %}</th>{% endif %}
+            <th class="d-none col-duration">{% translate "Duration" %}</th>
+            {% if show_submission_types %}<th class="col-subtype d-none">{% translate "Type" %}</th>{% endif %}
+            {% if filter_form.tags %}<th class="col-tags">{% translate "Tags" %}</th>{% endif %}
+            <th class="col-state">{% translate "State" %}</th>
+            <th><span class="action-row d-flex justify-space-around">
+              {% if can_accept_submissions %}
+                <div class="radio form-check accept">
+                  <input type="radio" id="a-all" name="s-all" value="accept">
+                  <label for="a-all" title="{% translate "Accept all" %}"></label>
+                </div>
+                <div class="radio form-check reject">
+                  <input type="radio" id="r-all" name="s-all" value="reject">
+                  <label for="r-all" title="{% translate "Reject all" %}"></label>
+                </div>
+                <div class="unmark-radio always-active" id="u-all" title="{% translate "Unset accept/reject vote for all" %}"><i class="fa fa-ban"></i></div>
+              {% endif %}
+            </span></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for submission in submissions %}
+            <tr class="{{ submission.state }}">
+              {% if can_see_all_reviews %}
+                <td class="text-center col-score-avg numeric">
+                  {% review_score submission %}
+                </td>
+                {% if independent_categories %}
+                  {% for score in submission.independent_scores %}
+                    <td class="col-score-avg numeric"> {% if score is None %}-{% else %}{{ score }}{% endif %}</td>
+                  {% endfor %}
+                {% endif %}
+              {% endif %}
+              {% if can_review or submissions_reviewed %}
+                <td class="text-center col-score-user numeric">
+                  {% review_score submission True %}
+                </td>
+                {% if not can_see_all_reviews and independent_categories %}
+                  {% for score in submission.independent_scores %}
+                    <td class="col-score-user numeric"> {% if score is None %}-{% else %}{{ score }}{% endif %}</td>
+                  {% endfor %}
+                {% endif %}
+              {% endif %}
+              <td class="text-center col-review-count numeric">
+                {{ submission.review_nonnull_count|default:"-" }}
+                {% if submission.review_count != submission.review_nonnull_count %}({{ submission.review_count|default:"-" }}){% endif %}
+                {% if submission.pk in submissions_reviewed %}
+                  <i class="fa fa-check text-success" title="{% translate "You have reviewed this proposal" %}"></i>
+                {% elif request.user in submission.speakers.all %}
+                  <i class="fa fa-check text-muted" title="{% translate "You cannot review this proposal" %}"></i>
+                {% endif %}
+                {% if submission.is_assigned %}
+                  <i class="fa fa-star text-warning" title="{% translate "You have been assigned to this proposal" %}"></i>
+                {% endif %}
+              </td>
+              <td>
+                <a href="{% if can_review %}{{ submission.orga_urls.reviews }}{% else %}{{ submission.orga_urls.base }}{% endif %}">
+                  {% if can_view_speakers %}{{ submission.title }}{% else %}{{ submission.anonymised.title|default:submission.title }}{% endif %}
+                </a>
+              </td>
+              {% if can_view_speakers %}<td class="col-speakers">
+                {% for speaker in submission.speakers.all %}
+                  {% include "orga/includes/user_name.html" with user=speaker lightbox=True %}<br>
+                {% endfor %}
+              </td>{% endif %}
+              {% if short_questions %}
+                {% for answer in submission.short_answers %}
+                  <td class="col-question-{{ answer.question_id }} d-none">
+                    {{ answer.answer_string }}
+                  </td>
+                {% endfor %}
+              {% endif %}
+              {% if filter_form.track %}<td class="col-track">{{ submission.track.name }}</td>{% endif %}
+              <td class="d-none col-duration">{{ submission.export_duration }}</td>
+              {% if show_submission_types %}<td class="col-subtype d-none">{{ submission.submission_type.name }}</td>{% endif %}
+              {% if filter_form.tags %}<td class="col-tags">
+                <div class="d-flex flex-column">
+                  {% for tag in submission.tags.all %}
+                    {{ tag.tag }}
+                  {% endfor %}
+                </div>
+              </td>{% endif %}
+              <td class="nowrap col-state">
+                {% include "cfp/event/fragment_state.html" with state=submission.state %}
+                {% if submission.pending_state %}<br>
+                  ({% translate "pending" %} {% include "cfp/event/fragment_state.html" with state=submission.pending_state %})
+                {% endif %}
+              </td>
+              <td><div class="action-row d-flex justify-space-around">
+                {% if submission.state == "submitted" and can_accept_submissions %}
+                  <div class="radio form-check accept">
+                    <input type="radio" id="a-{{ submission.code }}" name="s-{{ submission.code }}" value="accept">
                                         {% comment %}Translators: This is a button to mark a proposal as accepted{% endcomment %}
-                                        <label for="a-{{ submission.code }}" title="{% translate "Accept" %}"></label>
-                                    </div>
-                                    <div class="radio form-check reject">
-                                        <input type="radio" id="r-{{ submission.code }}" name="s-{{ submission.code }}" value="reject">
+                    <label for="a-{{ submission.code }}" title="{% translate "Accept" %}"></label>
+                  </div>
+                  <div class="radio form-check reject">
+                    <input type="radio" id="r-{{ submission.code }}" name="s-{{ submission.code }}" value="reject">
                                         {% comment %}Translators: This is a button to mark a proposal as rejected{% endcomment %}
-                                        <label for="r-{{ submission.code }}" title="{% translate "Reject" %}"></label>
-                                    </div>
-                                    <div class="unmark-radio" title="{% translate "Unset accept/reject vote" %}"><i class="fa fa-ban"></i></div>
-                                {% endif %}
-                            </div></td>
-                        </tr>
-                    {% empty %}
-                        <tr>
-                            <td colspan=10>{% translate "You don’t seem to have any proposals yet." %}</td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-        <div id="submitBar">
-            <div id="pending" class="form-check mr-2">
-                <input type="checkbox" id="id_pending" name="pending">
-                <label for="id_pending">{% translate "Mark the new state as “pending”" %}</label>
-            </div>
-            <i class="fa fa-question-circle mr-4" data-toggle="tooltip" data-placement="top" title="{% translate "If you mark state changes as pending, they won’t be visible to speakers right away. You can always apply pending changes for some or all proposals in one go once you’re ready to make your decisions public." %}"></i>
-            <span id="submitText" class="d-none ml-2">
-                {% translate "Accept" %}: <span id="acceptCount" class="text-success"></span>
-                {% translate "Reject" %}: <span id="rejectCount" class="text-danger"></span>
-            </span>
-            <button type="submit" class="btn btn-success">{% translate "Go!" %}</button>
-        </div>
-    </form>
-    {% if page_obj.paginator.count > 50 %}
+                    <label for="r-{{ submission.code }}" title="{% translate "Reject" %}"></label>
+                  </div>
+                  <div class="unmark-radio" title="{% translate "Unset accept/reject vote" %}"><i class="fa fa-ban"></i></div>
+                {% endif %}
+              </div></td>
+            </tr>
+          {% empty %}
+            <tr>
+              <td colspan=10>{% translate "You don’t seem to have any proposals yet." %}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div id="submitBar">
+      <div id="pending" class="form-check mr-2">
+        <input type="checkbox" id="id_pending" name="pending">
+        <label for="id_pending">{% translate "Mark the new state as “pending”" %}</label>
+      </div>
+      <i class="fa fa-question-circle mr-4" data-toggle="tooltip" data-placement="top" title="{% translate "If you mark state changes as pending, they won’t be visible to speakers right away. You can always apply pending changes for some or all proposals in one go once you’re ready to make your decisions public." %}"></i>
+      <span id="submitText" class="d-none ml-2">
+        {% translate "Accept" %}: <span id="acceptCount" class="text-success"></span>
+        {% translate "Reject" %}: <span id="rejectCount" class="text-danger"></span>
+      </span>
+      <button type="submit" class="btn btn-success">{% translate "Go!" %}</button>
+    </div>
+  </form>
+  {% if page_obj.paginator.count > 50 %}
 
-        {% include "orga/includes/pagination.html" %}
+    {% include "orga/includes/pagination.html" %}
 
-    {% endif %}
+  {% endif %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/review/export.html
+++ b/src/pretalx/orga/templates/orga/review/export.html
@@ -5,73 +5,73 @@
 {% block extra_title %}{% translate "Export review data" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Export review data" %}</h2>
+  <h2>{% translate "Export review data" %}</h2>
 
-    {% include "orga/includes/tablist.html" %}
+  {% include "orga/includes/tablist.html" %}
 
-    <section role="tabpanel" id="tabpanel-custom" aria-labelledby="tab-custom" tabindex="0" aria-hidden="false">
-        <p>
-            {% blocktranslate trimmed %}
-                Build your own custom export here, by selecting all the data you need,
-                and the export format. CSV exports can be opened with Excel and similar
-                applications, while JSON exports are often used for integration with
-                other tools.
-            {% endblocktranslate %}
-        </p>
-        <form method="post">
-            {% csrf_token %}
-            <fieldset>
-                <legend>{% translate "Dataset" %}</legend>
-                {{ form.target.as_field_group }}
-            </fieldset>
-            <fieldset>
-                <legend>{% translate "Data fields" %}</legend>
-                <div class="d-flex">
-                    <div class="ml-auto form-check">
-                        <input type="checkbox" id="select-all" name="select-all">
-                        <label for="select-all">{% translate "Select all" %}</label>
-                    </div>
-                </div>
-                {% for field in form.export_fields %}
-                    {{ field.as_field_group }}
-                {% endfor %}
-            </fieldset>
-            <fieldset>
-                <legend>{% translate "Export settings" %}</legend>
-                {{ form.export_format.as_field_group }}
-            </fieldset>
+  <section role="tabpanel" id="tabpanel-custom" aria-labelledby="tab-custom" tabindex="0" aria-hidden="false">
+    <p>
+      {% blocktranslate trimmed %}
+        Build your own custom export here, by selecting all the data you need,
+        and the export format. CSV exports can be opened with Excel and similar
+        applications, while JSON exports are often used for integration with
+        other tools.
+      {% endblocktranslate %}
+    </p>
+    <form method="post">
+      {% csrf_token %}
+      <fieldset>
+        <legend>{% translate "Dataset" %}</legend>
+        {{ form.target.as_field_group }}
+      </fieldset>
+      <fieldset>
+        <legend>{% translate "Data fields" %}</legend>
+        <div class="d-flex">
+          <div class="ml-auto form-check">
+            <input type="checkbox" id="select-all" name="select-all">
+            <label for="select-all">{% translate "Select all" %}</label>
+          </div>
+        </div>
+        {% for field in form.export_fields %}
+          {{ field.as_field_group }}
+        {% endfor %}
+      </fieldset>
+      <fieldset>
+        <legend>{% translate "Export settings" %}</legend>
+        {{ form.export_format.as_field_group }}
+      </fieldset>
 
-            {% include "orga/includes/submit_row.html" %}
+      {% include "orga/includes/submit_row.html" %}
 
-        </form>
+    </form>
 
-    </section>
-    <section role="tabpanel" id="tabpanel-api" aria-labelledby="tab-api" tabindex="0" aria-hidden="true">
-        <p>
-            {% translate "You can also use the API to export or use data." %}
-        </p>
+  </section>
+  <section role="tabpanel" id="tabpanel-api" aria-labelledby="tab-api" tabindex="0" aria-hidden="true">
+    <p>
+      {% translate "You can also use the API to export or use data." %}
+    </p>
 
-        <p>
-            {% blocktranslate trimmed %}
-                Some of the general exports are only accessible for organisers, or include
-                more information when accessed with your organiser account. If you want to
-                access the organiser version in automatic integrations, you’ll have to
-                provide your authentication token just like in the API, like this:
-            {% endblocktranslate %}
-        </p>
+    <p>
+      {% blocktranslate trimmed %}
+        Some of the general exports are only accessible for organisers, or include
+        more information when accessed with your organiser account. If you want to
+        access the organiser version in automatic integrations, you’ll have to
+        provide your authentication token just like in the API, like this:
+      {% endblocktranslate %}
+    </p>
 
             <pre> curl -H "Authorization: Token {{ request.user.auth_token.key }}" {{ request.event.api_urls.reviews.full }} </pre>
 
-        <div class="submit-group"><span></span><span>
-            <a class="btn btn-lg btn-info" href="#">
-                <i class="fa fa-book"></i>
-                {% translate "Documentation" %}
-            </a>
-            <a class="btn btn-lg btn-success" href="{{ request.event.api_urls.base }}">
-                {% translate "Go to API" %}
-            </a>
-        </span>
-        </div>
-    </section>
-    <script defer src="{% static "orga/js/speaker_export.js" %}"></script>
+    <div class="submit-group"><span></span><span>
+      <a class="btn btn-lg btn-info" href="#">
+        <i class="fa fa-book"></i>
+        {% translate "Documentation" %}
+      </a>
+      <a class="btn btn-lg btn-success" href="{{ request.event.api_urls.base }}">
+        {% translate "Go to API" %}
+      </a>
+    </span>
+    </div>
+  </section>
+  <script defer src="{% static "orga/js/speaker_export.js" %}"></script>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/schedule/base.html
+++ b/src/pretalx/orga/templates/orga/schedule/base.html
@@ -1,5 +1,5 @@
 {% extends "orga/base.html" %}
 
 {% block content %}
-    {% block schedule_content %}{% endblock schedule_content %}
+  {% block schedule_content %}{% endblock schedule_content %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/schedule/export.html
+++ b/src/pretalx/orga/templates/orga/schedule/export.html
@@ -7,141 +7,141 @@
 {% block extra_title %}{% translate "Export schedule data" %} :: {% endblock extra_title %}
 
 {% block schedule_content %}
-    <h2>{% translate "Export schedule data" %}</h2>
+  <h2>{% translate "Export schedule data" %}</h2>
 
-    {% include "orga/includes/tablist.html" %}
+  {% include "orga/includes/tablist.html" %}
 
-    <section role="tabpanel" id="tabpanel-custom" aria-labelledby="tab-custom" tabindex="0" aria-hidden="false">
-        <form method="post">
-            {% csrf_token %}
-            {% include "common/forms/errors.html" %}
-            <fieldset>
-                <legend>{% translate "Export settings" %}</legend>
-                {{ form.export_format.as_field_group }}
-                <div id="data-delimiter">
-                    {{ form.data_delimiter.as_field_group }}
-                </div>
-            </fieldset>
-            <fieldset>
-                <legend>{% translate "Dataset" %}</legend>
-                {{ form.target.as_field_group }}
-            </fieldset>
-            <fieldset>
-                <legend>{% translate "Data fields" %}</legend>
-                <div class="d-flex">
-                    <div class="ml-auto form-check">
-                        <input type="checkbox" id="select-all" name="select-all">
-                        <label for="select-all">{% translate "Select all" %}</label>
-                    </div>
-                </div>
-                {% for field in form.export_fields %}
-                    {{ field.as_field_group }}
-                {% endfor %}
-            </fieldset>
-
-            {% include "orga/includes/submit_row.html" %}
-        </form>
-    </section>
-
-    <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="true">
-        {% blocktranslate trimmed %}
-            eventyay provides a range of exports. If none of these match what you are looking
-            for, you can also provide a custom plugin to export the data – please ask
-            your administrator to install the plugin.
-        {% endblocktranslate %}
-        {% blocktranslate trimmed %}
-            If you are looking for exports of proposals, sessions or schedule data, please head
-            here:
-        {% endblocktranslate %}
-        <a class="btn btn-outline-info btn-sm" href="{{ request.event.orga_urls.speakers }}export/">{% translate "Speaker exports" %}</a>
-        {% if not request.event.current_schedule %}
-            <div class="alert alert-warning">
-                {% blocktranslate trimmed %}
-                    You haven’t released a schedule yet – many of these data exporters only work on a released schedule.
-                {% endblocktranslate %}
-            </div>
-        {% endif %}
-        <ul>
-            {% for exporter in exporters %}
-                <li>
-                    <a href="{{ exporter.urls.base }}">
-                        {% if exporter.icon|slice:":3" == "fa-" %}
-                            <i class="fa {{ exporter.icon }}"></i>
-                        {% else %}
-                            {{ exporter.icon }}
-                        {% endif %}
-                        {{ exporter.verbose_name }}
-                        {% if exporter.show_qrcode %}
-                            <span class="export-qrcode">
-                                <i class="fa fa-qrcode"></i>
-                                <div class="export-qrcode-image">{{ exporter.get_qrcode }}</div>
-                            </span>
-                        {% endif %}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-
-        <hr>
-        <h3>{% translate "HTML Export" %}</h3>
-
-        <p>
-            {% blocktranslate trimmed %}
-                The event schedule can be exported to a static HTML dump, so you can upload it
-                to a normal file-serving web server like nginx.
-            {% endblocktranslate %}
-            {% if request.export_html_on_release %}
-                {% blocktranslate trimmed %}
-                    This is done automatically on
-                    schedule release, but you can also trigger that action here.
-                {% endblocktranslate %}
-            {% endif %}
-        </p>
-
-        <div class="submit-group"><span></span><span>
-            <a href="{{ request.event.orga_urls.schedule_export_download }}" class="btn btn-lg btn-info">
-                <i class="fa fa-download"></i>
-                {% translate "Download ZIP" %}
-            </a>
-            <form action="{{ request.event.orga_urls.schedule_export_trigger }}" method="POST" class="d-inline-block">
-                {% csrf_token %}
-                <button type="submit" class="btn btn-lg btn-success">
-                    <i class="fa fa-refresh"></i>
-                    {% translate "Regenerate Export" %}
-                </button>
-            </form>
-        </span>
+  <section role="tabpanel" id="tabpanel-custom" aria-labelledby="tab-custom" tabindex="0" aria-hidden="false">
+    <form method="post">
+      {% csrf_token %}
+      {% include "common/forms/errors.html" %}
+      <fieldset>
+        <legend>{% translate "Export settings" %}</legend>
+        {{ form.export_format.as_field_group }}
+        <div id="data-delimiter">
+          {{ form.data_delimiter.as_field_group }}
         </div>
-    </section>
-    <section role="tabpanel" id="tabpanel-api" aria-labelledby="tab-api" tabindex="0" aria-hidden="true">
+      </fieldset>
+      <fieldset>
+        <legend>{% translate "Dataset" %}</legend>
+        {{ form.target.as_field_group }}
+      </fieldset>
+      <fieldset>
+        <legend>{% translate "Data fields" %}</legend>
+        <div class="d-flex">
+          <div class="ml-auto form-check">
+            <input type="checkbox" id="select-all" name="select-all">
+            <label for="select-all">{% translate "Select all" %}</label>
+          </div>
+        </div>
+        {% for field in form.export_fields %}
+          {{ field.as_field_group }}
+        {% endfor %}
+      </fieldset>
 
-        <h3>{% translate "API" %}</h3>
+      {% include "orga/includes/submit_row.html" %}
+    </form>
+  </section>
 
-        <p>{% translate "You can also use the API to export or use data." %}</p>
+  <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="true">
+    {% blocktranslate trimmed %}
+      eventyay provides a range of exports. If none of these match what you are looking
+      for, you can also provide a custom plugin to export the data – please ask
+      your administrator to install the plugin.
+    {% endblocktranslate %}
+    {% blocktranslate trimmed %}
+      If you are looking for exports of proposals, sessions or schedule data, please head
+      here:
+    {% endblocktranslate %}
+    <a class="btn btn-outline-info btn-sm" href="{{ request.event.orga_urls.speakers }}export/">{% translate "Speaker exports" %}</a>
+    {% if not request.event.current_schedule %}
+      <div class="alert alert-warning">
+        {% blocktranslate trimmed %}
+          You haven’t released a schedule yet – many of these data exporters only work on a released schedule.
+        {% endblocktranslate %}
+      </div>
+    {% endif %}
+    <ul>
+      {% for exporter in exporters %}
+        <li>
+          <a href="{{ exporter.urls.base }}">
+            {% if exporter.icon|slice:":3" == "fa-" %}
+              <i class="fa {{ exporter.icon }}"></i>
+            {% else %}
+              {{ exporter.icon }}
+            {% endif %}
+            {{ exporter.verbose_name }}
+            {% if exporter.show_qrcode %}
+              <span class="export-qrcode">
+                <i class="fa fa-qrcode"></i>
+                <div class="export-qrcode-image">{{ exporter.get_qrcode }}</div>
+              </span>
+            {% endif %}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
 
-        <p>
-            {% blocktranslate trimmed %}
-                Some of the general exports are only accessible for organisers, or include
-                more information when accessed with your organiser account. If you want to
-                access the organiser version in automatic integrations, you’ll have to
-                provide your authentication token just like in the API, like this:
-            {% endblocktranslate %}
-        </p>
+    <hr>
+    <h3>{% translate "HTML Export" %}</h3>
+
+    <p>
+      {% blocktranslate trimmed %}
+        The event schedule can be exported to a static HTML dump, so you can upload it
+        to a normal file-serving web server like nginx.
+      {% endblocktranslate %}
+      {% if request.export_html_on_release %}
+        {% blocktranslate trimmed %}
+          This is done automatically on
+          schedule release, but you can also trigger that action here.
+        {% endblocktranslate %}
+      {% endif %}
+    </p>
+
+    <div class="submit-group"><span></span><span>
+      <a href="{{ request.event.orga_urls.schedule_export_download }}" class="btn btn-lg btn-info">
+        <i class="fa fa-download"></i>
+        {% translate "Download ZIP" %}
+      </a>
+      <form action="{{ request.event.orga_urls.schedule_export_trigger }}" method="POST" class="d-inline-block">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-lg btn-success">
+          <i class="fa fa-refresh"></i>
+          {% translate "Regenerate Export" %}
+        </button>
+      </form>
+    </span>
+    </div>
+  </section>
+  <section role="tabpanel" id="tabpanel-api" aria-labelledby="tab-api" tabindex="0" aria-hidden="true">
+
+    <h3>{% translate "API" %}</h3>
+
+    <p>{% translate "You can also use the API to export or use data." %}</p>
+
+    <p>
+      {% blocktranslate trimmed %}
+        Some of the general exports are only accessible for organisers, or include
+        more information when accessed with your organiser account. If you want to
+        access the organiser version in automatic integrations, you’ll have to
+        provide your authentication token just like in the API, like this:
+      {% endblocktranslate %}
+    </p>
 
             <pre> curl -H "Authorization: Token {{ request.user.auth_token.key }}" {{ request.event.urls.frab_xml.full }}
  curl -H "Authorization: Token {{ request.user.auth_token.key }}" {{ request.event.api_urls.submissions.full }} </pre>
 
-        <div class="submit-group"><span></span><span>
-            <a class="btn btn-lg btn-info" href="#">
-                <i class="fa fa-book"></i>
-                {% translate "Documentation" %}
-            </a>
-            <a class="btn btn-lg btn-success" href="{{ request.event.api_urls.base }}">
-                {% translate "Go to API" %}
-            </a>
-        </span>
-        </div>
-    </section>
-    <script defer src="{% static "orga/js/speaker_export.js" %}"></script>
+    <div class="submit-group"><span></span><span>
+      <a class="btn btn-lg btn-info" href="#">
+        <i class="fa fa-book"></i>
+        {% translate "Documentation" %}
+      </a>
+      <a class="btn btn-lg btn-success" href="{{ request.event.api_urls.base }}">
+        {% translate "Go to API" %}
+      </a>
+    </span>
+    </div>
+  </section>
+  <script defer src="{% static "orga/js/speaker_export.js" %}"></script>
 
 {% endblock schedule_content %}

--- a/src/pretalx/orga/templates/orga/schedule/index.html
+++ b/src/pretalx/orga/templates/orga/schedule/index.html
@@ -8,72 +8,72 @@
 {% load vite %}
 
 {% block scripts %}
-    {% vite_hmr %}
-    {% vite_asset "src/main.js" %}
+  {% vite_hmr %}
+  {% vite_asset "src/main.js" %}
 {% endblock scripts %}
 
 {% block extra_title %}{{ phrases.schedule.schedule }} :: {% endblock extra_title %}
 
 {% block navbar_right %}
-    <li class="nav-item">
-        <a class="nav-link text-danger">
-            <i class="fa fa-clock-o"></i>
-            {% phrase "phrases.schedule.timezone_hint" tz=request.event.timezone %}
-        </a>
-    </li>
+  <li class="nav-item">
+    <a class="nav-link text-danger">
+      <i class="fa fa-clock-o"></i>
+      {% phrase "phrases.schedule.timezone_hint" tz=request.event.timezone %}
+    </a>
+  </li>
 {% endblock navbar_right %}
 
 {% block schedule_content %}
 
-    <div class="schedule-header d-flex m-3 d-print-none">
-        <div id="schedule-action-wrapper" class="d-flex align-items-center ml-auto">
-            {% if not schedule_version %}
-                <a id="schedule-release" href="{{ request.event.orga_urls.release_schedule }}" class="btn ml-2 btn-success"><i class="fa fa-plus"></i> {% translate "New release" %}</a>
-            {% else %}
-                <form method="post" action="{{ request.event.orga_urls.reset_schedule }}?{{ request.GET.urlencode }}">
-                    {% csrf_token %}
-                    <button type="submit" class="btn btn-outline-danger ml-2">{% translate "Override WIP schedule with this version" %}</button>
-                </form>
-            {% endif %}
-            <details class="dropdown ml-2" aria-haspopup="menu" role="menu">
-                <summary class="btn btn-info" id="schedule-actions">
-                    {% translate "Actions" %} <i class="fa fa-caret-down"></i>
-                </summary>
+  <div class="schedule-header d-flex m-3 d-print-none">
+    <div id="schedule-action-wrapper" class="d-flex align-items-center ml-auto">
+      {% if not schedule_version %}
+        <a id="schedule-release" href="{{ request.event.orga_urls.release_schedule }}" class="btn ml-2 btn-success"><i class="fa fa-plus"></i> {% translate "New release" %}</a>
+      {% else %}
+        <form method="post" action="{{ request.event.orga_urls.reset_schedule }}?{{ request.GET.urlencode }}">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-outline-danger ml-2">{% translate "Override WIP schedule with this version" %}</button>
+        </form>
+      {% endif %}
+      <details class="dropdown ml-2" aria-haspopup="menu" role="menu">
+        <summary class="btn btn-info" id="schedule-actions">
+          {% translate "Actions" %} <i class="fa fa-caret-down"></i>
+        </summary>
 
-                <div class="dropdown-content dropdown-front dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
-                    <a class="dropdown-item" href="{{ active_schedule.urls.public }}" target="_blank" rel="noopener" role="menuitem" tabindex="-1">
-                        <i class="fa fa-link"></i> {% translate "View in frontend" %}
-                    </a>
-                    {% if request.event|get_feature_flag:"show_schedule" %}
-                        <a class="dropdown-item role="menuitem" tabindex="-1""
-                           href="{{ request.event.orga_urls.toggle_schedule }}">
-                            <i class="fa fa-eye"></i> {% translate "Hide schedule" %}
-                        </a>
-                    {% else %}
-                        <a class="dropdown-item" href="{{ request.event.orga_urls.toggle_schedule }}" role="menuitem" tabindex="-1">
-                            <i class="fa fa-eye"></i> {% translate "Make schedule public" %}
-                        </a>
-                    {% endif %}
-                    <a href="{{ request.event.orga_urls.submission_cards }}" class="dropdown-item" role="menuitem" tabindex="-1">
-                        <i class="fa fa-print"></i> {% translate "Print cards" %}
-                    </a>
-                    <a href="resend_mails" class="dropdown-item" role="menuitem" tabindex="-1">
-                        <i class="fa fa-envelope"></i> {% translate "Resend speaker notifications" %}
-                    </a>
-                </div>
-            </details>
+        <div class="dropdown-content dropdown-front dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
+          <a class="dropdown-item" href="{{ active_schedule.urls.public }}" target="_blank" rel="noopener" role="menuitem" tabindex="-1">
+            <i class="fa fa-link"></i> {% translate "View in frontend" %}
+          </a>
+          {% if request.event|get_feature_flag:"show_schedule" %}
+            <a class="dropdown-item role="menuitem" tabindex="-1""
+               href="{{ request.event.orga_urls.toggle_schedule }}">
+              <i class="fa fa-eye"></i> {% translate "Hide schedule" %}
+            </a>
+          {% else %}
+            <a class="dropdown-item" href="{{ request.event.orga_urls.toggle_schedule }}" role="menuitem" tabindex="-1">
+              <i class="fa fa-eye"></i> {% translate "Make schedule public" %}
+            </a>
+          {% endif %}
+          <a href="{{ request.event.orga_urls.submission_cards }}" class="dropdown-item" role="menuitem" tabindex="-1">
+            <i class="fa fa-print"></i> {% translate "Print cards" %}
+          </a>
+          <a href="resend_mails" class="dropdown-item" role="menuitem" tabindex="-1">
+            <i class="fa fa-envelope"></i> {% translate "Resend speaker notifications" %}
+          </a>
         </div>
+      </details>
     </div>
-    {% if not request.event.rooms.count %}
-        <div class="alert alert-warning schedule-alert">
-            <span>
-                {% translate "You can start planning your schedule once you have configured some rooms for sessions to take place in." %}
-                <a href="{{ request.event.orga_urls.new_room }}">{% translate "Configure rooms" %}</a>
-            </span>
-        </div>
-    {% else %}
+  </div>
+  {% if not request.event.rooms.count %}
+    <div class="alert alert-warning schedule-alert">
+      <span>
+        {% translate "You can start planning your schedule once you have configured some rooms for sessions to take place in." %}
+        <a href="{{ request.event.orga_urls.new_room }}">{% translate "Configure rooms" %}</a>
+      </span>
+    </div>
+  {% else %}
 
-        <div id="app" data-gettext="{{ gettext_language }}"></div>
+    <div id="app" data-gettext="{{ gettext_language }}"></div>
 
-    {% endif %}
+  {% endif %}
 {% endblock schedule_content %}

--- a/src/pretalx/orga/templates/orga/schedule/quick.html
+++ b/src/pretalx/orga/templates/orga/schedule/quick.html
@@ -7,8 +7,8 @@
 {% block extra_title %}{% translate "Schedule session" %} {{ quotation_open }}{{ form.instance.submission.title }}{{ quotation_close }} :: {% endblock extra_title %}
 
 {% block schedule_content %}
-    <h2>
-        {% translate "Schedule session" %} {{ quotation_close }}{{ form.instance.submission.title }}{{ quotation_open }}
-    </h2>
-    {% include "orga/includes/base_form.html" %}
+  <h2>
+    {% translate "Schedule session" %} {{ quotation_close }}{{ form.instance.submission.title }}{{ quotation_open }}
+  </h2>
+  {% include "orga/includes/base_form.html" %}
 {% endblock schedule_content %}

--- a/src/pretalx/orga/templates/orga/schedule/release.html
+++ b/src/pretalx/orga/templates/orga/schedule/release.html
@@ -7,134 +7,134 @@
 {% block extra_title %}{% translate "Release new schedule" %} :: {% endblock extra_title %}
 
 {% block schedule_content %}
-    <form method="post">
-        {% include "common/forms/errors.html" %}
-        {% csrf_token %}
-        <h2>
-            {% translate "Release new schedule" %}
-            <div class="d-inline-block">
-                {{ form.version.as_field_group }}
-            </div>
-        </h2>
-        {% if warnings.unconfirmed or warnings.unscheduled or warnings.no_track or warnings.talk_warnings %}
-            <div class="alert alert-warning">
-                <span></span><span>
-                    {% blocktranslate trimmed %}
-                        There are still warnings about the release of this schedule. Please review them carefully!
-                    {% endblocktranslate %}
-                </span>
-            </div>
-        {% endif %}
+  <form method="post">
+    {% include "common/forms/errors.html" %}
+    {% csrf_token %}
+    <h2>
+      {% translate "Release new schedule" %}
+      <div class="d-inline-block">
+        {{ form.version.as_field_group }}
+      </div>
+    </h2>
+    {% if warnings.unconfirmed or warnings.unscheduled or warnings.no_track or warnings.talk_warnings %}
+      <div class="alert alert-warning">
+        <span></span><span>
+          {% blocktranslate trimmed %}
+            There are still warnings about the release of this schedule. Please review them carefully!
+          {% endblocktranslate %}
+        </span>
+      </div>
+    {% endif %}
 
+    <ul>
+      <li>
+        {% if request.event.wip_schedule.previous_schedule.version %}
+          {% blocktranslate with prev=request.event.wip_schedule.previous_schedule.version since=request.event.wip_schedule.previous_schedule.published|timesince trimmed %}
+            The previous schedule ({{ prev }}) was released {{ since }} ago.
+          {% endblocktranslate %}
+        {% else %}
+          {% translate "This will be the very first schedule release." %}
+        {% endif %}
+      </li>
+      <li>
+        {% if notifications %}
+          {% blocktranslate trimmed count count=notifications %}
+            When releasing this new schedule, <strong>one notifications email
+            </strong> can be generated and placed in the outbox, to tell speakers about their
+            session slots.
+          {% plural %}
+            When releasing this new schedule, <strong>{{ count }} notifications emails
+            </strong> can be generated and placed in the outbox, to tell speakers about their
+            session slots.
+          {% endblocktranslate %}
+          <br>
+          {% translate "Email template" %}: <a href="{{ notification_template.urls.base }}">{% translate "New schedule version" %}</a>
+        {% else %}
+          {% blocktranslate trimmed %}
+            This schedule release would result in <strong>no notification emails</strong> for
+            speakers.
+          {% endblocktranslate %}
+        {% endif %}
+      </li>
+      {% if warnings.unconfirmed %}
+        <li>{% blocktranslate trimmed count count=warnings.unconfirmed %}
+          One session is still <strong>unconfirmed</strong> and will not show up
+          on the public schedule.
+        {% plural %}
+          {{ count }} sessions are still <strong>unconfirmed</strong> and will not show up
+          on the public schedule.
+        {% endblocktranslate %} <a href="{{ request.event.orga_urls.submissions }}?state=accepted&state=pending_state__accepted&state=pending_state__confirmed">{% translate "See all unconfirmed sessions." %}</a></li>
+      {% endif %}
+      {% if warnings.unscheduled %}
+        <li>{% blocktranslate trimmed count count=warnings.unscheduled %}
+          One session has <strong>not yet been scheduled</strong>.
+        {% plural %}
+          {{ count }} sessions have <strong>not yet been scheduled</strong>.
+        {% endblocktranslate %}</li>
+      {% endif %}
+      {% if warnings.no_track %}
+        <li>{% blocktranslate trimmed count count=warnings.no_track|length %}
+          One session has <strong>not yet been assigned a track</strong>.
+        {% plural %}
+          {{ count }} sessions have <strong>not yet been assigned a track</strong>.
+        {% endblocktranslate %}
+          <ul>
+            {% for talk in warnings.no_track %}
+              <li><a href="{{ talk.submission.orga_url }}">{{ quotation_open }}{{ talk.submission.title }}{{ quotation_close }}</a></li>
+            {% endfor %}
+          </ul>
+        </li>
+      {% endif %}
+    </ul>
+    {% if warnings.talk_warnings %}
+      <details>
+        <summary class="pb-1">
+          <h4 class="d-inline-flex">{{ warnings.talk_warnings|length }} {% translate "Warnings" %}</h4>
+          <hr class="ml-3 mr-3 mt-0 mr-0">
+        </summary>
         <ul>
-            <li>
-                {% if request.event.wip_schedule.previous_schedule.version %}
-                    {% blocktranslate with prev=request.event.wip_schedule.previous_schedule.version since=request.event.wip_schedule.previous_schedule.published|timesince trimmed %}
-                        The previous schedule ({{ prev }}) was released {{ since }} ago.
-                    {% endblocktranslate %}
-                {% else %}
-                    {% translate "This will be the very first schedule release." %}
-                {% endif %}
-            </li>
-            <li>
-                {% if notifications %}
-                    {% blocktranslate trimmed count count=notifications %}
-                        When releasing this new schedule, <strong>one notifications email
-                        </strong> can be generated and placed in the outbox, to tell speakers about their
-                        session slots.
-                    {% plural %}
-                        When releasing this new schedule, <strong>{{ count }} notifications emails
-                        </strong> can be generated and placed in the outbox, to tell speakers about their
-                        session slots.
-                    {% endblocktranslate %}
-                    <br>
-                    {% translate "Email template" %}: <a href="{{ notification_template.urls.base }}">{% translate "New schedule version" %}</a>
-                {% else %}
-                    {% blocktranslate trimmed %}
-                        This schedule release would result in <strong>no notification emails</strong> for
-                        speakers.
-                    {% endblocktranslate %}
-                {% endif %}
-            </li>
-            {% if warnings.unconfirmed %}
-                <li>{% blocktranslate trimmed count count=warnings.unconfirmed %}
-                    One session is still <strong>unconfirmed</strong> and will not show up
-                    on the public schedule.
-                {% plural %}
-                    {{ count }} sessions are still <strong>unconfirmed</strong> and will not show up
-                    on the public schedule.
-                {% endblocktranslate %} <a href="{{ request.event.orga_urls.submissions }}?state=accepted&state=pending_state__accepted&state=pending_state__confirmed">{% translate "See all unconfirmed sessions." %}</a></li>
-            {% endif %}
-            {% if warnings.unscheduled %}
-                <li>{% blocktranslate trimmed count count=warnings.unscheduled %}
-                    One session has <strong>not yet been scheduled</strong>.
-                {% plural %}
-                    {{ count }} sessions have <strong>not yet been scheduled</strong>.
-                {% endblocktranslate %}</li>
-            {% endif %}
-            {% if warnings.no_track %}
-                <li>{% blocktranslate trimmed count count=warnings.no_track|length %}
-                    One session has <strong>not yet been assigned a track</strong>.
-                {% plural %}
-                    {{ count }} sessions have <strong>not yet been assigned a track</strong>.
-                {% endblocktranslate %}
-                    <ul>
-                        {% for talk in warnings.no_track %}
-                            <li><a href="{{ talk.submission.orga_url }}">{{ quotation_open }}{{ talk.submission.title }}{{ quotation_close }}</a></li>
-                        {% endfor %}
-                    </ul>
-                </li>
-            {% endif %}
+          {% for talk in warnings.talk_warnings %}
+            {% for warning in talk.warnings %}
+              <li><a href="{{ warning.url }}">{{ quotation_open }}{{ talk.talk.submission.title }}{{ quotation_close }}</a>: {{ warning.message }}</li>
+            {% endfor %}
+          {% endfor %}
         </ul>
-        {% if warnings.talk_warnings %}
-            <details>
-                <summary class="pb-1">
-                    <h4 class="d-inline-flex">{{ warnings.talk_warnings|length }} {% translate "Warnings" %}</h4>
-                    <hr class="ml-3 mr-3 mt-0 mr-0">
-                </summary>
-                <ul>
-                    {% for talk in warnings.talk_warnings %}
-                        {% for warning in talk.warnings %}
-                            <li><a href="{{ warning.url }}">{{ quotation_open }}{{ talk.talk.submission.title }}{{ quotation_close }}</a>: {{ warning.message }}</li>
-                        {% endfor %}
-                    {% endfor %}
-                </ul>
-            </details>
+      </details>
 
-        {% endif %}
+    {% endif %}
 
-        <details open>
-            <summary class="pb-3">
-                <div class="d-inline-flex flex-column">
-                    <h4>{% translate "Public changelog" %}</h4>
-                    {% translate "This is how the new schedule version will appear in the public changelog and in the RSS feed." %}
-                    {% translate "You can include a comment here." %}
-                </div>
-                <hr class="ml-3 mr-3 mt-0 mr-0">
-            </summary>
-
-            <div id="fake-changelog">
-                <h4>
-                    {{ phrases.schedule.version }}  {{ suggested_version }}
-                </h4>
-                <div class="flex-next-column">
-                    {{ form.comment.as_field_group }}
-                </div>
-                {% include "agenda/changelog_block.html" with schedule=request.event.wip_schedule %}
-            </div>
-        </details>
-
-        <div class="submit-group" id="release">
-            <div class="d-flex align-items-center">
-                <a href="{{ request.event.orga_urls.schedule }}" class="btn btn-info btn-lg">
-                    {{ phrases.base.back_button }}
-                </a>
-            </div>
-            <div class="d-flex align-items-center justify-content-end" id="notify-speakers-check">
-                {{ form.notify_speakers.as_field_group }}
-                <button type="submit" class="btn btn-success btn-lg">{% translate "Release" %}</button>
-            </div>
+    <details open>
+      <summary class="pb-3">
+        <div class="d-inline-flex flex-column">
+          <h4>{% translate "Public changelog" %}</h4>
+          {% translate "This is how the new schedule version will appear in the public changelog and in the RSS feed." %}
+          {% translate "You can include a comment here." %}
         </div>
-    </form>
+        <hr class="ml-3 mr-3 mt-0 mr-0">
+      </summary>
+
+      <div id="fake-changelog">
+        <h4>
+          {{ phrases.schedule.version }}  {{ suggested_version }}
+        </h4>
+        <div class="flex-next-column">
+          {{ form.comment.as_field_group }}
+        </div>
+        {% include "agenda/changelog_block.html" with schedule=request.event.wip_schedule %}
+      </div>
+    </details>
+
+    <div class="submit-group" id="release">
+      <div class="d-flex align-items-center">
+        <a href="{{ request.event.orga_urls.schedule }}" class="btn btn-info btn-lg">
+          {{ phrases.base.back_button }}
+        </a>
+      </div>
+      <div class="d-flex align-items-center justify-content-end" id="notify-speakers-check">
+        {{ form.notify_speakers.as_field_group }}
+        <button type="submit" class="btn btn-success btn-lg">{% translate "Release" %}</button>
+      </div>
+    </div>
+  </form>
 
 {% endblock schedule_content %}

--- a/src/pretalx/orga/templates/orga/schedule/room_form.html
+++ b/src/pretalx/orga/templates/orga/schedule/room_form.html
@@ -7,31 +7,31 @@
 {% block extra_title %}{% if form.instance.pk %}{% translate "Room" %} {{ quotation_open }}{{ form.instance.name }}{{ quotation_close }}{% else %}{% translate "New room" %}{% endif %} :: {% endblock extra_title %}
 
 {% block content %}
-    {% include "common/availabilities.html" %}
+  {% include "common/availabilities.html" %}
 
-    <h2>
-        {% if form.instance.pk %}
-            {% translate "Room" %} {{ quotation_open }}{{ form.instance.name }}{{ quotation_close }}
-        {% else %}
-            {% translate "New room" %}
-        {% endif %}
-    </h2>
-    <form method="post">
-        {% csrf_token %}
-        {% include "common/forms/errors.html" %}
-        {% for field in form %}
-            {% if field.name != "guid" %}
-                {{ field.as_field_group }}
-            {% endif %}
-        {% endfor %}
-        <details>
-            <summary class="col-md-9 ml-auto mb-4">
-                <h3 class="d-inline">{% translate "Advanced settings" %}</h3>
-            </summary>
-            {{ form.guid.as_field_group }}
-        </details>
+  <h2>
+    {% if form.instance.pk %}
+      {% translate "Room" %} {{ quotation_open }}{{ form.instance.name }}{{ quotation_close }}
+    {% else %}
+      {% translate "New room" %}
+    {% endif %}
+  </h2>
+  <form method="post">
+    {% csrf_token %}
+    {% include "common/forms/errors.html" %}
+    {% for field in form %}
+      {% if field.name != "guid" %}
+        {{ field.as_field_group }}
+      {% endif %}
+    {% endfor %}
+    <details>
+      <summary class="col-md-9 ml-auto mb-4">
+        <h3 class="d-inline">{% translate "Advanced settings" %}</h3>
+      </summary>
+      {{ form.guid.as_field_group }}
+    </details>
 
-        {% include "orga/includes/submit_row.html" %}
+    {% include "orga/includes/submit_row.html" %}
 
-    </form>
+  </form>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/schedule/room_list.html
+++ b/src/pretalx/orga/templates/orga/schedule/room_list.html
@@ -7,73 +7,73 @@
 {% block extra_title %}{{ request.event.rooms.count }} {% blocktranslate trimmed count count=request.event.rooms.count context "Number of rooms" %}Room{% plural %}Rooms{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "orga/css/dragsort.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "orga/css/dragsort.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "orga/js/dragsort.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "orga/js/dragsort.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block content %}
-    <div>
-        <h2>
-            {{ request.event.rooms.count }}
-            {% blocktranslate trimmed count count=request.event.rooms.count context "Number of rooms" %}
-                Room
-            {% plural %}
-                Rooms
-            {% endblocktranslate %}
-        </h2>
+  <div>
+    <h2>
+      {{ request.event.rooms.count }}
+      {% blocktranslate trimmed count count=request.event.rooms.count context "Number of rooms" %}
+        Room
+      {% plural %}
+        Rooms
+      {% endblocktranslate %}
+    </h2>
 
-        <div class="table-responsive-sm">
-            <table class="table table-sm table-hover table-flip table-sticky">
-                <thead>
-                    <tr>
-                        <th>{% translate "Name" %}</th>
-                        <th class="numeric">{% translate "Capacity" %}</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody dragsort-url="{{ request.event.orga_urls.room_settings }}">
-                    {% for room in request.event.rooms.all %}
-                        <tr dragsort-id="{{ room.pk }}">
-                            <td>
-                                <a href="{{ room.urls.settings_base }}">{{ room.name }}</a>
-                            </td>
-                            <td class="numeric">
-                                {% if room.capacity %}{{ room.capacity }}{% endif %}
-                            </td>
-                            <td class="text-right">
-                                <button draggable="true" class="btn btn-sm btn-primary mr-1 dragsort-button" title="{% translate "Move item" %}">
-                                    <i class="fa fa-arrows"></i>
-                                </button>
+    <div class="table-responsive-sm">
+      <table class="table table-sm table-hover table-flip table-sticky">
+        <thead>
+          <tr>
+            <th>{% translate "Name" %}</th>
+            <th class="numeric">{% translate "Capacity" %}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody dragsort-url="{{ request.event.orga_urls.room_settings }}">
+          {% for room in request.event.rooms.all %}
+            <tr dragsort-id="{{ room.pk }}">
+              <td>
+                <a href="{{ room.urls.settings_base }}">{{ room.name }}</a>
+              </td>
+              <td class="numeric">
+                {% if room.capacity %}{{ room.capacity }}{% endif %}
+              </td>
+              <td class="text-right">
+                <button draggable="true" class="btn btn-sm btn-primary mr-1 dragsort-button" title="{% translate "Move item" %}">
+                  <i class="fa fa-arrows"></i>
+                </button>
 
-                                <a href="{{ room.urls.edit }}" class="btn btn-sm btn-info">
-                                    <i class="fa fa-edit"></i>
-                                </a>
-                                <a href="{{ room.urls.delete }}" class="btn btn-sm btn-danger">
-                                    <i class="fa fa-trash"></i>
-                                </a>
-                            </td>
-                        </tr>
-                    {% empty %}
-                        <tr>
-                            <td>{% translate "Please add at least one place in which sessions can take place." %}</td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-
-        <div class="submit-group"><span></span>
-            <a class="btn btn-lg btn-success" href="{{ request.event.orga_urls.new_room }}">
-                <i class="fa fa-plus"></i>
-                {% translate "New room" %}
-            </a>
-        </div>
+                <a href="{{ room.urls.edit }}" class="btn btn-sm btn-info">
+                  <i class="fa fa-edit"></i>
+                </a>
+                <a href="{{ room.urls.delete }}" class="btn btn-sm btn-danger">
+                  <i class="fa fa-trash"></i>
+                </a>
+              </td>
+            </tr>
+          {% empty %}
+            <tr>
+              <td>{% translate "Please add at least one place in which sessions can take place." %}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
+
+    <div class="submit-group"><span></span>
+      <a class="btn btn-lg btn-success" href="{{ request.event.orga_urls.new_room }}">
+        <i class="fa fa-plus"></i>
+        {% translate "New room" %}
+      </a>
+    </div>
+  </div>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/settings/form.html
+++ b/src/pretalx/orga/templates/orga/settings/form.html
@@ -6,136 +6,136 @@
 {% load static %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" type="text/css" href="{% static "common/css/headers-uncompressed.css" %}" />
-    {% compress css %}
-        <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  <link rel="stylesheet" type="text/css" href="{% static "common/css/headers-uncompressed.css" %}" />
+  {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "vendored/vanilla-picker/vanilla-picker.min.js" %}"></script>
-        <script defer src="{% static "orga/js/colorpicker.js" %}"></script>
-        <script defer src="{% static "common/js/lightbox.js" %}"></script>
-        <script defer src="{% static "orga/js/eventSettings.js" %}"></script>
-        <script defer src="{% static "js/jquery.js" %}"></script>
-        <script defer src="{% static "js/jquery.formset.js" %}"></script>
-        <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "vendored/vanilla-picker/vanilla-picker.min.js" %}"></script>
+    <script defer src="{% static "orga/js/colorpicker.js" %}"></script>
+    <script defer src="{% static "common/js/lightbox.js" %}"></script>
+    <script defer src="{% static "orga/js/eventSettings.js" %}"></script>
+    <script defer src="{% static "js/jquery.js" %}"></script>
+    <script defer src="{% static "js/jquery.formset.js" %}"></script>
+    <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{% translate "Settings" %} :: {% endblock extra_title %}
 
 {% block settings_content %}
-    <h2>{% translate "Settings" %}</h2>
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
+  <h2>{% translate "Settings" %}</h2>
+  <form method="post" enctype="multipart/form-data">
+    {% csrf_token %}
 
-        {% include "orga/includes/tablist.html" %}
+    {% include "orga/includes/tablist.html" %}
 
-        <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="false">
-            {% include "common/forms/errors.html" %}
+    <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="false">
+      {% include "common/forms/errors.html" %}
 
-            {{ form.name.as_field_group }}
-            {{ form.slug.as_field_group }}
-            {{ form.date_from.as_field_group }}
-            {{ form.date_to.as_field_group }}
-            {{ form.email.as_field_group }}
-            {{ form.custom_domain.as_field_group }}
-            {{ form.meta_noindex.as_field_group }}
-            {{ form.imprint_url.as_field_group }}
-        </section>
-        <section role="tabpanel" id="tabpanel-localisation" aria-labelledby="tab-localisation" tabindex="0" aria-hidden="true">
-            {{ form.locale.as_field_group }}
-            {{ form.locales.as_field_group }}
-            {{ form.content_locales.as_field_group }}
-            {{ form.timezone.as_field_group }}
-        </section>
-        <section role="tabpanel" id="tabpanel-texts" aria-labelledby="tab-texts" tabindex="0" aria-hidden="true">
-            {{ form.landing_page_text.as_field_group }}
-            {{ form.featured_sessions_text.as_field_group }}
-        </section>
-        <section role="tabpanel" id="tabpanel-display" aria-labelledby="tab-display" tabindex="0" aria-hidden="true">
-            <fieldset>
-                <legend>{% translate "Design" %}</legend>
-                {{ form.primary_color.as_field_group }}
-                {{ form.logo.as_field_group }}
-                {{ form.header_image.as_field_group }}
-                <div id="csswrap">
-                    {{ form.custom_css.as_field_group }}
-                    <button class="btn btn-outline-info" type="button" data-toggle="collapse" data-target="#collapseCSSBox" aria-expanded="false" aria-controls="collapseCSSBox">
-                        <i class="fa fa-code"></i>
-                    </button>
-                </div>
-                <div class="collapse" id="collapseCSSBox">
-                    {{ form.custom_css_text.as_field_group }}
-                </div>
-                <div {% if request.event.primary_color %}style="--color: {{ request.event.primary_color }}"{% endif %} class="colorpicker-update">
-                    {{ form.header_pattern.as_field_group }}
-                </div>
-            </fieldset>
-            <fieldset>
-                <legend>{% translate "Schedule" %}</legend>
-                {{ form.show_schedule.as_field_group }}
-                {{ form.schedule.as_field_group }}
-                {{ form.show_featured.as_field_group }}
-                {{ form.use_feedback.as_field_group }}
-                {{ form.export_html_on_release.as_field_group }}
-                {{ form.html_export_url.as_field_group }}
-            </fieldset>
-            <fieldset>
-                <legend>{% translate "Other settings" %}</legend>
-
-                <div class="form-group">
-                    <label class="col-md-3 control-label">
-                        {% translate "Header links" %}<br>
-                        <span class="optional">{% translate "Optional" %}</span>
-                    </label>
-                    <div class="col-md-9">
-                        <p class="mt-1 mb-2 text-muted">
-                            {% blocktranslate trimmed %}
-                                These links will be shown at the top of all your schedule-related pages, e.g.
-                                the schedule itself, speaker pages, session pages, etc.
-                                You could for example link to your home page, your registration page, or your
-                                livestream here.
-                            {% endblocktranslate %}
-                        </p>
-                        {% include "orga/includes/event_links_formset.html" with formset=header_links_formset %}
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <label class="col-md-3 control-label">
-                        {% translate "Footer links" %}<br>
-                        <span class="optional">{% translate "Optional" %}</span>
-                    </label>
-                    <div class="col-md-9">
-                        <p class="mt-1 mb-2 text-muted">
-                            {% blocktranslate trimmed %}
-                                These links will be shown in the footer of all your public pages. You could
-                                for example link your terms of service, imprint, or privacy policy here.
-                            {% endblocktranslate %}
-                        </p>
-                        {% include "orga/includes/event_links_formset.html" with formset=footer_links_formset %}
-                    </div>
-                </div>
-            </fieldset>
-        </section>
-        <div class="submit-group panel">
-            <span>
-                {% has_perm "person.is_administrator" request.user request.event as can_delete_event %}
-                {% if can_delete_event %}
-                    <a class="btn btn-outline-danger btn-lg" href="{{ request.event.orga_urls.delete }}">
-                        {% translate "Delete event" %}
-                    </a>
-                {% endif %}
-            </span>
-            <span>
-                <button type="submit" class="btn btn-success btn-lg">
-                    <i class="fa fa-check"></i>
-                    {{ phrases.base.save }}
-                </button>
-            </span>
+      {{ form.name.as_field_group }}
+      {{ form.slug.as_field_group }}
+      {{ form.date_from.as_field_group }}
+      {{ form.date_to.as_field_group }}
+      {{ form.email.as_field_group }}
+      {{ form.custom_domain.as_field_group }}
+      {{ form.meta_noindex.as_field_group }}
+      {{ form.imprint_url.as_field_group }}
+    </section>
+    <section role="tabpanel" id="tabpanel-localisation" aria-labelledby="tab-localisation" tabindex="0" aria-hidden="true">
+      {{ form.locale.as_field_group }}
+      {{ form.locales.as_field_group }}
+      {{ form.content_locales.as_field_group }}
+      {{ form.timezone.as_field_group }}
+    </section>
+    <section role="tabpanel" id="tabpanel-texts" aria-labelledby="tab-texts" tabindex="0" aria-hidden="true">
+      {{ form.landing_page_text.as_field_group }}
+      {{ form.featured_sessions_text.as_field_group }}
+    </section>
+    <section role="tabpanel" id="tabpanel-display" aria-labelledby="tab-display" tabindex="0" aria-hidden="true">
+      <fieldset>
+        <legend>{% translate "Design" %}</legend>
+        {{ form.primary_color.as_field_group }}
+        {{ form.logo.as_field_group }}
+        {{ form.header_image.as_field_group }}
+        <div id="csswrap">
+          {{ form.custom_css.as_field_group }}
+          <button class="btn btn-outline-info" type="button" data-toggle="collapse" data-target="#collapseCSSBox" aria-expanded="false" aria-controls="collapseCSSBox">
+            <i class="fa fa-code"></i>
+          </button>
         </div>
-    </form>
+        <div class="collapse" id="collapseCSSBox">
+          {{ form.custom_css_text.as_field_group }}
+        </div>
+        <div {% if request.event.primary_color %}style="--color: {{ request.event.primary_color }}"{% endif %} class="colorpicker-update">
+          {{ form.header_pattern.as_field_group }}
+        </div>
+      </fieldset>
+      <fieldset>
+        <legend>{% translate "Schedule" %}</legend>
+        {{ form.show_schedule.as_field_group }}
+        {{ form.schedule.as_field_group }}
+        {{ form.show_featured.as_field_group }}
+        {{ form.use_feedback.as_field_group }}
+        {{ form.export_html_on_release.as_field_group }}
+        {{ form.html_export_url.as_field_group }}
+      </fieldset>
+      <fieldset>
+        <legend>{% translate "Other settings" %}</legend>
+
+        <div class="form-group">
+          <label class="col-md-3 control-label">
+            {% translate "Header links" %}<br>
+            <span class="optional">{% translate "Optional" %}</span>
+          </label>
+          <div class="col-md-9">
+            <p class="mt-1 mb-2 text-muted">
+              {% blocktranslate trimmed %}
+                These links will be shown at the top of all your schedule-related pages, e.g.
+                the schedule itself, speaker pages, session pages, etc.
+                You could for example link to your home page, your registration page, or your
+                livestream here.
+              {% endblocktranslate %}
+            </p>
+            {% include "orga/includes/event_links_formset.html" with formset=header_links_formset %}
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label class="col-md-3 control-label">
+            {% translate "Footer links" %}<br>
+            <span class="optional">{% translate "Optional" %}</span>
+          </label>
+          <div class="col-md-9">
+            <p class="mt-1 mb-2 text-muted">
+              {% blocktranslate trimmed %}
+                These links will be shown in the footer of all your public pages. You could
+                for example link your terms of service, imprint, or privacy policy here.
+              {% endblocktranslate %}
+            </p>
+            {% include "orga/includes/event_links_formset.html" with formset=footer_links_formset %}
+          </div>
+        </div>
+      </fieldset>
+    </section>
+    <div class="submit-group panel">
+      <span>
+        {% has_perm "person.is_administrator" request.user request.event as can_delete_event %}
+        {% if can_delete_event %}
+          <a class="btn btn-outline-danger btn-lg" href="{{ request.event.orga_urls.delete }}">
+            {% translate "Delete event" %}
+          </a>
+        {% endif %}
+      </span>
+      <span>
+        <button type="submit" class="btn btn-success btn-lg">
+          <i class="fa fa-check"></i>
+          {{ phrases.base.save }}
+        </button>
+      </span>
+    </div>
+  </form>
 {% endblock settings_content %}

--- a/src/pretalx/orga/templates/orga/settings/mail.html
+++ b/src/pretalx/orga/templates/orga/settings/mail.html
@@ -5,49 +5,49 @@
 {% load static %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "orga/js/mailSettings.js" %}"></script>
-        <script defer src="{% static "common/js/modalDialog.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "orga/js/mailSettings.js" %}"></script>
+    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{% translate "Email settings" %} :: {% endblock extra_title %}
 
 {% block settings_content %}
-    <form method="post">
-        {% csrf_token %}
-        <h2>
-            {% translate "Email settings" %}
-            <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-                <i class="fa fa-question-circle-o text-info"></i>
-            </span>
-        </h2>
-        <dialog id="info-dialog">
-            <div class="alert alert-info">
-                {% blocktranslate trimmed %}
-                    If you don’t configure custom email settings, the global configuration
-                    for this server will be used (ask your administrator for details).<br>
-                    We recommend that you add email settings here explicitly.
-                {% endblocktranslate %}
-            </div>
-        </dialog>
-        {{ form }}
-        <div class="submit-group panel">
-            <span></span>
-            <span>
-                {% if action == "edit" or action == "create" %}
-                    <button type="submit" class="btn btn-lg btn-success" name="test" value="1">
-                        {% translate "Save and test custom SMTP connection" %}
-                    </button>
-                    <button type="submit" class="btn btn-lg btn-info">{{ phrases.base.save }}</button>
-                {% endif %}
-            </span>
-        </div>
-    </form>
+  <form method="post">
+    {% csrf_token %}
+    <h2>
+      {% translate "Email settings" %}
+      <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+        <i class="fa fa-question-circle-o text-info"></i>
+      </span>
+    </h2>
+    <dialog id="info-dialog">
+      <div class="alert alert-info">
+        {% blocktranslate trimmed %}
+          If you don’t configure custom email settings, the global configuration
+          for this server will be used (ask your administrator for details).<br>
+          We recommend that you add email settings here explicitly.
+        {% endblocktranslate %}
+      </div>
+    </dialog>
+    {{ form }}
+    <div class="submit-group panel">
+      <span></span>
+      <span>
+        {% if action == "edit" or action == "create" %}
+          <button type="submit" class="btn btn-lg btn-success" name="test" value="1">
+            {% translate "Save and test custom SMTP connection" %}
+          </button>
+          <button type="submit" class="btn btn-lg btn-info">{{ phrases.base.save }}</button>
+        {% endif %}
+      </span>
+    </div>
+  </form>
 {% endblock settings_content %}

--- a/src/pretalx/orga/templates/orga/settings/review.html
+++ b/src/pretalx/orga/templates/orga/settings/review.html
@@ -8,275 +8,275 @@
 {% block extra_title %}{% translate "Review settings" %} :: {% endblock extra_title %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "js/jquery.js" %}"></script>
-        <script defer src="{% static "js/jquery.formset.js" %}"></script>
-        <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
-        <script defer src="{% static "common/js/modalDialog.js" %}"></script>
-        <script defer src="{% static "orga/js/reviewSettings.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "js/jquery.js" %}"></script>
+    <script defer src="{% static "js/jquery.formset.js" %}"></script>
+    <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
+    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+    <script defer src="{% static "orga/js/reviewSettings.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block settings_content %}
-    <form method="post" class="d-flex flex-column">
-        {% csrf_token %}
+  <form method="post" class="d-flex flex-column">
+    {% csrf_token %}
 
-        <h2>{% translate "Review settings" %}</h2>
+    <h2>{% translate "Review settings" %}</h2>
 
-        {% include "orga/includes/tablist.html" %}
+    {% include "orga/includes/tablist.html" %}
 
-        <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="false">
-            {% include "common/forms/errors.html" %}
-            {{ form.score_mandatory.as_field_group }}
-            {{ form.text_mandatory.as_field_group }}
-            <div class="col-md-9 flip ml-auto mb-4">
-                <div class="text-muted">
-                    {% blocktranslate trimmed %}
-                        If you require neither a review score nor a review text, reviewers will
-                        be offered an additional {{ quotation_open }}Abstain{{ quotation_close }}
-                        button when reviewing proposals.
-                    {% endblocktranslate %}
-                </div>
+    <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="false">
+      {% include "common/forms/errors.html" %}
+      {{ form.score_mandatory.as_field_group }}
+      {{ form.text_mandatory.as_field_group }}
+      <div class="col-md-9 flip ml-auto mb-4">
+        <div class="text-muted">
+          {% blocktranslate trimmed %}
+            If you require neither a review score nor a review text, reviewers will
+            be offered an additional {{ quotation_open }}Abstain{{ quotation_close }}
+            button when reviewing proposals.
+          {% endblocktranslate %}
+        </div>
+      </div>
+      {{ form.aggregate_method.as_field_group }}
+      {{ form.score_format.as_field_group }}
+      {{ form.review_help_text.as_field_group }}
+
+    </section>
+    <section role="tabpanel" id="tabpanel-scores" aria-labelledby="tab-scores" tabindex="0" aria-hidden="true">
+      <dialog id="info-review-scoring">
+        <div class="alert alert-info">
+          <p>
+            {% blocktranslate trimmed %}
+              You can ask reviewers to provide one or multiple scores. If you ask for multiple scores,
+              they will be added up to a final total score. If you want, this total score can be weighted.
+              Currently, the total score is calculated as:
+            {% endblocktranslate %}
+            <span class="text-center d-block">
+              <strong><span id="total-score"></span></strong>
+            </span>
+          </p>
+        </div>
+      </dialog>
+
+      <div id="score-formset" class="formset" data-formset data-formset-prefix="{{ scores_formset.prefix }}">
+        {{ scores_formset.management_form }}
+        {{ scores_formset.non_form_errors }}
+        <div data-formset-body class="card"><div class="list-group list-group-flush">
+          {% for form in scores_formset %}
+            <div data-formset-form class="score-group list-group-item">
+              <h3 class="d-flex offset-md-3 flex-wrap align-items-start mt-2 hide-label">
+                <span class="m-2">{% translate "Review Score category" %}
+
+                </span>
+                {{ form.name.as_field_group }}
+                {% if forloop.first %}
+                  <span class="dialog-anchor" data-target="#info-review-scoring" data-toggle="dialog">
+                    <i class="fa fa-question-circle-o text-info ml-2"></i>
+                  </span>
+                {% endif %}
+                {% if action != "view" %}
+                  <button type="button" class="btn btn-xs btn-danger ml-auto" data-formset-delete-button>
+                    <i class="fa fa-trash"></i>
+                  </button>
+                {% endif %}
+              </h3>
+              <div class="sr-only">
+                {{ form.id }}
+                {{ form.new_scores }}
+                {{ form.DELETE }}
+              </div>
+              <div class="score-row flip ml-auto score-input{% if action == "view" %} disabled{% endif %}">
+                {% include "common/forms/errors.html" %}
+                {{ form.is_independent.as_field_group }}
+                {{ form.weight.as_field_group }}
+                {{ form.required.as_field_group }}
+                {{ form.active.as_field_group }}
+
+                {% if form.limit_tracks %}{{ form.limit_tracks.as_field_group }}{% endif %}
+
+                {% for label_pair in form.get_label_fields %}
+                  <div class="row form-group">
+                    {% if forloop.first %}
+                      <label class="col-md-3 col-form-label">
+                        {% translate "Scores" %}
+                      </label>
+                    {% endif %}
+                    <div class="col-md-9 flip ml-auto d-flex hide-label">
+                      <div class="mr-2 score-score">
+                        {{ label_pair.0.as_field_group }}
+                      </div>
+                      <div class="score-label">
+                        {{ label_pair.1.as_field_group }}
+                      </div>
+                      {% if forloop.first %}
+                        <div role="button" class="new-score btn btn-info flip ml-auto align-self-start"><i class="fa fa-plus"></i></div>
+                      {% endif %}
+                    </div>
+                  </div>
+                {% empty %}
+                  <div class="row form-group">
+                    <label class="col-md-3 col-form-label">
+                      {% translate "Scores" %}
+                    </label>
+                    <div class="col-md-9 flip ml-auto d-flex">
+                      <div role="button" class="new-score btn btn-info flip ml-auto"><i class="fa fa-plus"></i></div>
+                    </div>
+                  </div>
+                {% endfor %}
+              </div>
             </div>
-            {{ form.aggregate_method.as_field_group }}
-            {{ form.score_format.as_field_group }}
-            {{ form.review_help_text.as_field_group }}
-
-        </section>
-        <section role="tabpanel" id="tabpanel-scores" aria-labelledby="tab-scores" tabindex="0" aria-hidden="true">
-            <dialog id="info-review-scoring">
-                <div class="alert alert-info">
-                    <p>
-                        {% blocktranslate trimmed %}
-                            You can ask reviewers to provide one or multiple scores. If you ask for multiple scores,
-                            they will be added up to a final total score. If you want, this total score can be weighted.
-                            Currently, the total score is calculated as:
-                        {% endblocktranslate %}
-                        <span class="text-center d-block">
-                            <strong><span id="total-score"></span></strong>
-                        </span>
-                    </p>
+          {% endfor %}
+        </div>
+          <script type="form-template" data-formset-empty-form>
+            {% escapescript %}
+              <div data-formset-form class="score-group list-group-item p-3">
+              <h3 class="d-flex offset-md-3 flex-wrap align-items-start mt-2 hide-label">
+              <span class="m-2">{% translate "Score Category" %}</span>
+              {{ scores_formset.empty_form.name.as_field_group }}
+              {% if action != "view" %}
+                <div class="score-delete flip ml-auto">
+                <button type="button" class="btn btn-danger" data-formset-delete-button>
+                <i class="fa fa-trash"></i></button>
                 </div>
-            </dialog>
+              {% endif %}
+              </h3>
+              <div class="sr-only">
+              {{ scores_formset.empty_form.id }}
+              {{ scores_formset.empty_form.new_scores }}
+              {{ scores_formset.empty_form.DELETE }}
+              </div>
+              <div class="score-row flip ml-auto score-input">
+              {{ scores_formset.empty_form.is_independent.as_field_group }}
+              {{ scores_formset.empty_form.weight.as_field_group }}
+              {{ scores_formset.empty_form.required.as_field_group }}
+              {{ scores_formset.empty_form.active.as_field_group }}
+              <div class="row form-group">
+              <label class="col-md-3 col-form-label">
+              {% translate "Scores" %}
+              </label>
+              <div class="col-md-9 d-flex hide-label">
+              <div class="mr-2 score-score"></div>
+              <div class="score-label"></div>
+              <div role="button" class="new-score btn btn-info flip ml-auto"><i class="fa fa-plus"></i></div>
+              </div>
+              </div>
+              </div>
+              </div>
+            {% endescapescript %}
+          </script>
+        </div>
+        <div class="d-flex lg-action">
+          <button type="button" id="score-add" class="btn btn btn-info flip ml-auto m-3" data-formset-add>
+            <i class="fa fa-plus"></i> {% translate "Add another score category" %}
+          </button>
+        </div>
+      </div>
+    </section>
+    <section role="tabpanel" id="tabpanel-phases" aria-labelledby="tab-phases" tabindex="0" aria-hidden="true">
 
-            <div id="score-formset" class="formset" data-formset data-formset-prefix="{{ scores_formset.prefix }}">
-                {{ scores_formset.management_form }}
-                {{ scores_formset.non_form_errors }}
-                <div data-formset-body class="card"><div class="list-group list-group-flush">
-                    {% for form in scores_formset %}
-                        <div data-formset-form class="score-group list-group-item">
-                            <h3 class="d-flex offset-md-3 flex-wrap align-items-start mt-2 hide-label">
-                                <span class="m-2">{% translate "Review Score category" %}
-
-                                </span>
-                                {{ form.name.as_field_group }}
-                                {% if forloop.first %}
-                                    <span class="dialog-anchor" data-target="#info-review-scoring" data-toggle="dialog">
-                                        <i class="fa fa-question-circle-o text-info ml-2"></i>
-                                    </span>
-                                {% endif %}
-                                {% if action != "view" %}
-                                    <button type="button" class="btn btn-xs btn-danger ml-auto" data-formset-delete-button>
-                                        <i class="fa fa-trash"></i>
-                                    </button>
-                                {% endif %}
-                            </h3>
-                            <div class="sr-only">
-                                {{ form.id }}
-                                {{ form.new_scores }}
-                                {{ form.DELETE }}
-                            </div>
-                            <div class="score-row flip ml-auto score-input{% if action == "view" %} disabled{% endif %}">
-                                {% include "common/forms/errors.html" %}
-                                {{ form.is_independent.as_field_group }}
-                                {{ form.weight.as_field_group }}
-                                {{ form.required.as_field_group }}
-                                {{ form.active.as_field_group }}
-
-                                {% if form.limit_tracks %}{{ form.limit_tracks.as_field_group }}{% endif %}
-
-                                {% for label_pair in form.get_label_fields %}
-                                    <div class="row form-group">
-                                        {% if forloop.first %}
-                                            <label class="col-md-3 col-form-label">
-                                                {% translate "Scores" %}
-                                            </label>
-                                        {% endif %}
-                                        <div class="col-md-9 flip ml-auto d-flex hide-label">
-                                            <div class="mr-2 score-score">
-                                                {{ label_pair.0.as_field_group }}
-                                            </div>
-                                            <div class="score-label">
-                                                {{ label_pair.1.as_field_group }}
-                                            </div>
-                                            {% if forloop.first %}
-                                                <div role="button" class="new-score btn btn-info flip ml-auto align-self-start"><i class="fa fa-plus"></i></div>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                {% empty %}
-                                    <div class="row form-group">
-                                        <label class="col-md-3 col-form-label">
-                                            {% translate "Scores" %}
-                                        </label>
-                                        <div class="col-md-9 flip ml-auto d-flex">
-                                            <div role="button" class="new-score btn btn-info flip ml-auto"><i class="fa fa-plus"></i></div>
-                                        </div>
-                                    </div>
-                                {% endfor %}
-                            </div>
-                        </div>
-                    {% endfor %}
-                </div>
-                    <script type="form-template" data-formset-empty-form>
-                        {% escapescript %}
-                            <div data-formset-form class="score-group list-group-item p-3">
-                            <h3 class="d-flex offset-md-3 flex-wrap align-items-start mt-2 hide-label">
-                            <span class="m-2">{% translate "Score Category" %}</span>
-                            {{ scores_formset.empty_form.name.as_field_group }}
-                            {% if action != "view" %}
-                                <div class="score-delete flip ml-auto">
-                                <button type="button" class="btn btn-danger" data-formset-delete-button>
-                                <i class="fa fa-trash"></i></button>
-                                </div>
-                            {% endif %}
-                            </h3>
-                            <div class="sr-only">
-                            {{ scores_formset.empty_form.id }}
-                            {{ scores_formset.empty_form.new_scores }}
-                            {{ scores_formset.empty_form.DELETE }}
-                            </div>
-                            <div class="score-row flip ml-auto score-input">
-                            {{ scores_formset.empty_form.is_independent.as_field_group }}
-                            {{ scores_formset.empty_form.weight.as_field_group }}
-                            {{ scores_formset.empty_form.required.as_field_group }}
-                            {{ scores_formset.empty_form.active.as_field_group }}
-                            <div class="row form-group">
-                            <label class="col-md-3 col-form-label">
-                            {% translate "Scores" %}
-                            </label>
-                            <div class="col-md-9 d-flex hide-label">
-                            <div class="mr-2 score-score"></div>
-                            <div class="score-label"></div>
-                            <div role="button" class="new-score btn btn-info flip ml-auto"><i class="fa fa-plus"></i></div>
-                            </div>
-                            </div>
-                            </div>
-                            </div>
-                        {% endescapescript %}
-                    </script>
-                </div>
-                <div class="d-flex lg-action">
-                    <button type="button" id="score-add" class="btn btn btn-info flip ml-auto m-3" data-formset-add>
-                        <i class="fa fa-plus"></i> {% translate "Add another score category" %}
+      <dialog id="info-review-phases">
+        <div class="alert alert-info">
+          {% blocktranslate trimmed %}
+            Review phases allow you to structure your review process.
+            By default, there are two review phases: The review itself, and
+            the selection process once the review phase is over. But you could for example
+            add another review and selection phase after that, if you require additional
+            review rounds.
+          {% endblocktranslate %}
+        </div>
+      </dialog>
+      <div class="formset" data-formset data-formset-prefix="{{ phases_formset.prefix }}" id="review-phases-formset">
+        {{ phases_formset.management_form }}
+        {{ phases_formset.non_form_errors }}
+        <div data-formset-body class="card"><div class="list-group list-group-flush">
+          {% for form in phases_formset %}
+            <div data-formset-form class="list-group-item review-phase">
+              <h3 class="d-flex offset-md-3 flex-wrap mt-2 hide-label">
+                <span class="m-2">{% translate "Review Phase" %}</span>
+                {{ form.name.as_field_group }}
+                {% if forloop.first %}
+                  <span class="dialog-anchor" data-target="#info-review-phases" data-toggle="dialog">
+                    <i class="fa fa-question-circle-o text-info ml-2"></i>
+                  </span>
+                {% endif %}
+                {% if action != "view" %}
+                  <div class="phase-option-delete flip ml-auto">
+                    {% if not form.instance.is_active %}
+                      <a href="{{ form.instance.urls.activate }}"
+                         class="btn btn-outline-warning flip ml-auto mr-2 keep-scroll-position"
+                         title="{% translate "Activate phase" %}">
+                        <i class="fa fa-star"></i>
+                      </a>
+                    {% else %}
+                      <a href=""
+                         class="btn btn-warning flip ml-auto mr-2 keep-scroll-position"
+                         title="{% translate "Phase is active" %}">
+                        <i class="fa fa-star"></i>
+                      </a>
+                    {% endif %}
+                    <button type="button" class="btn btn-xs btn-danger ml-auto" data-formset-delete-button>
+                      <i class="fa fa-trash"></i>
                     </button>
+                  </div>
+                {% endif %}
+              </h3>
+              <div class="sr-only">
+                {{ form.id }}
+                {{ form.DELETE }}
+              </div>
+              <div class="phase-option-row flip ml-auto">
+                <div class="phase-option-input{% if action == "view" %} disabled{% endif %}">
+                  {% include "common/forms/errors.html" %}
+                  {% for field in form %}
+                    {% if field.name != "DELETE" and field.name != "name" and field.name != "id" %}
+                      {{ field.as_field_group }}
+                    {% endif %}
+                  {% endfor %}
                 </div>
+              </div>
             </div>
-        </section>
-        <section role="tabpanel" id="tabpanel-phases" aria-labelledby="tab-phases" tabindex="0" aria-hidden="true">
-
-            <dialog id="info-review-phases">
-                <div class="alert alert-info">
-                    {% blocktranslate trimmed %}
-                        Review phases allow you to structure your review process.
-                        By default, there are two review phases: The review itself, and
-                        the selection process once the review phase is over. But you could for example
-                        add another review and selection phase after that, if you require additional
-                        review rounds.
-                    {% endblocktranslate %}
-                </div>
-            </dialog>
-            <div class="formset" data-formset data-formset-prefix="{{ phases_formset.prefix }}" id="review-phases-formset">
-                {{ phases_formset.management_form }}
-                {{ phases_formset.non_form_errors }}
-                <div data-formset-body class="card"><div class="list-group list-group-flush">
-                    {% for form in phases_formset %}
-                        <div data-formset-form class="list-group-item review-phase">
-                            <h3 class="d-flex offset-md-3 flex-wrap mt-2 hide-label">
-                                <span class="m-2">{% translate "Review Phase" %}</span>
-                                {{ form.name.as_field_group }}
-                                {% if forloop.first %}
-                                    <span class="dialog-anchor" data-target="#info-review-phases" data-toggle="dialog">
-                                        <i class="fa fa-question-circle-o text-info ml-2"></i>
-                                    </span>
-                                {% endif %}
-                                {% if action != "view" %}
-                                    <div class="phase-option-delete flip ml-auto">
-                                        {% if not form.instance.is_active %}
-                                            <a href="{{ form.instance.urls.activate }}"
-                                               class="btn btn-outline-warning flip ml-auto mr-2 keep-scroll-position"
-                                               title="{% translate "Activate phase" %}">
-                                                <i class="fa fa-star"></i>
-                                            </a>
-                                        {% else %}
-                                            <a href=""
-                                               class="btn btn-warning flip ml-auto mr-2 keep-scroll-position"
-                                               title="{% translate "Phase is active" %}">
-                                                <i class="fa fa-star"></i>
-                                            </a>
-                                        {% endif %}
-                                        <button type="button" class="btn btn-xs btn-danger ml-auto" data-formset-delete-button>
-                                            <i class="fa fa-trash"></i>
-                                        </button>
-                                    </div>
-                                {% endif %}
-                            </h3>
-                            <div class="sr-only">
-                                {{ form.id }}
-                                {{ form.DELETE }}
-                            </div>
-                            <div class="phase-option-row flip ml-auto">
-                                <div class="phase-option-input{% if action == "view" %} disabled{% endif %}">
-                                    {% include "common/forms/errors.html" %}
-                                    {% for field in form %}
-                                        {% if field.name != "DELETE" and field.name != "name" and field.name != "id" %}
-                                            {{ field.as_field_group }}
-                                        {% endif %}
-                                    {% endfor %}
-                                </div>
-                            </div>
-                        </div>
-                    {% endfor %}
-                    <script type="form-template" data-formset-empty-form>
-                        {% escapescript %}
-                            <div data-formset-form class="list-group-item review-phase p-3">
-                            <h3 class="d-flex offset-md-3 mt-2 hide-label">
-                            <span class="m-2">{% translate "Review Phase" %}</span>
-                            {{ phases_formset.empty_form.name.as_field_group }}
-                            <div class="phase-option-delete flip ml-auto mr-2">
-                            <button type="button" class="btn btn-danger" data-formset-delete-button>
-                            <i class="fa fa-trash"></i></button>
-                            </div>
-                            </h3>
-                            <div class="sr-only">
-                            {{ phases_formset.empty_form.id }}
-                            {{ phases_formset.empty_form.DELETE }}
-                            </div>
-                            <div class="phase-option-row flip ml-auto"><div class="phase-option-input">
-                            {% for field in phases_formset.empty_form %}
-                                {% if field.name != "DELETE" and field.name != "name" and field.name != "id" %}
-                                    {{ field.as_field_group }}
-                                {% endif %}
-                            {% endfor %}
-                            </div></div>
-                            </div>
-                        {% endescapescript %}
-                    </script>
-                </div>
-                </div>
-                <div class="d-flex lg-action">
-                    <button type="button" id="phase-add" class="btn btn btn-info flip ml-auto m-3" data-formset-add>
-                        <i class="fa fa-plus"></i> {% translate "Add another phase" %}
-                    </button>
-                </div>
-            </div>
-        </section>
-        {% include "orga/includes/submit_row.html" %}
-    </form>
+          {% endfor %}
+          <script type="form-template" data-formset-empty-form>
+            {% escapescript %}
+              <div data-formset-form class="list-group-item review-phase p-3">
+              <h3 class="d-flex offset-md-3 mt-2 hide-label">
+              <span class="m-2">{% translate "Review Phase" %}</span>
+              {{ phases_formset.empty_form.name.as_field_group }}
+              <div class="phase-option-delete flip ml-auto mr-2">
+              <button type="button" class="btn btn-danger" data-formset-delete-button>
+              <i class="fa fa-trash"></i></button>
+              </div>
+              </h3>
+              <div class="sr-only">
+              {{ phases_formset.empty_form.id }}
+              {{ phases_formset.empty_form.DELETE }}
+              </div>
+              <div class="phase-option-row flip ml-auto"><div class="phase-option-input">
+              {% for field in phases_formset.empty_form %}
+                {% if field.name != "DELETE" and field.name != "name" and field.name != "id" %}
+                  {{ field.as_field_group }}
+                {% endif %}
+              {% endfor %}
+              </div></div>
+              </div>
+            {% endescapescript %}
+          </script>
+        </div>
+        </div>
+        <div class="d-flex lg-action">
+          <button type="button" id="phase-add" class="btn btn btn-info flip ml-auto m-3" data-formset-add>
+            <i class="fa fa-plus"></i> {% translate "Add another phase" %}
+          </button>
+        </div>
+      </div>
+    </section>
+    {% include "orga/includes/submit_row.html" %}
+  </form>
 {% endblock settings_content %}

--- a/src/pretalx/orga/templates/orga/settings/team_detail.html
+++ b/src/pretalx/orga/templates/orga/settings/team_detail.html
@@ -7,146 +7,146 @@
 {% block extra_title %}{% translate "Team" %} {{ quotation_open }}{{ team.name }}{{ quotation_close }} :: {% endblock extra_title %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/lightbox.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/lightbox.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block settings_content %}
-    <div>
-        {% if team.pk %}
-            <h2>
-                {% translate "Team" %} {{ quotation_open }}{{ team.name }}{{ quotation_close }}: {% translate "Members" %}
-            </h2>
+  <div>
+    {% if team.pk %}
+      <h2>
+        {% translate "Team" %} {{ quotation_open }}{{ team.name }}{{ quotation_close }}: {% translate "Members" %}
+      </h2>
 
-            <form method="post">
-                {% csrf_token %}
-                <div class="table-responsive-sm">
-                    <table class="table table-sm table-hover table-flip table-sticky">
-                        <thead>
-                            <tr>
-                                <th>{% translate "Name" %}</th>
-                                <th>{% translate "Email" %}</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for member in members %}
-                                <tr>
-                                    <td>
-                                        {% include "orga/includes/user_name.html" with user=member lightbox=True %}
-                                    </td>
-                                    <td>
-                                        <a href="mailto:{{ member.email }}">{{ member.email }}</a>
-                                    </td>
-                                    <td class="flip text-right">
-                                        <a
-                                            href="{% if request.event %}{{ request.event.orga_urls.team_settings }}{% else %}{{ request.organiser.orga_urls.teams }}{% endif %}{{ team.id }}/reset/{{ member.id }}"
-                                            class="btn btn-sm btn-warning"
-                                        >
-                                            {{ phrases.base.password_reset_heading }}
-                                        </a>
-                                        <a
-                                            href="{% if request.event %}{{ request.event.orga_urls.team_settings }}{% else %}{{ request.organiser.orga_urls.teams }}{% endif %}{{ team.id }}/delete/{{ member.id }}"
-                                            class="btn btn-sm btn-danger" title="{% translate "Remove team member" %}"
-                                        >
-                                            <i class="fa fa-trash"></i>
-                                        </a>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                            {% for member in team.invites.all %}
-                                <tr>
-                                    <td>
-                                        <em>({% translate "pending Invitation" %})</em>
-                                    </td>
-                                    <td>
-                                        {{ member.email }}
-                                        <a href="{{ member.urls.invitation }}">
-                                            <i class="fa fa-link"></i>
-                                        </a>
-                                    </td>
-                                    <td class="flip text-right">
-                                        <a
-                                            href="{% if request.event %}{{ request.event.orga_urls.team_settings }}{% else %}{{ request.organiser.orga_urls.teams }}{% endif %}{{ member.id }}/resend"
-                                            class="btn btn-sm btn-outline-warning"
-                                        >
-                                            {% translate "Resend invite" %}
-                                        </a>
-                                        <a
-                                            href="{% if request.event %}{{ request.event.orga_urls.team_settings }}{% else %}{{ request.organiser.orga_urls.teams }}{% endif %}{{ member.id }}/uninvite"
-                                            class="btn btn-sm btn-danger"
-                                        >
-                                            <i class="fa fa-trash"></i>
-                                        </a>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                            <tr>
-                                <td>
-                                    <strong>{% translate "Add member" %}</strong>
-                                    <br>
-                                    <small><em><a id="bulk-email" href="">{% translate "Add multiple team members?" %}</a></em></small>
-                                </td>
-                                <td class="w-50">
-                                    {% csrf_token %}
-                                    <div id="single-invite">
-                                        <select multiple name="invite-email" id="id_invite-email" class="form-control" placeholder="{{ invite_form.email.label }}"> </select>
-                                    </div>
-                                    <div id="bulk-invite" class="d-none">
-                                        {{ invite_form.bulk_email.as_field_group }}
-                                    </div>
-                                </td>
-                                <td class="flip text-right">
-                                    <button type="submit" name="form" value="invite" class="btn btn-success btn-sm"><i class="fa fa-check"></i></button>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </form>
-            <h3 id="permissions">
-                {% translate "Team" %} {{ quotation_open }}{{ team.name }}{{ quotation_close }}: {% translate "Permissions" %}
-            </h3>
-        {% else %}
-            <h2>{% translate "New team" %}</h2>
-        {% endif %}
+      <form method="post">
+        {% csrf_token %}
+        <div class="table-responsive-sm">
+          <table class="table table-sm table-hover table-flip table-sticky">
+            <thead>
+              <tr>
+                <th>{% translate "Name" %}</th>
+                <th>{% translate "Email" %}</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for member in members %}
+                <tr>
+                  <td>
+                    {% include "orga/includes/user_name.html" with user=member lightbox=True %}
+                  </td>
+                  <td>
+                    <a href="mailto:{{ member.email }}">{{ member.email }}</a>
+                  </td>
+                  <td class="flip text-right">
+                    <a
+                      href="{% if request.event %}{{ request.event.orga_urls.team_settings }}{% else %}{{ request.organiser.orga_urls.teams }}{% endif %}{{ team.id }}/reset/{{ member.id }}"
+                      class="btn btn-sm btn-warning"
+                    >
+                      {{ phrases.base.password_reset_heading }}
+                    </a>
+                    <a
+                      href="{% if request.event %}{{ request.event.orga_urls.team_settings }}{% else %}{{ request.organiser.orga_urls.teams }}{% endif %}{{ team.id }}/delete/{{ member.id }}"
+                      class="btn btn-sm btn-danger" title="{% translate "Remove team member" %}"
+                    >
+                      <i class="fa fa-trash"></i>
+                    </a>
+                  </td>
+                </tr>
+              {% endfor %}
+              {% for member in team.invites.all %}
+                <tr>
+                  <td>
+                    <em>({% translate "pending Invitation" %})</em>
+                  </td>
+                  <td>
+                    {{ member.email }}
+                    <a href="{{ member.urls.invitation }}">
+                      <i class="fa fa-link"></i>
+                    </a>
+                  </td>
+                  <td class="flip text-right">
+                    <a
+                      href="{% if request.event %}{{ request.event.orga_urls.team_settings }}{% else %}{{ request.organiser.orga_urls.teams }}{% endif %}{{ member.id }}/resend"
+                      class="btn btn-sm btn-outline-warning"
+                    >
+                      {% translate "Resend invite" %}
+                    </a>
+                    <a
+                      href="{% if request.event %}{{ request.event.orga_urls.team_settings }}{% else %}{{ request.organiser.orga_urls.teams }}{% endif %}{{ member.id }}/uninvite"
+                      class="btn btn-sm btn-danger"
+                    >
+                      <i class="fa fa-trash"></i>
+                    </a>
+                  </td>
+                </tr>
+              {% endfor %}
+              <tr>
+                <td>
+                  <strong>{% translate "Add member" %}</strong>
+                  <br>
+                  <small><em><a id="bulk-email" href="">{% translate "Add multiple team members?" %}</a></em></small>
+                </td>
+                <td class="w-50">
+                  {% csrf_token %}
+                  <div id="single-invite">
+                    <select multiple name="invite-email" id="id_invite-email" class="form-control" placeholder="{{ invite_form.email.label }}"> </select>
+                  </div>
+                  <div id="bulk-invite" class="d-none">
+                    {{ invite_form.bulk_email.as_field_group }}
+                  </div>
+                </td>
+                <td class="flip text-right">
+                  <button type="submit" name="form" value="invite" class="btn btn-success btn-sm"><i class="fa fa-check"></i></button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </form>
+      <h3 id="permissions">
+        {% translate "Team" %} {{ quotation_open }}{{ team.name }}{{ quotation_close }}: {% translate "Permissions" %}
+      </h3>
+    {% else %}
+      <h2>{% translate "New team" %}</h2>
+    {% endif %}
 
-        <form method="post">
-            {% csrf_token %}
-            {% include "common/forms/errors.html" %}
-            {{ form.name.as_field_group }}
-            {{ form.all_events.as_field_group }}
-            {{ form.limit_events.as_field_group }}
-            {{ form.can_create_events.as_field_group }}
-            {{ form.can_change_teams.as_field_group }}
-            {{ form.can_change_organiser_settings.as_field_group }}
-            {{ form.can_change_event_settings.as_field_group }}
-            {{ form.can_change_submissions.as_field_group }}
-            {{ form.is_reviewer.as_field_group }}
-            <div id="review-settings">
-                <div class="form-group row">
-                    <div class="col-md-9 offset-md-3">
-                        <h3 id="review-settings">{% translate "Review settings" %}</h3>
-                    </div>
-                </div>
-                {{ form.force_hide_speaker_names.as_field_group }}
-                {{ form.limit_tracks.as_field_group }}
-            </div>
+    <form method="post">
+      {% csrf_token %}
+      {% include "common/forms/errors.html" %}
+      {{ form.name.as_field_group }}
+      {{ form.all_events.as_field_group }}
+      {{ form.limit_events.as_field_group }}
+      {{ form.can_create_events.as_field_group }}
+      {{ form.can_change_teams.as_field_group }}
+      {{ form.can_change_organiser_settings.as_field_group }}
+      {{ form.can_change_event_settings.as_field_group }}
+      {{ form.can_change_submissions.as_field_group }}
+      {{ form.is_reviewer.as_field_group }}
+      <div id="review-settings">
+        <div class="form-group row">
+          <div class="col-md-9 offset-md-3">
+            <h3 id="review-settings">{% translate "Review settings" %}</h3>
+          </div>
+        </div>
+        {{ form.force_hide_speaker_names.as_field_group }}
+        {{ form.limit_tracks.as_field_group }}
+      </div>
 
-            {% include "orga/includes/submit_row.html" with submit_value="team" submit_name="form" %}
+      {% include "orga/includes/submit_row.html" with submit_value="team" submit_name="form" %}
 
-        </form>
-    </div>
+    </form>
+  </div>
 
-    <span id="vars" remoteUrl="{{ request.organiser.orga_urls.user_search }}"></span>
-    {% compress js %}
-        <script defer src="{% static "orga/js/speakers.js" %}"></script>
-        <script defer src="{% static "orga/js/teamSettings.js" %}"></script>
-    {% endcompress %}
+  <span id="vars" remoteUrl="{{ request.organiser.orga_urls.user_search }}"></span>
+  {% compress js %}
+    <script defer src="{% static "orga/js/speakers.js" %}"></script>
+    <script defer src="{% static "orga/js/teamSettings.js" %}"></script>
+  {% endcompress %}
 {% endblock settings_content %}

--- a/src/pretalx/orga/templates/orga/settings/widget.html
+++ b/src/pretalx/orga/templates/orga/settings/widget.html
@@ -8,71 +8,71 @@
 {% block extra_title %}{% translate "Widget generation" %} :: {% endblock extra_title %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "orga/js/widgetSettings.js" %}"></script>
-        <script defer src="{% static "common/js/modalDialog.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "orga/js/widgetSettings.js" %}"></script>
+    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block settings_content %}
-    <h2>
-        {% translate "Widget settings" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
-    <dialog id="info-dialog">
-        <div class="alert alert-info flip ml-auto">
-            {% blocktranslate trimmed %}
-                You can configure a eventyay schedule widget to show your event schedule
-                on your homepage, instead of using this page. If you want to disable the
-                schedule on here entirely, please activate the setting below.
-            {% endblocktranslate %}
-        </div>
-    </dialog>
-
-    {% include "orga/includes/base_form.html" %}
-
-    <h2>{% translate "Widget generation" %}</h2>
-    <p>
-        {% blocktranslate trimmed %}
-            The eventyay schedule widget is a way to embed your schedule into your event website. This way, your attendees can see your schedule without leaving your website, and you can style the schedule to fit right in with your website.
-        {% endblocktranslate %}
-    </p>
-
-    <div id="widget-generation">
-        <p>
-            {% blocktranslate trimmed %}
-                Using this form, you can generate code to copy and paste to your website source.
-            {% endblocktranslate %}
-        </p>
-        {{ extra_form }}
-        <div class="submit-group panel">
-            <span></span>
-            <span>
-                <button id="generate-widget" class="btn btn-info btn-lg">{% translate "Generate widget" %}</button>
-            </span>
-        </div>
+  <h2>
+    {% translate "Widget settings" %}
+    <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+      <i class="fa fa-question-circle-o text-info"></i>
+    </span>
+  </h2>
+  <dialog id="info-dialog">
+    <div class="alert alert-info flip ml-auto">
+      {% blocktranslate trimmed %}
+        You can configure a eventyay schedule widget to show your event schedule
+        on your homepage, instead of using this page. If you want to disable the
+        schedule on here entirely, please activate the setting below.
+      {% endblocktranslate %}
     </div>
-    <div id="generated-widget" class="d-none">
-        <p>
-            {% blocktranslate trimmed %}
-                To embed the widget into your website, copy the following code to the <code>&lt;head></code> section of your website:
-            {% endblocktranslate %}
-        </p>
+  </dialog>
+
+  {% include "orga/includes/base_form.html" %}
+
+  <h2>{% translate "Widget generation" %}</h2>
+  <p>
+    {% blocktranslate trimmed %}
+      The eventyay schedule widget is a way to embed your schedule into your event website. This way, your attendees can see your schedule without leaving your website, and you can style the schedule to fit right in with your website.
+    {% endblocktranslate %}
+  </p>
+
+  <div id="widget-generation">
+    <p>
+      {% blocktranslate trimmed %}
+        Using this form, you can generate code to copy and paste to your website source.
+      {% endblocktranslate %}
+    </p>
+    {{ extra_form }}
+    <div class="submit-group panel">
+      <span></span>
+      <span>
+        <button id="generate-widget" class="btn btn-info btn-lg">{% translate "Generate widget" %}</button>
+      </span>
+    </div>
+  </div>
+  <div id="generated-widget" class="d-none">
+    <p>
+      {% blocktranslate trimmed %}
+        To embed the widget into your website, copy the following code to the <code>&lt;head></code> section of your website:
+      {% endblocktranslate %}
+    </p>
         <pre id="widget-head">
 &lt;script type="text/javascript" src="{{ request.event.urls.schedule_widget_script.full }}">&lt;/script></pre>
-        <p>
-            {% blocktranslate trimmed %}
-                Then, copy the following code to the place of your website where you want the widget to show up:
-            {% endblocktranslate %}
-        </p>
+    <p>
+      {% blocktranslate trimmed %}
+        Then, copy the following code to the place of your website where you want the widget to show up:
+      {% endblocktranslate %}
+    </p>
         <pre id="widget-body">
 &lt;pretalx-schedule event-url="{{ request.event.urls.base.full }}" locale="LOCALE" format="FORMAT" style="--pretalx-clr-primary: {{ request.event.visible_primary_color }}"FILTER_DAYS>&lt;/pretalx-schedule>
 &lt;noscript>
@@ -83,25 +83,25 @@
         &lt;/div>
     &lt;/div>
 &lt;/noscript></pre>
-        <p>
-            <span class="text-success">
-                <i class="fa fa-info-circle"></i>
-            </span>
-            {% blocktranslate trimmed with link="#" %}
+    <p>
+      <span class="text-success">
+        <i class="fa fa-info-circle"></i>
+      </span>
+      {% blocktranslate trimmed with link="#" %}
 
-                Please look at <a href="{{ link }}">our documentation</a> for more information.
-            {% endblocktranslate %}
-        </p>
-    </div>
+        Please look at <a href="{{ link }}">our documentation</a> for more information.
+      {% endblocktranslate %}
+    </p>
+  </div>
 
-    {% if request.event.is_public and request.event|get_feature_flag:"show_schedule" and request.event.current_schedule and not request.event.custom_domain %}
-        <div class="mw-100">
-            <h2>{% translate "Widget preview" %}</h2>
-            <p>
-                {% blocktranslate trimmed %}
-                    This is roughly what your widget will look like if you choose the grid format:
-                {% endblocktranslate %}
-            </p>
+  {% if request.event.is_public and request.event|get_feature_flag:"show_schedule" and request.event.current_schedule and not request.event.custom_domain %}
+    <div class="mw-100">
+      <h2>{% translate "Widget preview" %}</h2>
+      <p>
+        {% blocktranslate trimmed %}
+          This is roughly what your widget will look like if you choose the grid format:
+        {% endblocktranslate %}
+      </p>
             <pretalx-schedule event-url="{{ request.event.urls.base }}" locale="{{ request.event.locale }}" style="--pretalx-clr-primary: {{ request.event.primary_color|default:"#2185d0" }}"></pretalx-schedule>
       </div>
    <script type="text/javascript" src="{{ request.event.urls.schedule_widget_script }}" async></script>

--- a/src/pretalx/orga/templates/orga/speaker/export.html
+++ b/src/pretalx/orga/templates/orga/speaker/export.html
@@ -6,115 +6,115 @@
 {% block extra_title %}{% translate "Export speaker data" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Export speaker data" %}</h2>
+  <h2>{% translate "Export speaker data" %}</h2>
 
-    {% include "orga/includes/tablist.html" %}
+  {% include "orga/includes/tablist.html" %}
 
-    <section role="tabpanel" id="tabpanel-custom" aria-labelledby="tab-custom" tabindex="0" aria-hidden="false">
-        <p>
-            {% blocktranslate trimmed %}
-                Build your own custom export here, by selecting all the data you need,
-                and the export format. CSV exports can be opened with Excel and similar
-                applications, while JSON exports are often used for integration with
-                other tools.
-            {% endblocktranslate %}
-        </p>
-        <form method="post">
-            {% csrf_token %}
-            <fieldset>
-                <legend>{% translate "Dataset" %}</legend>
-                {{ form.target.as_field_group }}
-            </fieldset>
-            <fieldset>
-                <legend>{% translate "Data fields" %}</legend>
-                <div class="d-flex">
-                    <div class="ml-auto form-check">
-                        <input type="checkbox" id="select-all" name="select-all">
-                        <label for="select-all">{% translate "Select all" %}</label>
-                    </div>
-                </div>
-                {% for field in form.export_fields %}
-                    {{ field.as_field_group }}
-                {% endfor %}
-            </fieldset>
-            <fieldset>
-                <legend>{% translate "Export settings" %}</legend>
-                {{ form.export_format.as_field_group }}
-                <div id="data-delimiter">
-                    {{ form.data_delimiter.as_field_group }}
-                </div>
-            </fieldset>
+  <section role="tabpanel" id="tabpanel-custom" aria-labelledby="tab-custom" tabindex="0" aria-hidden="false">
+    <p>
+      {% blocktranslate trimmed %}
+        Build your own custom export here, by selecting all the data you need,
+        and the export format. CSV exports can be opened with Excel and similar
+        applications, while JSON exports are often used for integration with
+        other tools.
+      {% endblocktranslate %}
+    </p>
+    <form method="post">
+      {% csrf_token %}
+      <fieldset>
+        <legend>{% translate "Dataset" %}</legend>
+        {{ form.target.as_field_group }}
+      </fieldset>
+      <fieldset>
+        <legend>{% translate "Data fields" %}</legend>
+        <div class="d-flex">
+          <div class="ml-auto form-check">
+            <input type="checkbox" id="select-all" name="select-all">
+            <label for="select-all">{% translate "Select all" %}</label>
+          </div>
+        </div>
+        {% for field in form.export_fields %}
+          {{ field.as_field_group }}
+        {% endfor %}
+      </fieldset>
+      <fieldset>
+        <legend>{% translate "Export settings" %}</legend>
+        {{ form.export_format.as_field_group }}
+        <div id="data-delimiter">
+          {{ form.data_delimiter.as_field_group }}
+        </div>
+      </fieldset>
 
-            {% include "orga/includes/submit_row.html" %}
+      {% include "orga/includes/submit_row.html" %}
 
-        </form>
+    </form>
 
-    </section>
-    <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="true">
-        <p>
-            {% blocktranslate trimmed %}
-                eventyay provides a range of exports. If none of these match what you are looking
-                for, you can also provide a custom plugin to export the data – please ask
-                your administrator to install the plugin.
-            {% endblocktranslate %}
-            {% blocktranslate trimmed %}
-                If you are looking for exports of proposals, sessions or schedule data, please head
-                here:
-            {% endblocktranslate %}
-            <a class="btn btn-outline-info btn-sm" href="{{ request.event.orga_urls.schedule_export }}">{% translate "Schedule exports" %}</a>
-        </p>
-        <p>
-            {% blocktranslate trimmed %}
-                You can either create exactly the export you need in the “Custom” tab, or use these pre-built exports:
-            {% endblocktranslate %}
-        </p>
-        <ul>
-            {% for exporter in exporters %}
-                <li>
-                    <a href="{{ exporter.urls.base }}">
-                        {% if exporter.icon|slice:":3" == "fa-" %}
-                            <i class="fa {{ exporter.icon }}"></i>
-                        {% else %}
-                            {{ exporter.icon }}
-                        {% endif %}
-                        {{ exporter.verbose_name }}
-                        {% if exporter.show_qrcode %}
-                            <span class="export-qrcode">
-                                <i class="fa fa-qrcode"></i>
-                                <div class="export-qrcode-image">{{ exporter.get_qrcode }}</div>
-                            </span>
-                        {% endif %}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-    </section>
-    <section role="tabpanel" id="tabpanel-api" aria-labelledby="tab-api" tabindex="0" aria-hidden="true">
-        <p>
-            {% translate "You can also use the API to export or use data." %}
-        </p>
+  </section>
+  <section role="tabpanel" id="tabpanel-general" aria-labelledby="tab-general" tabindex="0" aria-hidden="true">
+    <p>
+      {% blocktranslate trimmed %}
+        eventyay provides a range of exports. If none of these match what you are looking
+        for, you can also provide a custom plugin to export the data – please ask
+        your administrator to install the plugin.
+      {% endblocktranslate %}
+      {% blocktranslate trimmed %}
+        If you are looking for exports of proposals, sessions or schedule data, please head
+        here:
+      {% endblocktranslate %}
+      <a class="btn btn-outline-info btn-sm" href="{{ request.event.orga_urls.schedule_export }}">{% translate "Schedule exports" %}</a>
+    </p>
+    <p>
+      {% blocktranslate trimmed %}
+        You can either create exactly the export you need in the “Custom” tab, or use these pre-built exports:
+      {% endblocktranslate %}
+    </p>
+    <ul>
+      {% for exporter in exporters %}
+        <li>
+          <a href="{{ exporter.urls.base }}">
+            {% if exporter.icon|slice:":3" == "fa-" %}
+              <i class="fa {{ exporter.icon }}"></i>
+            {% else %}
+              {{ exporter.icon }}
+            {% endif %}
+            {{ exporter.verbose_name }}
+            {% if exporter.show_qrcode %}
+              <span class="export-qrcode">
+                <i class="fa fa-qrcode"></i>
+                <div class="export-qrcode-image">{{ exporter.get_qrcode }}</div>
+              </span>
+            {% endif %}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+  <section role="tabpanel" id="tabpanel-api" aria-labelledby="tab-api" tabindex="0" aria-hidden="true">
+    <p>
+      {% translate "You can also use the API to export or use data." %}
+    </p>
 
-        <p>
-            {% blocktranslate trimmed %}
-                Some of the general exports are only accessible for organisers, or include
-                more information when accessed with your organiser account. If you want to
-                access the organiser version in automatic integrations, you’ll have to
-                provide your authentication token just like in the API, like this:
-            {% endblocktranslate %}
-        </p>
+    <p>
+      {% blocktranslate trimmed %}
+        Some of the general exports are only accessible for organisers, or include
+        more information when accessed with your organiser account. If you want to
+        access the organiser version in automatic integrations, you’ll have to
+        provide your authentication token just like in the API, like this:
+      {% endblocktranslate %}
+    </p>
 
             <pre> curl -H "Authorization: Token {{ request.user.auth_token.key }}" {{ request.event.api_urls.speakers.full }} </pre>
 
-        <div class="submit-group"><span></span><span>
-            <a class="btn btn-lg btn-info" href="#">
-                <i class="fa fa-book"></i>
-                {% translate "Documentation" %}
-            </a>
-            <a class="btn btn-lg btn-success" href="{{ request.event.api_urls.base }}">
-                {% translate "Go to API" %}
-            </a>
-        </span>
-        </div>
-    </section>
-    <script defer src="{% static "orga/js/speaker_export.js" %}"></script>
+    <div class="submit-group"><span></span><span>
+      <a class="btn btn-lg btn-info" href="#">
+        <i class="fa fa-book"></i>
+        {% translate "Documentation" %}
+      </a>
+      <a class="btn btn-lg btn-success" href="{{ request.event.api_urls.base }}">
+        {% translate "Go to API" %}
+      </a>
+    </span>
+    </div>
+  </section>
+  <script defer src="{% static "orga/js/speaker_export.js" %}"></script>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -6,102 +6,102 @@
 {% load static %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/lightbox.js" %}"></script>
-    {% endcompress %}
-    {% if form.biography %}
-        <script src="{% static "vendored/marked.min.js" %}" defer></script> {# do not compress #}
-        <script defer src="{% static "vendored/purify.min.js" %}"></script>
-    {% endif %}
+  {% compress js %}
+    <script defer src="{% static "common/js/lightbox.js" %}"></script>
+  {% endcompress %}
+  {% if form.biography %}
+    <script src="{% static "vendored/marked.min.js" %}" defer></script> {# do not compress #}
+    <script defer src="{% static "vendored/purify.min.js" %}"></script>
+  {% endif %}
 {% endblock scripts %}
 
 {% block extra_title %}{{ form.instance.user.get_display_name }} :: {% endblock extra_title %}
 
 {% block alternate_link %}
-    <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.speakers.full }}{{ form.instance.code }}" />
+  <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.speakers.full }}{{ form.instance.code }}" />
 {% endblock alternate_link %}
 
 {% block content %}
-    {% has_perm "orga.change_speaker" request.user form.instance as can_edit_speaker %}
-    {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
-    <h2 class="d-flex justify-content-between align-items-baseline">
-        {% include "orga/includes/user_name.html" with user=form.instance.user lightbox=True %}
-        <span class="ml-2">
-            ({{ submissions.count }}
-            {% blocktranslate asvar proposal_title trimmed count count=submissions.count %}
-                proposal
-            {% plural %}
-                proposals
-            {% endblocktranslate %}
-            {{ proposal_title }})
-        </span>
-        <div class="ml-auto mb-1">
-            <a href="{{ form.instance.orga_urls.password_reset }}" class="btn btn-info flip">{{ phrases.base.password_reset_heading }}</a>
-            {% if can_send_mails %}
-                <a class="btn btn-outline-info ml-2" href="{{ request.event.orga_urls.compose_mails_sessions }}?speakers={{ form.instance.user.code }}">
-                    <i class="fa fa-envelope"></i>
-                    {% translate "Send email" %}
-                </a>
-            {% endif %}
-        </div>
-    </h2>
-    <div class="alert alert-info col-md-9 flip offset-md-3">
-        <span>
-            <h5>
-                {{ proposal_title|capfirst }}
-            </h5>
-            <ul>
-                {% for submission in submissions %}
-                    <li>
-                        <a href="{{ submission.orga_urls.base }}">
-                            {{ submission.title }}
-                            ({% include "cfp/event/fragment_state.html" with state=submission.state %}{% if submission.pending_state %}, {% translate "pending" %}{% include "cfp/event/fragment_state.html" with state=submission.pending_state %}{% endif %})
-                        </a>
-                    </li>
-                {% endfor %}
-            </ul>
-        </span>
+  {% has_perm "orga.change_speaker" request.user form.instance as can_edit_speaker %}
+  {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
+  <h2 class="d-flex justify-content-between align-items-baseline">
+    {% include "orga/includes/user_name.html" with user=form.instance.user lightbox=True %}
+    <span class="ml-2">
+      ({{ submissions.count }}
+      {% blocktranslate asvar proposal_title trimmed count count=submissions.count %}
+        proposal
+      {% plural %}
+        proposals
+      {% endblocktranslate %}
+      {{ proposal_title }})
+    </span>
+    <div class="ml-auto mb-1">
+      <a href="{{ form.instance.orga_urls.password_reset }}" class="btn btn-info flip">{{ phrases.base.password_reset_heading }}</a>
+      {% if can_send_mails %}
+        <a class="btn btn-outline-info ml-2" href="{{ request.event.orga_urls.compose_mails_sessions }}?speakers={{ form.instance.user.code }}">
+          <i class="fa fa-envelope"></i>
+          {% translate "Send email" %}
+        </a>
+      {% endif %}
     </div>
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        {% include "common/forms/errors.html" %}
+  </h2>
+  <div class="alert alert-info col-md-9 flip offset-md-3">
+    <span>
+      <h5>
+        {{ proposal_title|capfirst }}
+      </h5>
+      <ul>
+        {% for submission in submissions %}
+          <li>
+            <a href="{{ submission.orga_urls.base }}">
+              {{ submission.title }}
+              ({% include "cfp/event/fragment_state.html" with state=submission.state %}{% if submission.pending_state %}, {% translate "pending" %}{% include "cfp/event/fragment_state.html" with state=submission.pending_state %}{% endif %})
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </span>
+  </div>
+  <form method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {% include "common/forms/errors.html" %}
 
-        {{ form.name.as_field_group }}
-        {{ form.email.as_field_group }}
-        {% if form.avatar %}
-            {% include "common/avatar.html" with user=form.instance.user form=form %}
-        {% endif %}
-        {% if form.avatar_source %}{{ form.avatar_source.as_field_group }}{% endif %}
-        {% if form.avatar_license %}{{ form.avatar_license.as_field_group }}{% endif %}
-
-        {% if form.biography %}
-            {{ form.biography.as_field_group }}
-        {% endif %}
-        {% if form.availabilities %}
-            {% include "common/availabilities.html" %}
-
-            {{ form.availabilities.as_field_group }}
-        {% endif %}
-
-        {{ questions_form }}
-
-        {% include "orga/includes/submit_row.html" %}
-
-    </form>
-
-    <h3>{% translate "Emails" %}</h3>
-    {% if mails %}
-
-        {% include "common/mail_log.html" %}
-
-    {% else %}
-        {% translate "No mails were sent to this speaker yet." %}
+    {{ form.name.as_field_group }}
+    {{ form.email.as_field_group }}
+    {% if form.avatar %}
+      {% include "common/avatar.html" with user=form.instance.user form=form %}
     {% endif %}
+    {% if form.avatar_source %}{{ form.avatar_source.as_field_group }}{% endif %}
+    {% if form.avatar_license %}{{ form.avatar_license.as_field_group }}{% endif %}
+
+    {% if form.biography %}
+      {{ form.biography.as_field_group }}
+    {% endif %}
+    {% if form.availabilities %}
+      {% include "common/availabilities.html" %}
+
+      {{ form.availabilities.as_field_group }}
+    {% endif %}
+
+    {{ questions_form }}
+
+    {% include "orga/includes/submit_row.html" %}
+
+  </form>
+
+  <h3>{% translate "Emails" %}</h3>
+  {% if mails %}
+
+    {% include "common/mail_log.html" %}
+
+  {% else %}
+    {% translate "No mails were sent to this speaker yet." %}
+  {% endif %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/speaker/information_form.html
+++ b/src/pretalx/orga/templates/orga/speaker/information_form.html
@@ -5,14 +5,14 @@
 {% block extra_title %}{% blocktranslate trimmed count count=1 %}Speaker Information Note{% plural %}Speaker Information Notes{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% blocktranslate trimmed count count=1 %}
-            Speaker Information Note
-        {% plural %}
-            Speaker Information Notes
-        {% endblocktranslate %}
-    </h2>
+  <h2>
+    {% blocktranslate trimmed count count=1 %}
+      Speaker Information Note
+    {% plural %}
+      Speaker Information Notes
+    {% endblocktranslate %}
+  </h2>
 
-    {% include "orga/includes/base_form.html" %}
+  {% include "orga/includes/base_form.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/speaker/information_list.html
+++ b/src/pretalx/orga/templates/orga/speaker/information_list.html
@@ -5,73 +5,73 @@
 {% load static %}
 
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/modalDialog.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{{ information.count }} {% blocktranslate trimmed count count=information.count %}Speaker Information Note{% plural %}Speaker Information Notes{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {{ information.count }}
-        {% blocktranslate trimmed count count=information.count %}
-            Speaker Information Note
-        {% plural %}
-            Speaker Information Notes
-        {% endblocktranslate %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
-    <dialog class="info-dialog" id="info-dialog">
-        <div class="alert alert-info">
-            {% blocktranslate trimmed %}
-                Add important messages (e.g. “Please bring an HDMI adapter if required.”) or files (e.g. a conference styleguide).
-                <br>
-                They are shown to the selected speakers above the list of their submitted sessions.
-            {% endblocktranslate %}
-        </div>
-    </dialog>
-    <div class="d-flex justify-content-end mb-3"><span></span>
-        <a href="{{ request.event.orga_urls.new_information }}" class="btn btn-info">
-            <i class="fa fa-plus"></i>
-            {% translate "Add a new note" %}
-        </a>
+  <h2>
+    {{ information.count }}
+    {% blocktranslate trimmed count count=information.count %}
+      Speaker Information Note
+    {% plural %}
+      Speaker Information Notes
+    {% endblocktranslate %}
+    <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+      <i class="fa fa-question-circle-o text-info"></i>
+    </span>
+  </h2>
+  <dialog class="info-dialog" id="info-dialog">
+    <div class="alert alert-info">
+      {% blocktranslate trimmed %}
+        Add important messages (e.g. “Please bring an HDMI adapter if required.”) or files (e.g. a conference styleguide).
+        <br>
+        They are shown to the selected speakers above the list of their submitted sessions.
+      {% endblocktranslate %}
     </div>
-    <div class="table-responsive-md">
-        <table class="table table-sm table-hover table-flip table-sticky">
-            <thead>
-                <tr>
-                    <th>{% translate "Title" %}</th>
-                    <th>{% translate "Target group" %}</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for info in information %}
-                    <tr>
-                        <td>
-                            <a href="{{ info.orga_urls.edit }}">{{ info.title }}</a>
-                            {% if info.resource %}<a href="{{ info.resource.url }}"><i class="fa fa-paperclip"></i></a>{% endif %}
-                        </td>
-                        <td>{{ info.target_group }}</td>
-                        <td class="text-right">
-                            <a href="{{ info.orga_urls.edit }}" class="btn btn-sm btn-info"><i class="fa fa-edit"></i></a>
-                            <a href="{{ info.orga_urls.delete }}" class="btn btn-sm btn-danger"><i class="fa fa-trash"></i></a>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+  </dialog>
+  <div class="d-flex justify-content-end mb-3"><span></span>
+    <a href="{{ request.event.orga_urls.new_information }}" class="btn btn-info">
+      <i class="fa fa-plus"></i>
+      {% translate "Add a new note" %}
+    </a>
+  </div>
+  <div class="table-responsive-md">
+    <table class="table table-sm table-hover table-flip table-sticky">
+      <thead>
+        <tr>
+          <th>{% translate "Title" %}</th>
+          <th>{% translate "Target group" %}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for info in information %}
+          <tr>
+            <td>
+              <a href="{{ info.orga_urls.edit }}">{{ info.title }}</a>
+              {% if info.resource %}<a href="{{ info.resource.url }}"><i class="fa fa-paperclip"></i></a>{% endif %}
+            </td>
+            <td>{{ info.target_group }}</td>
+            <td class="text-right">
+              <a href="{{ info.orga_urls.edit }}" class="btn btn-sm btn-info"><i class="fa fa-edit"></i></a>
+              <a href="{{ info.orga_urls.delete }}" class="btn btn-sm btn-danger"><i class="fa fa-trash"></i></a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/speaker/list.html
+++ b/src/pretalx/orga/templates/orga/speaker/list.html
@@ -6,79 +6,79 @@
 {% block extra_title %}{{ page_obj.paginator.count }} {% blocktranslate trimmed count count=page_obj.paginator.count %}submitter{% plural %}submitters{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {{ page_obj.paginator.count }}
-        {% blocktranslate trimmed count count=page_obj.paginator.count %}
-            submitter
-        {% plural %}
-            submitters
-        {% endblocktranslate %}
-    </h2>
+  <h2>
+    {{ page_obj.paginator.count }}
+    {% blocktranslate trimmed count count=page_obj.paginator.count %}
+      submitter
+    {% plural %}
+      submitters
+    {% endblocktranslate %}
+  </h2>
 
-    {% include "common/includes/search_form.html" %}
+  {% include "common/includes/search_form.html" %}
 
-    {% if filter_form.is_valid and filter_form.cleaned_data.question %}
-        <p class="text-muted ml-2">
-            <span class="fa fa-filter"></span>
-            {% blocktranslate trimmed with question=filter_form.cleaned_data.question.question %}
-                List filtered by answers to question “{{ question }}”.
-            {% endblocktranslate %}
-            <a href="{% querystring question="" answer="" answer__options="" %}" class="text-muted">
-                <span class="fa fa-times"></span>
-                {% translate "Remove filter" %}
-            </a>
-        </p>
-    {% endif %}
+  {% if filter_form.is_valid and filter_form.cleaned_data.question %}
+    <p class="text-muted ml-2">
+      <span class="fa fa-filter"></span>
+      {% blocktranslate trimmed with question=filter_form.cleaned_data.question.question %}
+        List filtered by answers to question “{{ question }}”.
+      {% endblocktranslate %}
+      <a href="{% querystring question="" answer="" answer__options="" %}" class="text-muted">
+        <span class="fa fa-times"></span>
+        {% translate "Remove filter" %}
+      </a>
+    </p>
+  {% endif %}
 
-    {% has_perm "orga.mark_speakers_arrived" request.user request.event as can_mark_speaker %}
-    {% has_perm "orga.see_speakers_arrival" request.user request.event as can_see_speaker_status %}
-    <div class="table-responsive-md">
-        <table class="table table-sm table-hover table-flip table-sticky">
-            <thead>
-                <tr>
-                    <th>{% translate "Name" %}</th>
-                    <th class="numeric">{% translate "Accepted Proposals" %}</th>
-                    <th class="numeric">{% translate "Proposals" %}</th>
-                    {% if can_mark_speaker or can_see_speaker_status %}<th></th>{% endif %}
-                </tr>
-            </thead>
-            <tbody>
-                {% for profile in speakers %}
-                    <tr>
-                        <td>
-                            <a href="{{ profile.orga_urls.base }}">
-                                {% include "orga/includes/user_name.html" with user=profile.user %}
-                            </a>
-                        </td>
-                        <td class="numeric">{{ profile.accepted_submission_count }}</td>
-                        <td class="numeric">{{ profile.submission_count }}</td>
-                        {% if can_mark_speaker or can_see_speaker_status %}
-                            <td class="text-right">
-                                {% if profile.accepted_submission_count %}
-                                    {% if can_mark_speaker %}
-                                        <a class="btn btn-sm btn-{{ profile.has_arrived|yesno:"success,info" }}" href="{{ profile.orga_urls.toggle_arrived }}?from=list">
-                                            {% if profile.has_arrived %}
-                                                {% translate "Mark speaker as not arrived" %}
-                                            {% else %}
-                                                {% translate "Mark speaker as arrived" %}
-                                            {% endif %}
-                                        </a>
-                                    {% else %}
-                                        {% if profile.has_arrived %}
-                                            <a><i class="fa fa-check"></i> {% translate "Arrived" %}</a>
-                                        {% else %}
-                                            <a><i class="fa fa-times"></i> {% translate "Not arrived" %}</a>
-                                        {% endif %}
-                                    {% endif %}
-                                {% endif %}
-                            </td>
-                        {% endif %}
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+  {% has_perm "orga.mark_speakers_arrived" request.user request.event as can_mark_speaker %}
+  {% has_perm "orga.see_speakers_arrival" request.user request.event as can_see_speaker_status %}
+  <div class="table-responsive-md">
+    <table class="table table-sm table-hover table-flip table-sticky">
+      <thead>
+        <tr>
+          <th>{% translate "Name" %}</th>
+          <th class="numeric">{% translate "Accepted Proposals" %}</th>
+          <th class="numeric">{% translate "Proposals" %}</th>
+          {% if can_mark_speaker or can_see_speaker_status %}<th></th>{% endif %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for profile in speakers %}
+          <tr>
+            <td>
+              <a href="{{ profile.orga_urls.base }}">
+                {% include "orga/includes/user_name.html" with user=profile.user %}
+              </a>
+            </td>
+            <td class="numeric">{{ profile.accepted_submission_count }}</td>
+            <td class="numeric">{{ profile.submission_count }}</td>
+            {% if can_mark_speaker or can_see_speaker_status %}
+              <td class="text-right">
+                {% if profile.accepted_submission_count %}
+                  {% if can_mark_speaker %}
+                    <a class="btn btn-sm btn-{{ profile.has_arrived|yesno:"success,info" }}" href="{{ profile.orga_urls.toggle_arrived }}?from=list">
+                      {% if profile.has_arrived %}
+                        {% translate "Mark speaker as not arrived" %}
+                      {% else %}
+                        {% translate "Mark speaker as arrived" %}
+                      {% endif %}
+                    </a>
+                  {% else %}
+                    {% if profile.has_arrived %}
+                      <a><i class="fa fa-check"></i> {% translate "Arrived" %}</a>
+                    {% else %}
+                      <a><i class="fa fa-times"></i> {% translate "Not arrived" %}</a>
+                    {% endif %}
+                  {% endif %}
+                {% endif %}
+              </td>
+            {% endif %}
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/submission/anonymise.html
+++ b/src/pretalx/orga/templates/orga/submission/anonymise.html
@@ -9,67 +9,67 @@
 {% block submission_title %}{% translate "Anonymisation" %} :: {% endblock submission_title %}
 
 {% block scripts %}
-    {{ block.super }}
-    {% compress js %}
-        <script defer src="{% static "common/js/modalDialog.js" %}"></script>
-        <script defer src="{% static "orga/js/anonymise.js" %}"></script>
-    {% endcompress %}
+  {{ block.super }}
+  {% compress js %}
+    <script defer src="{% static "common/js/modalDialog.js" %}"></script>
+    <script defer src="{% static "orga/js/anonymise.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block submission_content %}
-    <form method="post" enctype="multipart/form-data"><fieldset>
-        {% include "common/forms/errors.html" %}
-        {% csrf_token %}
+  <form method="post" enctype="multipart/form-data"><fieldset>
+    {% include "common/forms/errors.html" %}
+    {% csrf_token %}
 
-        <div id="anonymise">
-            <div>
-                <div class="plaintext">
-                    <h2>{% translate "Original" %}</h2>
-                </div>
-                <div class="anonymised">
-                    <h2>
-                        {% translate "Anonymised" %}
-                        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-                            <i class="fa fa-question-circle-o text-info"></i>
-                        </span>
-                    </h2>
-                </div>
-            </div>
-            <dialog class="info-dialog" id="info-dialog">
-                <div class="alert alert-info">
-                    {% blocktranslate trimmed %}
-                        If a review phase with anonymisation is currently active, all reviewers
-                        who have no permissions to change this proposal will be shown the anonymised
-                        proposal content.
-                    {% endblocktranslate %}
-                </div>
-            </dialog>
-            {% for field in form %}
-                <h4>{{ field.label }}</h4>
-                <div>
-                    <div class="plaintext"><p>{{ field.field.plaintext|rich_text }}</p></div>
-                    <div class="anonymised">{{ field.as_field_group }}</div>
-                </div>
-            {% endfor %}
+    <div id="anonymise">
+      <div>
+        <div class="plaintext">
+          <h2>{% translate "Original" %}</h2>
         </div>
-        <div class="submit-group panel">
-            <span></span>
-            <span>
-                <button type="submit" class="btn btn-success btn-lg" name="action" value="save">
-                    <i class="fa fa-check"></i>
-                    {{ phrases.base.save }}
-                </button>
-                {% if next_unanonymised %}
-                    <button type="submit" class="btn btn-info btn-lg" name="action" value="next">
-                        <i class="fa fa-arrow-right"></i>
-                        {% translate "Save and go to next unanonymised" %}
-                    </button>
-                {% endif %}
+        <div class="anonymised">
+          <h2>
+            {% translate "Anonymised" %}
+            <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+              <i class="fa fa-question-circle-o text-info"></i>
             </span>
+          </h2>
         </div>
-    </fieldset></form>
-
-    <div id="anon-menu" class="d-none">
-        <button>{% translate "Replace selection with █" %}</button>
+      </div>
+      <dialog class="info-dialog" id="info-dialog">
+        <div class="alert alert-info">
+          {% blocktranslate trimmed %}
+            If a review phase with anonymisation is currently active, all reviewers
+            who have no permissions to change this proposal will be shown the anonymised
+            proposal content.
+          {% endblocktranslate %}
+        </div>
+      </dialog>
+      {% for field in form %}
+        <h4>{{ field.label }}</h4>
+        <div>
+          <div class="plaintext"><p>{{ field.field.plaintext|rich_text }}</p></div>
+          <div class="anonymised">{{ field.as_field_group }}</div>
+        </div>
+      {% endfor %}
     </div>
+    <div class="submit-group panel">
+      <span></span>
+      <span>
+        <button type="submit" class="btn btn-success btn-lg" name="action" value="save">
+          <i class="fa fa-check"></i>
+          {{ phrases.base.save }}
+        </button>
+        {% if next_unanonymised %}
+          <button type="submit" class="btn btn-info btn-lg" name="action" value="next">
+            <i class="fa fa-arrow-right"></i>
+            {% translate "Save and go to next unanonymised" %}
+          </button>
+        {% endif %}
+      </span>
+    </div>
+  </fieldset></form>
+
+  <div id="anon-menu" class="d-none">
+    <button>{% translate "Replace selection with █" %}</button>
+  </div>
 {% endblock submission_content %}

--- a/src/pretalx/orga/templates/orga/submission/apply_pending.html
+++ b/src/pretalx/orga/templates/orga/submission/apply_pending.html
@@ -5,46 +5,46 @@
 {% block extra_title %}{% translate "Apply pending changes" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <form method="post">
-        {% if submission_count %}
-            <h3>
-                {% blocktranslate with count=submission_count trimmed %}
-                    Apply {{ count }} pending changes?
-                {% endblocktranslate %}
-            </h3>
+  <form method="post">
+    {% if submission_count %}
+      <h3>
+        {% blocktranslate with count=submission_count trimmed %}
+          Apply {{ count }} pending changes?
+        {% endblocktranslate %}
+      </h3>
 
-            <p>
-                {% blocktranslate trimmed %}
-                    Please confirm that you really want to change the state of these {{ count }} proposals.
-                {% endblocktranslate %}
-            </p>
+      <p>
+        {% blocktranslate trimmed %}
+          Please confirm that you really want to change the state of these {{ count }} proposals.
+        {% endblocktranslate %}
+      </p>
 
-            {% csrf_token %}
-            <input type="hidden" name="next" value="{{ next }}">
+      {% csrf_token %}
+      <input type="hidden" name="next" value="{{ next }}">
 
-            <div class="submit-group"><span></span><span>
-                <a
-                    class="btn btn-lg btn-outline-info"
-                    href="{% if request.GET.next %}{{ request.GET.next }}{% else %}{{ request.event.orga_urls.submissions }}{% endif %}"
-                >
-                    {{ phrases.base.back_button }}
-                </a>
-                <button type="submit" class="btn btn-lg btn-success">
-                    {% translate "Do it" %}
-                </button>
-            </span></div>
-        {% else %}
-            <p>
-                {% translate "There are no pending changes to apply right now." %}
-            </p>
-            <div class="submit-group" id="submission-state-change"><span></span><span>
-                <a
-                    class="btn btn-lg btn-outline-info"
-                    href="{% if request.GET.next %}{{ request.GET.next }}{% else %}{{ request.event.orga_urls.submissions }}{% endif %}"
-                >
-                    {{ phrases.base.back_button }}
-                </a>
-            </span></div>
-        {% endif %}
-    </form>
+      <div class="submit-group"><span></span><span>
+        <a
+          class="btn btn-lg btn-outline-info"
+          href="{% if request.GET.next %}{{ request.GET.next }}{% else %}{{ request.event.orga_urls.submissions }}{% endif %}"
+        >
+          {{ phrases.base.back_button }}
+        </a>
+        <button type="submit" class="btn btn-lg btn-success">
+          {% translate "Do it" %}
+        </button>
+      </span></div>
+    {% else %}
+      <p>
+        {% translate "There are no pending changes to apply right now." %}
+      </p>
+      <div class="submit-group" id="submission-state-change"><span></span><span>
+        <a
+          class="btn btn-lg btn-outline-info"
+          href="{% if request.GET.next %}{{ request.GET.next }}{% else %}{{ request.event.orga_urls.submissions }}{% endif %}"
+        >
+          {{ phrases.base.back_button }}
+        </a>
+      </span></div>
+    {% endif %}
+  </form>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/submission/base.html
+++ b/src/pretalx/orga/templates/orga/submission/base.html
@@ -7,104 +7,104 @@
 {% load static %}
 
 {% block extra_title %}
-    {% block submission_title %}{% endblock submission_title %}
-    {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
-    {% if can_view_speakers %}{{ submission.title }}{% else %}{{ submission.anonymised.title|default:submission.title }}{% endif %} ::
+  {% block submission_title %}{% endblock submission_title %}
+  {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
+  {% if can_view_speakers %}{{ submission.title }}{% else %}{{ submission.anonymised.title|default:submission.title }}{% endif %} ::
 {% endblock extra_title %}
 
 {% block alternate_link %}
-    <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.talks.full }}{{ submission.code }}" />
+  <link rel="alternate" type="application/json" title="{{ request.event.name }} API" href="{{ request.event.api_urls.talks.full }}{{ submission.code }}" />
 {% endblock alternate_link %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "common/js/lightbox.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "common/js/lightbox.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 {% block stylesheets %}
-    {% compress css %}
-        <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
-    {% endcompress %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static "common/css/dialog.css" %}">
+  {% endcompress %}
 {% endblock stylesheets %}
 
 {% block content %}
-    {% if submission %}
-        {% has_perm "submission.edit_submission" request.user submission as can_edit_submission %}
-        {% has_perm "orga.view_reviews" request.user request.event as can_view_reviews %}
-        {% has_perm "submission.review_submission" request.user submission as can_review %}
-        {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
-        {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
-        <h2>
-            <span>
-                {{ quotation_open }}{% if can_view_speakers %}{{ submission.title }}{% else %}{{ submission.anonymised.title|default:submission.title }}{% endif %}{{ quotation_close }}
-                {% if submission.speakers.exists and can_view_speakers %}
-                    – {% include "orga/includes/submission_speaker_names.html" with lightbox=True %}
-                {% endif %}
-                {% if can_edit_submission %}
-                    {% include "orga/submission/state_dropdown.html" with submission=submission %}
-                {% else %}
-                    {% include "cfp/event/fragment_state.html" with state=submission.state as_badge=True %}
-                {% endif %}
-            </span>
-        </h2>
+  {% if submission %}
+    {% has_perm "submission.edit_submission" request.user submission as can_edit_submission %}
+    {% has_perm "orga.view_reviews" request.user request.event as can_view_reviews %}
+    {% has_perm "submission.review_submission" request.user submission as can_review %}
+    {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
+    {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
+    <h2>
+      <span>
+        {{ quotation_open }}{% if can_view_speakers %}{{ submission.title }}{% else %}{{ submission.anonymised.title|default:submission.title }}{% endif %}{{ quotation_close }}
+        {% if submission.speakers.exists and can_view_speakers %}
+          – {% include "orga/includes/submission_speaker_names.html" with lightbox=True %}
+        {% endif %}
+        {% if can_edit_submission %}
+          {% include "orga/submission/state_dropdown.html" with submission=submission %}
+        {% else %}
+          {% include "cfp/event/fragment_state.html" with state=submission.state as_badge=True %}
+        {% endif %}
+      </span>
+    </h2>
 
-        <div role="tablist" class="mb-4">
-            <a role="tab" href="{{ submission.orga_urls.base }}" {% if "submissions.content" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
-                {% translate "Content" %}
-            </a>
-            {% if can_view_speakers %}
-                <a role="tab" href="{{ submission.orga_urls.speakers }}" {% if "submissions.speakers" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
-                    {{ phrases.schedule.speakers }}
+    <div role="tablist" class="mb-4">
+      <a role="tab" href="{{ submission.orga_urls.base }}" {% if "submissions.content" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
+        {% translate "Content" %}
+      </a>
+      {% if can_view_speakers %}
+        <a role="tab" href="{{ submission.orga_urls.speakers }}" {% if "submissions.speakers" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
+          {{ phrases.schedule.speakers }}
+        </a>
+      {% endif %}
+      {% if can_edit_submission and has_anonymised_review %}
+        <a role="tab" href="{{ submission.orga_urls.anonymise }}" {% if "submissions.anonymise" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
+          {% translate "Anonymisation" %}
+        </a>
+      {% endif %}
+      {% if submission.feedback.count and request.event|get_feature_flag:"use_feedback" %}
+        <a role="tab" href="{{ submission.orga_urls.feedback }}" {% if "submissions.feedback" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
+          {% translate "Feedback" %}
+        </a>
+      {% endif %}
+      {% if can_view_reviews or can_review %}
+        <a role="tab" href="{{ submission.orga_urls.reviews }}" {% if "submissions.reviews" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
+          {% translate "Reviews" %}
+        </a>
+      {% endif %}
+      <div class="ml-auto flip d-flex">
+        {% if can_send_mails %}
+          <a class="btn btn-outline-info mr-2 mb-1" href="{{ request.event.orga_urls.compose_mails_sessions }}?submissions={{ submission.code }}">
+            <i class="fa fa-envelope"></i>
+            {% translate "Send email to speakers" %}
+          </a>
+        {% endif %}
+        {% if submission.state == "confirmed" or can_view_speakers %}
+          <details class="dropdown" aria-haspopup="menu" role="menu">
+            <summary class="color-primary" role="button">
+              {% translate "Links" %} <i class="fa fa-caret-down"></i>
+            </summary>
+            <div class="dropdown-content dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
+              {% if is_publicly_visible or submission.state == "accepted" or submission.state == "confirmed" %}
+                <a href="{{ submission.urls.public.full }}" class="dropdown-item" target=_blank role="menuitem" tabindex="-1">
+                  <i class="fa fa-link"></i>
+                  {% translate "Public link" %}
+                  {% if not is_publicly_visible %}
+                    ({% translate "not public yet" %})
+                  {% endif %}
                 </a>
-            {% endif %}
-            {% if can_edit_submission and has_anonymised_review %}
-                <a role="tab" href="{{ submission.orga_urls.anonymise }}" {% if "submissions.anonymise" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
-                    {% translate "Anonymisation" %}
+              {% endif %}
+              {% if can_view_speakers and request.event|get_feature_flag:"submission_public_review" %}
+                <a href="{{ submission.urls.review.full }}" class="dropdown-item" target="_blank" role="menuitem" tabindex="-1">
+                  <i class="fa fa-eye"></i>
+                  {% translate "Secret public link" %}
                 </a>
-            {% endif %}
-            {% if submission.feedback.count and request.event|get_feature_flag:"use_feedback" %}
-                <a role="tab" href="{{ submission.orga_urls.feedback }}" {% if "submissions.feedback" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
-                    {% translate "Feedback" %}
-                </a>
-            {% endif %}
-            {% if can_view_reviews or can_review %}
-                <a role="tab" href="{{ submission.orga_urls.reviews }}" {% if "submissions.reviews" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
-                    {% translate "Reviews" %}
-                </a>
-            {% endif %}
-            <div class="ml-auto flip d-flex">
-                {% if can_send_mails %}
-                    <a class="btn btn-outline-info mr-2 mb-1" href="{{ request.event.orga_urls.compose_mails_sessions }}?submissions={{ submission.code }}">
-                        <i class="fa fa-envelope"></i>
-                        {% translate "Send email to speakers" %}
-                    </a>
-                {% endif %}
-                {% if submission.state == "confirmed" or can_view_speakers %}
-                    <details class="dropdown" aria-haspopup="menu" role="menu">
-                        <summary class="color-primary" role="button">
-                            {% translate "Links" %} <i class="fa fa-caret-down"></i>
-                        </summary>
-                        <div class="dropdown-content dropdown-content-s{% if rtl %}e{% else %}w{% endif %}">
-                            {% if is_publicly_visible or submission.state == "accepted" or submission.state == "confirmed" %}
-                                <a href="{{ submission.urls.public.full }}" class="dropdown-item" target=_blank role="menuitem" tabindex="-1">
-                                    <i class="fa fa-link"></i>
-                                    {% translate "Public link" %}
-                                    {% if not is_publicly_visible %}
-                                        ({% translate "not public yet" %})
-                                    {% endif %}
-                                </a>
-                            {% endif %}
-                            {% if can_view_speakers and request.event|get_feature_flag:"submission_public_review" %}
-                                <a href="{{ submission.urls.review.full }}" class="dropdown-item" target="_blank" role="menuitem" tabindex="-1">
-                                    <i class="fa fa-eye"></i>
-                                    {% translate "Secret public link" %}
-                                </a>
-                            {% endif %}
-                        </div>
-                    </details>
-                {% endif %}
+              {% endif %}
             </div>
-        </div>
-    {% endif %}
-    {% block submission_content %}{% endblock submission_content %}
+          </details>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
+  {% block submission_content %}{% endblock submission_content %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/submission/content.html
+++ b/src/pretalx/orga/templates/orga/submission/content.html
@@ -8,99 +8,99 @@
 {% load rules %}
 
 {% block scripts %}
-    {{ block.super }}
-    {% compress js %}
-        <script defer src="{% static "js/jquery.js" %}"></script>
-        <script defer src="{% static "js/jquery.formset.js" %}"></script>
-        <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
-        <script defer src="{% static "orga/js/speakers.js" %}"></script>
-        <script defer src="{% static "orga/js/submission_form.js" %}"></script>
-    {% endcompress %}
+  {{ block.super }}
+  {% compress js %}
+    <script defer src="{% static "js/jquery.js" %}"></script>
+    <script defer src="{% static "js/jquery.formset.js" %}"></script>
+    <script defer src="{% static "cfp/js/animateFormset.js" %}"></script>
+    <script defer src="{% static "orga/js/speakers.js" %}"></script>
+    <script defer src="{% static "orga/js/submission_form.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block submission_content %}
-    {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
-    {% has_perm "orga.view_all_reviews" request.user request.event as can_view_all_reviews %}
-    <form method="post" enctype="multipart/form-data">
+  {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
+  {% has_perm "orga.view_all_reviews" request.user request.event as can_view_all_reviews %}
+  <form method="post" enctype="multipart/form-data">
+    <fieldset>
+      {% if not submission %}
+        <legend>{% translate "Create proposal" %}</legend>
+      {% endif %}
+
+      {% if submission.access_code %}
+        <div class="alert alert-info"><span></span><span>
+          {% blocktranslate trimmed %}
+            This proposal was created using an access code:
+          {% endblocktranslate %} <a href="{{ submission.access_code.urls.edit }}">{{ submission.access_code.code }}</a>
+        </span></div>
+      {% endif %}
+      {% include "common/forms/errors.html" %}
+      {% csrf_token %}
+
+      {{ form.title.as_field_group }}
+
+      {% if action == "create" %}
+        {{ form.state.as_field_group }}
+        </fieldset>
         <fieldset>
-            {% if not submission %}
-                <legend>{% translate "Create proposal" %}</legend>
-            {% endif %}
+          <legend>{% translate "Speaker" %}</legend>
+          {{ new_speaker_form }}
+        </fieldset>
+        <fieldset>
+          <legend>{% translate "Proposal" %}</legend>
+      {% endif %}
+      {% if form.room %}
+        <div id="show-if-state" {% if action == "create" %}class="d-none"{% endif %}>
+          {{ form.room.as_field_group }}
+          {{ form.start.as_field_group }}
+          {{ form.end.as_field_group }}
+        </div>
+      {% endif %}
+      {% if form.instance.median_score != None and can_view_all_reviews %}
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label">
+            {% translate "Reviews" %}
+          </label>
+          <div class="col-md-9">
+            <div class="pt-2">
+              {{ submission.reviews.count }} {% translate "reviews" %}
+            </div>
+          </div>
+        </div>
+      {% endif %}
+      {{ form.submission_type.as_field_group }}
+      {% if form.track %}{{ form.track.as_field_group }}{% endif %}
+      {% if form.tags %}{{ form.tags.as_field_group }}{% endif %}
+      {% if form.abstract %}{{ form.abstract.as_field_group }}{% endif %}
+      {% if form.description %}{{ form.description.as_field_group }}{% endif %}
+      {% if form.notes %}{{ form.notes.as_field_group }}{% endif %}
+      {{ form.internal_notes.as_field_group }}
+      {% if form.content_locale %}{{ form.content_locale.as_field_group }}{% endif %}
+      {% if form.do_not_record %}{{ form.do_not_record.as_field_group }}{% endif %}
+      {{ form.is_featured.as_field_group }}
+      {{ form.duration.as_field_group }}
+      {% if form.slot_count %}{{ form.slot_count.as_field_group }}{% endif %}
+      {% if form.image %}{{ form.image.as_field_group }}{% endif %}
+      {% if action != "create" %}
+        {% include "cfp/includes/submission_resources_form.html" %}
+      {% endif %}
+      {% if questions_form and questions_form.fields %}
+        <div><legend>{% translate "Questions" %}</legend></div>
+        {{ questions_form }}
+      {% endif %}
 
-            {% if submission.access_code %}
-                <div class="alert alert-info"><span></span><span>
-                    {% blocktranslate trimmed %}
-                        This proposal was created using an access code:
-                    {% endblocktranslate %} <a href="{{ submission.access_code.urls.edit }}">{{ submission.access_code.code }}</a>
-                </span></div>
-            {% endif %}
-            {% include "common/forms/errors.html" %}
-            {% csrf_token %}
+      {% if not form.read_only %}
+        <div class="submit-group panel">
+          <span></span>
+          <span>
+            <button type="submit" class="btn btn-success btn-lg">
+              <i class="fa fa-check"></i>
+              {{ phrases.base.save }}
+            </button>
+          </span>
+        </div>
+      {% endif %}
+    </fieldset></form>
 
-            {{ form.title.as_field_group }}
-
-            {% if action == "create" %}
-                {{ form.state.as_field_group }}
-                </fieldset>
-                <fieldset>
-                    <legend>{% translate "Speaker" %}</legend>
-                    {{ new_speaker_form }}
-                </fieldset>
-                <fieldset>
-                    <legend>{% translate "Proposal" %}</legend>
-            {% endif %}
-            {% if form.room %}
-                <div id="show-if-state" {% if action == "create" %}class="d-none"{% endif %}>
-                    {{ form.room.as_field_group }}
-                    {{ form.start.as_field_group }}
-                    {{ form.end.as_field_group }}
-                </div>
-            {% endif %}
-            {% if form.instance.median_score != None and can_view_all_reviews %}
-                <div class="form-group row">
-                    <label class="col-md-3 col-form-label">
-                        {% translate "Reviews" %}
-                    </label>
-                    <div class="col-md-9">
-                        <div class="pt-2">
-                            {{ submission.reviews.count }} {% translate "reviews" %}
-                        </div>
-                    </div>
-                </div>
-            {% endif %}
-            {{ form.submission_type.as_field_group }}
-            {% if form.track %}{{ form.track.as_field_group }}{% endif %}
-            {% if form.tags %}{{ form.tags.as_field_group }}{% endif %}
-            {% if form.abstract %}{{ form.abstract.as_field_group }}{% endif %}
-            {% if form.description %}{{ form.description.as_field_group }}{% endif %}
-            {% if form.notes %}{{ form.notes.as_field_group }}{% endif %}
-            {{ form.internal_notes.as_field_group }}
-            {% if form.content_locale %}{{ form.content_locale.as_field_group }}{% endif %}
-            {% if form.do_not_record %}{{ form.do_not_record.as_field_group }}{% endif %}
-            {{ form.is_featured.as_field_group }}
-            {{ form.duration.as_field_group }}
-            {% if form.slot_count %}{{ form.slot_count.as_field_group }}{% endif %}
-            {% if form.image %}{{ form.image.as_field_group }}{% endif %}
-            {% if action != "create" %}
-                {% include "cfp/includes/submission_resources_form.html" %}
-            {% endif %}
-            {% if questions_form and questions_form.fields %}
-                <div><legend>{% translate "Questions" %}</legend></div>
-                {{ questions_form }}
-            {% endif %}
-
-            {% if not form.read_only %}
-                <div class="submit-group panel">
-                    <span></span>
-                    <span>
-                        <button type="submit" class="btn btn-success btn-lg">
-                            <i class="fa fa-check"></i>
-                            {{ phrases.base.save }}
-                        </button>
-                    </span>
-                </div>
-            {% endif %}
-        </fieldset></form>
-
-    <span id="vars" remoteUrl="{{ request.event.organiser.orga_urls.user_search }}"></span>
+  <span id="vars" remoteUrl="{{ request.event.organiser.orga_urls.user_search }}"></span>
 {% endblock submission_content %}

--- a/src/pretalx/orga/templates/orga/submission/feedback_list.html
+++ b/src/pretalx/orga/templates/orga/submission/feedback_list.html
@@ -6,14 +6,14 @@
 {% block submission_title %}{% translate "Attendee feedback" %} :: {% endblock submission_title %}
 
 {% block submission_content %}
-    {% for entry in feedback %}
-        <div class="card mb-2">
-            <div class="card-body pb-0">{{ entry.review|rich_text }}</div>
-        </div>
-    {% empty %}
-        {{ phrases.schedule.no_feedback }}
-    {% endfor %}
+  {% for entry in feedback %}
+    <div class="card mb-2">
+      <div class="card-body pb-0">{{ entry.review|rich_text }}</div>
+    </div>
+  {% empty %}
+    {{ phrases.schedule.no_feedback }}
+  {% endfor %}
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock submission_content %}

--- a/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
+++ b/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
@@ -7,29 +7,29 @@
 {% block extra_title %}{% translate "Attendee feedback" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2 class="d-flex w-100 justify-content-between align-items-start">{% translate "Attendee feedback" %}</h2>
+  <h2 class="d-flex w-100 justify-content-between align-items-start">{% translate "Attendee feedback" %}</h2>
 
-    {% regroup feedback|dictsort:"talk.title" by talk.title as feedbacks_list %}
+  {% regroup feedback|dictsort:"talk.title" by talk.title as feedbacks_list %}
 
-    {% for submission in feedbacks_list %}
-        <h4>
-            {% translate "Feedback" %}: {{ quotation_open }}<a href="{{ submission.list.0.talk.orga_urls.feedback }}">{{ submission.grouper }}</a>{{ quotation_close }}
-        </h4>
+  {% for submission in feedbacks_list %}
+    <h4>
+      {% translate "Feedback" %}: {{ quotation_open }}<a href="{{ submission.list.0.talk.orga_urls.feedback }}">{{ submission.grouper }}</a>{{ quotation_close }}
+    </h4>
 
-        {% for entry in submission.list %}
-            {% has_perm "submission.view_feedback" request.user entry.talk as can_see_feedback %}
-            {% if can_see_feedback %}
-                <div class="card mb-2">
-                    <div class="card-body pb-0">{{ entry.review|rich_text }}</div>
-                </div>
-            {% endif %}
-        {% endfor %}
-        <br>
-        <br>
-    {% empty %}
-        {% translate "There has been no feedback for sessions in this event yet." %}
+    {% for entry in submission.list %}
+      {% has_perm "submission.view_feedback" request.user entry.talk as can_see_feedback %}
+      {% if can_see_feedback %}
+        <div class="card mb-2">
+          <div class="card-body pb-0">{{ entry.review|rich_text }}</div>
+        </div>
+      {% endif %}
     {% endfor %}
+    <br>
+    <br>
+  {% empty %}
+    {% translate "There has been no feedback for sessions in this event yet." %}
+  {% endfor %}
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/submission/list.html
+++ b/src/pretalx/orga/templates/orga/submission/list.html
@@ -7,172 +7,172 @@
 {% load static %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "orga/js/submission_filter.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "orga/js/submission_filter.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block stylesheets %}
-    {% if timeline_data %}
-        <link rel="alternate" hreflang="en" type="application/rss+xml" title="{% translate "Proposal feed" %}" href="{{ request.event.orga_urls.submission_feed }}">
-    {% endif %}
+  {% if timeline_data %}
+    <link rel="alternate" hreflang="en" type="application/rss+xml" title="{% translate "Proposal feed" %}" href="{{ request.event.orga_urls.submission_feed }}">
+  {% endif %}
 {% endblock stylesheets %}
 
 {% block extra_title %}{{ page_obj.paginator.count }} {% blocktranslate trimmed count count=page_obj.paginator.count %}session{% plural %}sessions{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block content %}
-    {% has_perm "orga.create_submission" request.user request.event as can_create_submission %}
-    {% has_perm "orga.change_submission_state" request.user request.event as can_change_submission %}
-    {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
-    {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
-    <h2 class="d-flex align-items-center">
-        <span>
-            {{ page_obj.paginator.count }}
-            {% blocktranslate trimmed count count=page_obj.paginator.count %}
-                session
-            {% plural %}
-                sessions
-            {% endblocktranslate %}
-        </span>
-        <p class="flip ml-auto">
-            {% if can_send_mails %}
-                <a class="btn btn-outline-info mt-2" href="{{ request.event.orga_urls.compose_mails_sessions }}{% querystring page="" %}">
-                    <i class="fa fa-envelope"></i>
-                    {% translate "Send email" %}
-                </a>
+  {% has_perm "orga.create_submission" request.user request.event as can_create_submission %}
+  {% has_perm "orga.change_submission_state" request.user request.event as can_change_submission %}
+  {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
+  {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
+  <h2 class="d-flex align-items-center">
+    <span>
+      {{ page_obj.paginator.count }}
+      {% blocktranslate trimmed count count=page_obj.paginator.count %}
+        session
+      {% plural %}
+        sessions
+      {% endblocktranslate %}
+    </span>
+    <p class="flip ml-auto">
+      {% if can_send_mails %}
+        <a class="btn btn-outline-info mt-2" href="{{ request.event.orga_urls.compose_mails_sessions }}{% querystring page="" %}">
+          <i class="fa fa-envelope"></i>
+          {% translate "Send email" %}
+        </a>
+      {% endif %}
+      {% if pending_changes and can_change_submission %}
+        <a class="btn btn-info mt-2" href="{{ request.event.orga_urls.apply_pending }}">
+          {% translate "Apply pending changes" %} ({{ pending_changes }})
+        </a>
+      {% endif %}
+      {% if can_create_submission %}
+        <a href="{{ request.event.orga_urls.new_submission }}" class="btn btn-info mt-2">
+          <i class="fa fa-plus"></i> {% translate "Add new session or proposal" %}
+        </a>
+        <a class="btn btn-link" href="{{ request.event.orga_urls.submission_feed }}" title="{% translate "Proposal feed" %}">
+          <i class="fa fa-feed"></i>
+        </a>
+      {% endif %}
+    </p>
+  </h2>
+
+  {% include "orga/includes/submission_filter_form.html" %}
+
+  <div class="table-responsive-sm">
+    <table class="table table-sm table-hover table-flip table-sticky">
+      <thead>
+        <tr>
+          <th>
+            {% if request.event|get_feature_flag:"use_tracks" and filter_form.track %}
+              <a href="{% querystring sort="track__name" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
+              <a href="{% querystring sort="-track__name" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
             {% endif %}
-            {% if pending_changes and can_change_submission %}
-                <a class="btn btn-info mt-2" href="{{ request.event.orga_urls.apply_pending }}">
-                    {% translate "Apply pending changes" %} ({{ pending_changes }})
-                </a>
-            {% endif %}
-            {% if can_create_submission %}
-                <a href="{{ request.event.orga_urls.new_submission }}" class="btn btn-info mt-2">
-                    <i class="fa fa-plus"></i> {% translate "Add new session or proposal" %}
-                </a>
-                <a class="btn btn-link" href="{{ request.event.orga_urls.submission_feed }}" title="{% translate "Proposal feed" %}">
-                    <i class="fa fa-feed"></i>
-                </a>
-            {% endif %}
-        </p>
-    </h2>
-
-    {% include "orga/includes/submission_filter_form.html" %}
-
-    <div class="table-responsive-sm">
-        <table class="table table-sm table-hover table-flip table-sticky">
-            <thead>
-                <tr>
-                    <th>
-                        {% if request.event|get_feature_flag:"use_tracks" and filter_form.track %}
-                            <a href="{% querystring sort="track__name" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
-                            <a href="{% querystring sort="-track__name" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
-                        {% endif %}
-                    </th>
-                    <th>
-                        {% translate "Title" %}
-                        <a href="{% querystring sort="title" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
-                        <a href="{% querystring sort="-title" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
-                    </th>
-                    {% if can_view_speakers %}<th>{{ phrases.schedule.speakers }}</th>{% endif %}
-                    {% if show_submission_types %}
-                        <th>
-                            {% translate "Type" %}
-                            <a href="{% querystring sort="submission_type__name" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
-                            <a href="{% querystring sort="-submission_type__name" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
-                        </th>
-                    {% endif %}
-                    <th>
-                        {% translate "State" %}
-                        <a href="{% querystring sort="state" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
-                        <a href="{% querystring sort="-state" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
-                    </th>
-                    {% if can_change_submission %}
-                        <th>
-                            {% translate "Featured" %} <i class="fa fa-question-circle" data-toggle="tooltip" title="{% translate "Show this session on the list of featured sessions, once it was accepted" %}"></i>
-                            <a href="{% querystring sort="-is_featured" %}"><i class="fa fa-caret-down"></i></a>
-                            <a href="{% querystring sort="is_featured" %}"><i class="fa fa-caret-up"></i></a>
-                        </th>
-                        <th></th>
-                    {% endif %}
-                </tr>
-            </thead>
-            <tbody>
-                {% for submission in submissions %}
-                    <tr>
-                        <td class="text-center">
-                            {% if request.event|get_feature_flag:"use_tracks" and submission.track %}
-                                {% if not submission.is_anonymised %}
-                                    <div class="color-square" style="background-color: {{ submission.track.color }}" title="{{ submission.track.name }}">
-                                    </div>
-                                {% else %}
-                                    <i class="fa fa-user-secret" style="color: {{ submission.track.color }}" title="{{ submission.track.name }}, {% translate "anonymised" %}" aria-hidden="true"></i>
-                                {% endif %}
-                            {% else %}
-                                {% if submission.anonymised %}
-                                    <i class="fa fa-user-secret" style="color: #888" title="{% translate "anonymised" %}" aria-hidden="true"></i>
-                                {% endif %}
-                            {% endif %}
-                        </td>
-                        <td>
-                            <a href="{{ submission.orga_urls.base }}">
-                                {% if can_view_speakers %}
-                                    {{ submission.title }}
-                                {% else %}
-                                    {{ submission.anonymised.title|default:submission.title }}
-                                {% endif %}
-                            </a>
-                        </td>
-                        {% if can_view_speakers %}
-                            <td>
-                                {% for speaker in submission.speakers.all %}
-                                    <a href="{% url "orga:speakers.view" event=request.event.slug code=speaker.code %}">
-                                        {% include "orga/includes/user_name.html" with user=speaker %}
-                                    </a><br>
-                                {% endfor %}
-                            </td>
-                        {% endif %}
-                        {% if show_submission_types %}<td>{{ submission.submission_type.name }}</td>{% endif %}
-                        <td>
-
-                            {% if can_change_submission %}
-                                {% include "orga/submission/state_dropdown.html" with submission=submission %}
-                            {% else %}
-                                {% include "cfp/event/fragment_state.html" with state=submission.state as_badge=True %}
-                            {% endif %}
-
-                        </td>
-                        {% if can_change_submission %}
-                            <td class="submission_featured">
-                                <div class="mt-1 form-check" title="{% translate "Show this proposal in the list of featured sessions." %}">
-                                    <input
-                                        type="checkbox"
-                                        id="featured_{{ submission.code }}"
-                                        data-id="{{ submission.code }}"
-                                        class="submission_featured"
-                                        {% if submission.is_featured %}checked{% endif %}
-                                    >
-                                    <label for="featured_{{ submission.code }}"></label>
-                                </div>
-                                <i class="working fa fa-spinner fa-spin d-none"></i>
-                                <i class="done fa fa-check d-none text-success"></i>
-                                <i class="fail fa fa-times d-none"></i>
-                            </td>
-                            <td class="text-right">
-                                <a href="{{ submission.orga_urls.edit }}" title="{{ phrases.base.edit }}" class="btn btn-sm btn-info">
-                                    <i class="fa fa-edit"></i>
-                                </a>
-                                <a href="{{ submission.orga_urls.delete }}?from=list" title="{{ phrases.base.delete_button }}" class="btn btn-sm btn-danger">
-                                    <i class="fa fa-trash"></i>
-                                </a>
-                            </td>
-                        {% endif %}
-                    </tr>
+          </th>
+          <th>
+            {% translate "Title" %}
+            <a href="{% querystring sort="title" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
+            <a href="{% querystring sort="-title" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
+          </th>
+          {% if can_view_speakers %}<th>{{ phrases.schedule.speakers }}</th>{% endif %}
+          {% if show_submission_types %}
+            <th>
+              {% translate "Type" %}
+              <a href="{% querystring sort="submission_type__name" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
+              <a href="{% querystring sort="-submission_type__name" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
+            </th>
+          {% endif %}
+          <th>
+            {% translate "State" %}
+            <a href="{% querystring sort="state" %}"><i class="fa fa-caret-down" title="{% translate "Sort (a-z)" %}"></i></a>
+            <a href="{% querystring sort="-state" %}"><i class="fa fa-caret-up" title="{% translate "Sort (z-a)" %}"></i></a>
+          </th>
+          {% if can_change_submission %}
+            <th>
+              {% translate "Featured" %} <i class="fa fa-question-circle" data-toggle="tooltip" title="{% translate "Show this session on the list of featured sessions, once it was accepted" %}"></i>
+              <a href="{% querystring sort="-is_featured" %}"><i class="fa fa-caret-down"></i></a>
+              <a href="{% querystring sort="is_featured" %}"><i class="fa fa-caret-up"></i></a>
+            </th>
+            <th></th>
+          {% endif %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for submission in submissions %}
+          <tr>
+            <td class="text-center">
+              {% if request.event|get_feature_flag:"use_tracks" and submission.track %}
+                {% if not submission.is_anonymised %}
+                  <div class="color-square" style="background-color: {{ submission.track.color }}" title="{{ submission.track.name }}">
+                  </div>
+                {% else %}
+                  <i class="fa fa-user-secret" style="color: {{ submission.track.color }}" title="{{ submission.track.name }}, {% translate "anonymised" %}" aria-hidden="true"></i>
+                {% endif %}
+              {% else %}
+                {% if submission.anonymised %}
+                  <i class="fa fa-user-secret" style="color: #888" title="{% translate "anonymised" %}" aria-hidden="true"></i>
+                {% endif %}
+              {% endif %}
+            </td>
+            <td>
+              <a href="{{ submission.orga_urls.base }}">
+                {% if can_view_speakers %}
+                  {{ submission.title }}
+                {% else %}
+                  {{ submission.anonymised.title|default:submission.title }}
+                {% endif %}
+              </a>
+            </td>
+            {% if can_view_speakers %}
+              <td>
+                {% for speaker in submission.speakers.all %}
+                  <a href="{% url "orga:speakers.view" event=request.event.slug code=speaker.code %}">
+                    {% include "orga/includes/user_name.html" with user=speaker %}
+                  </a><br>
                 {% endfor %}
-            </tbody>
-        </table>
-    </div>
+              </td>
+            {% endif %}
+            {% if show_submission_types %}<td>{{ submission.submission_type.name }}</td>{% endif %}
+            <td>
 
-    {% include "orga/includes/pagination.html" %}
+              {% if can_change_submission %}
+                {% include "orga/submission/state_dropdown.html" with submission=submission %}
+              {% else %}
+                {% include "cfp/event/fragment_state.html" with state=submission.state as_badge=True %}
+              {% endif %}
+
+            </td>
+            {% if can_change_submission %}
+              <td class="submission_featured">
+                <div class="mt-1 form-check" title="{% translate "Show this proposal in the list of featured sessions." %}">
+                  <input
+                    type="checkbox"
+                    id="featured_{{ submission.code }}"
+                    data-id="{{ submission.code }}"
+                    class="submission_featured"
+                    {% if submission.is_featured %}checked{% endif %}
+                  >
+                  <label for="featured_{{ submission.code }}"></label>
+                </div>
+                <i class="working fa fa-spinner fa-spin d-none"></i>
+                <i class="done fa fa-check d-none text-success"></i>
+                <i class="fail fa fa-times d-none"></i>
+              </td>
+              <td class="text-right">
+                <a href="{{ submission.orga_urls.edit }}" title="{{ phrases.base.edit }}" class="btn btn-sm btn-info">
+                  <i class="fa fa-edit"></i>
+                </a>
+                <a href="{{ submission.orga_urls.delete }}?from=list" title="{{ phrases.base.delete_button }}" class="btn btn-sm btn-danger">
+                  <i class="fa fa-trash"></i>
+                </a>
+              </td>
+            {% endif %}
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/submission/review.html
+++ b/src/pretalx/orga/templates/orga/submission/review.html
@@ -9,224 +9,224 @@
 {% block submission_title %}{% translate "Reviews" %} :: {% endblock submission_title %}
 
 {% block scripts %}
-    {{ block.super }}
-    <script src="{% static "vendored/marked.min.js" %}" defer></script> {# do not compress #}
-    <script defer src="{% static "vendored/purify.min.js" %}"></script>
-    <script src="{% static "orga/js/reviewSubmission.js" %}" defer></script>
+  {{ block.super }}
+  <script src="{% static "vendored/marked.min.js" %}" defer></script> {# do not compress #}
+  <script defer src="{% static "vendored/purify.min.js" %}"></script>
+  <script src="{% static "orga/js/reviewSubmission.js" %}" defer></script>
 {% endblock scripts %}
 
 {% block submission_content %}
-    {% has_perm "orga.view_reviews" request.user submission as can_view_other_reviews %}
-    {% has_perm "orga.view_reviewer_names" request.user submission as can_view_reviewer_names %}
-    {% if request.user in submission.speakers.all %}
-        <div class="alert alert-error">
-            <span>
-                {% blocktranslate trimmed %}
-                    You’re not allowed to review or see reviews for your own proposals.
-                {% endblocktranslate %}
-            </span>
+  {% has_perm "orga.view_reviews" request.user submission as can_view_other_reviews %}
+  {% has_perm "orga.view_reviewer_names" request.user submission as can_view_reviewer_names %}
+  {% if request.user in submission.speakers.all %}
+    <div class="alert alert-error">
+      <span>
+        {% blocktranslate trimmed %}
+          You’re not allowed to review or see reviews for your own proposals.
+        {% endblocktranslate %}
+      </span>
+    </div>
+  {% else %}
+    {% if not read_only %}
+      {% if request.event.settings.review_help_text %}
+        <div class="alert alert-info">
+          <div>
+            <p>{{ request.event.settings.review_help_text|rich_text }}</p>
+          </div>
         </div>
-    {% else %}
-        {% if not read_only %}
-            {% if request.event.settings.review_help_text %}
-                <div class="alert alert-info">
-                    <div>
-                        <p>{{ request.event.settings.review_help_text|rich_text }}</p>
-                    </div>
-                </div>
-            {% elif not form.instance.pk and not can_view_other_reviews and request.event.active_review_phase and request.event.active_review_phase.can_see_other_reviews == "after_review" %}
-                <div class="alert alert-info">
-                    <p>
-                        {% blocktranslate trimmed %}
-                            You will be able to see other reviews once you have given yours.
-                        {% endblocktranslate %}
-                    </p>
-                </div>
+      {% elif not form.instance.pk and not can_view_other_reviews and request.event.active_review_phase and request.event.active_review_phase.can_see_other_reviews == "after_review" %}
+        <div class="alert alert-info">
+          <p>
+            {% blocktranslate trimmed %}
+              You will be able to see other reviews once you have given yours.
+            {% endblocktranslate %}
+          </p>
+        </div>
+      {% endif %}
+    {% endif %}
+
+    <form method="post" id="review-form">
+      {% csrf_token %}
+      {% include "common/forms/errors.html" %}
+      <div class="form-group row">
+        <label class="col-md-3 col-form-label">{% translate "Title" %}</label>
+        <div class="col-md-9 mt-1">
+          {% if not anonymise_review %}
+            {{ submission.title|default:"-" }}
+          {% else %}
+            {{ submission.anonymised.title|default:submission.title|default:"-" }}
+          {% endif %}
+        </div>
+      </div>
+      <div class="form-group row">
+        <label class="col-md-3 col-form-label">{% translate "Session type" %}</label>
+        <div class="col-md-9 mt-1">{{ submission.submission_type }}</div>
+      </div>
+      {% if submission.track %}
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label">{% translate "Track" %}</label>
+          <div class="col-md-9 mt-1">{{ submission.track.name|default:"-" }}</div>
+        </div>
+      {% endif %}
+      {% if request.event.cfp.request_abstract %}
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label">{% translate "Abstract" %}</label>
+          <div class="col-md-9 mt-1">
+            {% if not anonymise_review %}
+              {{ submission.abstract|rich_text|default:"-" }}
+            {% else %}
+              {{ submission.anonymised.abstract|default:submission.abstract|rich_text|default:"-" }}
             {% endif %}
+          </div>
+        </div>
+      {% endif %}
+      {% if request.event.cfp.request_description %}
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label">{% translate "Description" %}</label>
+          <div class="col-md-9 mt-1">
+            {% if not anonymise_review %}
+              {{ submission.description|rich_text|default:"-" }}
+            {% else %}
+              {{ submission.anonymised.description|default:submission.description|rich_text|default:"-" }}
+            {% endif %}
+          </div>
+        </div>
+      {% endif %}
+      {% if request.event.cfp.request_notes %}
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label">{% translate "Notes" %}</label>
+          <div class="col-md-9 mt-1">
+            {% if not anonymise_review %}
+              {{ submission.notes|rich_text|default:"-" }}
+            {% else %}
+              {{ submission.anonymised.notes|default:submission.notes|rich_text|default:"-" }}
+            {% endif %}
+          </div>
+        </div>
+      {% endif %}
+      {% for answer in submission.reviewer_answers %}
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label">{{ answer.question.question }}</label>
+          <div class="col-md-9 mt-1">
+
+            {% include "common/question_answer.html" with answer=answer %}
+
+          </div>
+        </div>
+      {% endfor %}
+      {% if not anonymise_review %}
+        {% if submission.active_resources %}
+          <div class="form-group row">
+            <label class="col-md-3 col-form-label">{% translate "Resources" %}</label>
+            <div class="col-md-9 mt-1">
+              {% for resource in submission.active_resources %}
+
+                {% include "agenda/includes/submission_resource.html" %}
+
+                {% if not forloop.last %}<br>{% endif %}
+              {% endfor %}
+            </div>
+          </div>
         {% endif %}
-
-        <form method="post" id="review-form">
-            {% csrf_token %}
-            {% include "common/forms/errors.html" %}
-            <div class="form-group row">
-                <label class="col-md-3 col-form-label">{% translate "Title" %}</label>
-                <div class="col-md-9 mt-1">
-                    {% if not anonymise_review %}
-                        {{ submission.title|default:"-" }}
-                    {% else %}
-                        {{ submission.anonymised.title|default:submission.title|default:"-" }}
-                    {% endif %}
-                </div>
+      {% endif %}
+      {% if not anonymise_review %}
+        {% for speaker in profiles %}
+          <div class="form-group row">
+            <label class="col-md-3 col-form-label">
+              {% translate "Biography" %}:
+              {% include "orga/includes/user_name.html" with user=speaker.user lightbox=True %}
+            </label>
+            <div class="col-md-9 mt-1">
+              {% if request.event.cfp.request_biography %}
+                {{ speaker.biography|default:"-"|rich_text }}
+              {% endif %}
+              {% if speaker.submissions.count > 1 %}<br><strong>{% translate "Other proposals" %}:</strong>
+                {% for other_submission in speaker.submissions %}{% if other_submission != submission %}
+                  <a href="{{ other_submission.orga_urls.reviews }}">{{ other_submission.title }}</a>{% if not forloop.last %}, {% endif %}
+                {% endif %}{% endfor %}
+              {% endif %}
             </div>
-            <div class="form-group row">
-                <label class="col-md-3 col-form-label">{% translate "Session type" %}</label>
-                <div class="col-md-9 mt-1">{{ submission.submission_type }}</div>
-            </div>
-            {% if submission.track %}
-                <div class="form-group row">
-                    <label class="col-md-3 col-form-label">{% translate "Track" %}</label>
-                    <div class="col-md-9 mt-1">{{ submission.track.name|default:"-" }}</div>
-                </div>
-            {% endif %}
-            {% if request.event.cfp.request_abstract %}
-                <div class="form-group row">
-                    <label class="col-md-3 col-form-label">{% translate "Abstract" %}</label>
-                    <div class="col-md-9 mt-1">
-                        {% if not anonymise_review %}
-                            {{ submission.abstract|rich_text|default:"-" }}
-                        {% else %}
-                            {{ submission.anonymised.abstract|default:submission.abstract|rich_text|default:"-" }}
-                        {% endif %}
-                    </div>
-                </div>
-            {% endif %}
-            {% if request.event.cfp.request_description %}
-                <div class="form-group row">
-                    <label class="col-md-3 col-form-label">{% translate "Description" %}</label>
-                    <div class="col-md-9 mt-1">
-                        {% if not anonymise_review %}
-                            {{ submission.description|rich_text|default:"-" }}
-                        {% else %}
-                            {{ submission.anonymised.description|default:submission.description|rich_text|default:"-" }}
-                        {% endif %}
-                    </div>
-                </div>
-            {% endif %}
-            {% if request.event.cfp.request_notes %}
-                <div class="form-group row">
-                    <label class="col-md-3 col-form-label">{% translate "Notes" %}</label>
-                    <div class="col-md-9 mt-1">
-                        {% if not anonymise_review %}
-                            {{ submission.notes|rich_text|default:"-" }}
-                        {% else %}
-                            {{ submission.anonymised.notes|default:submission.notes|rich_text|default:"-" }}
-                        {% endif %}
-                    </div>
-                </div>
-            {% endif %}
-            {% for answer in submission.reviewer_answers %}
-                <div class="form-group row">
-                    <label class="col-md-3 col-form-label">{{ answer.question.question }}</label>
-                    <div class="col-md-9 mt-1">
+          </div>
+        {% endfor %}
+      {% endif %}
 
-                        {% include "common/question_answer.html" with answer=answer %}
+      {% if not read_only %}
+        {% if tags_form %}{{ tags_form }}{% endif %}
 
-                    </div>
-                </div>
-            {% endfor %}
-            {% if not anonymise_review %}
-                {% if submission.active_resources %}
-                    <div class="form-group row">
-                        <label class="col-md-3 col-form-label">{% translate "Resources" %}</label>
-                        <div class="col-md-9 mt-1">
-                            {% for resource in submission.active_resources %}
+        <div id="own-review" {% if form.instance.pk %}class="d-none"{% endif %}>
+          {% for score_field in form.get_score_fields %}
+            {{ score_field.as_field_group }}
+          {% endfor %}
+          {{ qform }}
+          {{ form.text.as_field_group }}
+        </div>
+      {% endif %}
 
-                                {% include "agenda/includes/submission_resource.html" %}
+      {% if can_view_other_reviews or form.instance.pk %}
+        <div class="table-responsive-sm">
+          <table class="table review-table table-hover table-flip table-sticky">
+            <tr>
+              <th>{% translate "Score" %}</th>
+              {% if score_categories|length > 1 %}
+                {% for cat in score_categories %}<th>{{ cat.name }}</th>{% endfor %}
+              {% endif %}
+              {% for field in qform %}<th>{{ field.label }}</th>{% endfor %}
+              <th>{% translate "Review" %}</th>
+              <th></th>
+            </tr>
+            <tbody>
+              {% if form.instance.pk and review_display %}
 
-                                {% if not forloop.last %}<br>{% endif %}
-                            {% endfor %}
-                        </div>
-                    </div>
-                {% endif %}
-            {% endif %}
-            {% if not anonymise_review %}
-                {% for speaker in profiles %}
-                    <div class="form-group row">
-                        <label class="col-md-3 col-form-label">
-                            {% translate "Biography" %}:
-                            {% include "orga/includes/user_name.html" with user=speaker.user lightbox=True %}
-                        </label>
-                        <div class="col-md-9 mt-1">
-                            {% if request.event.cfp.request_biography %}
-                                {{ speaker.biography|default:"-"|rich_text }}
-                            {% endif %}
-                            {% if speaker.submissions.count > 1 %}<br><strong>{% translate "Other proposals" %}:</strong>
-                                {% for other_submission in speaker.submissions %}{% if other_submission != submission %}
-                                    <a href="{{ other_submission.orga_urls.reviews }}">{{ other_submission.title }}</a>{% if not forloop.last %}, {% endif %}
-                                {% endif %}{% endfor %}
-                            {% endif %}
-                        </div>
-                    </div>
+                {% include "orga/submission/review_fragment.html" with review=review_display read_only=read_only show_reviewer_name=False %}
+
+              {% endif %}
+              {% if can_view_other_reviews %}
+                {% for review in reviews %}
+
+                  {% include "orga/submission/review_fragment.html" with review=review read_only=True show_reviewer_name=can_view_reviewer_names %}
+
+                {% empty %}
+                  <tr>
+                    <td colspan="100">{% translate "Nobody else has submitted a review yet." %}</td>
+                  </tr>
                 {% endfor %}
+              {% endif %}
+            </tbody>
+          </table>
+        </div>
+      {% endif %}
+      {% if not read_only %}
+        {% if done != total_reviews %}
+          <div class="progress" title="{% translate "Review progress" %}: {{ done }} / {{ total_reviews }}">
+            <div class="progress-bar bg-success" role="progressbar" style="width: {{ percentage }}%" aria-valuenow="{{ done }}" aria-valuemin="0" aria-valuemax="{{ total_reviews }}" title="{% translate "Review progress" %}: {{ done }} / {{ total_reviews }}">
+            </div>
+          </div>
+        {% endif %}
+        <div class="submit-group pb-0 d-flex flex-row-reverse">
+          <div>
+            <div class="d-flex flex-row-reverse">
+              <button type="submit" class="btn btn-lg btn-success ml-1" name="review_submit" value="save_and_next" data-toggle="tooltip" data-placement="bottom" title="{% translate "Go to random next unreviewed proposal" %}">{% translate "Save and next" %}</button>
+              {% if not request.event.review_settings.score_mandatory and not request.event.review_settings.text_mandatory %}
+                <button type="submit" class="btn btn-lg btn-info ml-1" name="review_submit" value="abstain" data-toggle="tooltip" data-placement="bottom" title="{% translate "Go to random next unreviewed proposal" %}">{% translate "Abstain" %}</button>
+              {% endif %}
+              <button type="submit" class="btn btn-lg btn-info" name="review_submit" value="skip_for_now" data-toggle="tooltip" data-placement="bottom" title="{% translate "Go to random next unreviewed proposal, mark this one as skipped" %}">{% translate "Skip for now" %}</button>
+            </div>
+            <div class="text-right">
+              <small><a href="{{ request.event.orga_urls.reviews }}bulk/">
+                {% translate "Or review all proposals at once." %}
+              </a></small>
+            </div>
+          </div>
+          <div>
+            {% if form.instance.pk %}
+              <a href="{{ form.instance.urls.delete }}" class="btn btn-lg btn-outline-danger">{% translate "Delete review" %}</a>
             {% endif %}
-
-            {% if not read_only %}
-                {% if tags_form %}{{ tags_form }}{% endif %}
-
-                <div id="own-review" {% if form.instance.pk %}class="d-none"{% endif %}>
-                    {% for score_field in form.get_score_fields %}
-                        {{ score_field.as_field_group }}
-                    {% endfor %}
-                    {{ qform }}
-                    {{ form.text.as_field_group }}
-                </div>
-            {% endif %}
-
-            {% if can_view_other_reviews or form.instance.pk %}
-                <div class="table-responsive-sm">
-                    <table class="table review-table table-hover table-flip table-sticky">
-                        <tr>
-                            <th>{% translate "Score" %}</th>
-                            {% if score_categories|length > 1 %}
-                                {% for cat in score_categories %}<th>{{ cat.name }}</th>{% endfor %}
-                            {% endif %}
-                            {% for field in qform %}<th>{{ field.label }}</th>{% endfor %}
-                            <th>{% translate "Review" %}</th>
-                            <th></th>
-                        </tr>
-                        <tbody>
-                            {% if form.instance.pk and review_display %}
-
-                                {% include "orga/submission/review_fragment.html" with review=review_display read_only=read_only show_reviewer_name=False %}
-
-                            {% endif %}
-                            {% if can_view_other_reviews %}
-                                {% for review in reviews %}
-
-                                    {% include "orga/submission/review_fragment.html" with review=review read_only=True show_reviewer_name=can_view_reviewer_names %}
-
-                                {% empty %}
-                                    <tr>
-                                        <td colspan="100">{% translate "Nobody else has submitted a review yet." %}</td>
-                                    </tr>
-                                {% endfor %}
-                            {% endif %}
-                        </tbody>
-                    </table>
-                </div>
-            {% endif %}
-            {% if not read_only %}
-                {% if done != total_reviews %}
-                    <div class="progress" title="{% translate "Review progress" %}: {{ done }} / {{ total_reviews }}">
-                        <div class="progress-bar bg-success" role="progressbar" style="width: {{ percentage }}%" aria-valuenow="{{ done }}" aria-valuemin="0" aria-valuemax="{{ total_reviews }}" title="{% translate "Review progress" %}: {{ done }} / {{ total_reviews }}">
-                        </div>
-                    </div>
-                {% endif %}
-                <div class="submit-group pb-0 d-flex flex-row-reverse">
-                    <div>
-                        <div class="d-flex flex-row-reverse">
-                            <button type="submit" class="btn btn-lg btn-success ml-1" name="review_submit" value="save_and_next" data-toggle="tooltip" data-placement="bottom" title="{% translate "Go to random next unreviewed proposal" %}">{% translate "Save and next" %}</button>
-                            {% if not request.event.review_settings.score_mandatory and not request.event.review_settings.text_mandatory %}
-                                <button type="submit" class="btn btn-lg btn-info ml-1" name="review_submit" value="abstain" data-toggle="tooltip" data-placement="bottom" title="{% translate "Go to random next unreviewed proposal" %}">{% translate "Abstain" %}</button>
-                            {% endif %}
-                            <button type="submit" class="btn btn-lg btn-info" name="review_submit" value="skip_for_now" data-toggle="tooltip" data-placement="bottom" title="{% translate "Go to random next unreviewed proposal, mark this one as skipped" %}">{% translate "Skip for now" %}</button>
-                        </div>
-                        <div class="text-right">
-                            <small><a href="{{ request.event.orga_urls.reviews }}bulk/">
-                                {% translate "Or review all proposals at once." %}
-                            </a></small>
-                        </div>
-                    </div>
-                    <div>
-                        {% if form.instance.pk %}
-                            <a href="{{ form.instance.urls.delete }}" class="btn btn-lg btn-outline-danger">{% translate "Delete review" %}</a>
-                        {% endif %}
-                        <button type="submit" class="btn btn-lg btn-outline-success" name="review_submit" value="save">
-                            {{ phrases.base.save }}
-                        </button>
-                    </div>
-                </div>
-            {% endif %}
-        </form>
-    {% endif %}  {# endif: request.user in submission.speakers #}
+            <button type="submit" class="btn btn-lg btn-outline-success" name="review_submit" value="save">
+              {{ phrases.base.save }}
+            </button>
+          </div>
+        </div>
+      {% endif %}
+    </form>
+  {% endif %}  {# endif: request.user in submission.speakers #}
 {% endblock submission_content %}

--- a/src/pretalx/orga/templates/orga/submission/review_delete.html
+++ b/src/pretalx/orga/templates/orga/submission/review_delete.html
@@ -6,6 +6,6 @@
 
 {% block submission_content %}
 
-    {% include "common/includes/action_confirm.html" %}
+  {% include "common/includes/action_confirm.html" %}
 
 {% endblock submission_content %}

--- a/src/pretalx/orga/templates/orga/submission/review_fragment.html
+++ b/src/pretalx/orga/templates/orga/submission/review_fragment.html
@@ -2,27 +2,27 @@
 {% load rich_text %}
 
 <tr>
-    <td class="numeric-left">{{ review.score }}</td>
-    {% if score_categories|length > 1 %}
-        {% for score in review.scores %}
-            <td class="numeric-left">
-                {{ score }}
-            </td>
-        {% endfor %}
-    {% endif %}
-    {% for answer in review.answers %}
-        <td>
-            {{ answer.answer }}
-        </td>
+  <td class="numeric-left">{{ review.score }}</td>
+  {% if score_categories|length > 1 %}
+    {% for score in review.scores %}
+      <td class="numeric-left">
+        {{ score }}
+      </td>
     {% endfor %}
+  {% endif %}
+  {% for answer in review.answers %}
     <td>
-        {{ review.text|rich_text }}
+      {{ answer.answer }}
     </td>
-    <td>
-        {% if show_reviewer_name %}
-            {{ review.user }}
-        {% elif not read_only %}
-            <div class="btn btn-success" id="edit-review">{{ phrases.base.edit }}</div>
-        {% endif %}
-    </td>
+  {% endfor %}
+  <td>
+    {{ review.text|rich_text }}
+  </td>
+  <td>
+    {% if show_reviewer_name %}
+      {{ review.user }}
+    {% elif not read_only %}
+      <div class="btn btn-success" id="edit-review">{{ phrases.base.edit }}</div>
+    {% endif %}
+  </td>
 </tr>

--- a/src/pretalx/orga/templates/orga/submission/speakers.html
+++ b/src/pretalx/orga/templates/orga/submission/speakers.html
@@ -10,75 +10,75 @@
 {% block submission_title %}{% translate "Speakers" %} :: {% endblock submission_title %}
 
 {% block submission_content %}
-    {% has_perm "submission.edit_speaker_list" request.user submission as can_edit_speakers %}
-    {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
-    {% if can_edit_speakers %}<div class="alert">
-        <form method="POST" class="form d-flex w-100 flex-column">
-            {% csrf_token %}
-            <div class="d-flex flex-row">
-                <div class="w-50 hide-optional mr-4">{{ form.email.as_field_group }}</div>
-                <div class="w-50">{{ form.name.as_field_group }}</div>
-            </div>
-            <div class="d-flex flex-row hide-optional">
-                <div class="w-50 hide-optional mr-4">{% if form.locale %}{{ form.locale.as_field_group }}{% endif %}</div>
-                <div class="w-50 mt-4"><button type="submit" class="btn btn-sm btn-success btn-block btn-lg mt-2"><i class="fa fa-plus"></i> {% translate "Add speaker" %}</button></div>
-            </div>
-        </form>
-    </div>{% endif %}
+  {% has_perm "submission.edit_speaker_list" request.user submission as can_edit_speakers %}
+  {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
+  {% if can_edit_speakers %}<div class="alert">
+    <form method="POST" class="form d-flex w-100 flex-column">
+      {% csrf_token %}
+      <div class="d-flex flex-row">
+        <div class="w-50 hide-optional mr-4">{{ form.email.as_field_group }}</div>
+        <div class="w-50">{{ form.name.as_field_group }}</div>
+      </div>
+      <div class="d-flex flex-row hide-optional">
+        <div class="w-50 hide-optional mr-4">{% if form.locale %}{{ form.locale.as_field_group }}{% endif %}</div>
+        <div class="w-50 mt-4"><button type="submit" class="btn btn-sm btn-success btn-block btn-lg mt-2"><i class="fa fa-plus"></i> {% translate "Add speaker" %}</button></div>
+      </div>
+    </form>
+  </div>{% endif %}
 
-    {% for speaker in speakers %}
-        <div class="card mb-3"><div class="card-body">
-            <h3 class="card-title">
-                <a href="{% url "orga:speakers.view" event=request.event.slug code=speaker.user.code %}">
-                    {{ speaker.user.get_display_name }}
-                </a>
-                {% if speaker.user.avatar %}
-                    <div class="speaker-avatar">
-                        <a href="{{ speaker.user.avatar.url }}" data-lightbox="{{ speaker.user.avatar.url }}">
-                            <img loading="lazy" width="100%" src="{{ speaker.user.avatar|thumbnail:"default" }}" alt="{% translate "The speaker’s profile picture" %}">
-                        </a>
-                    </div>
-                {% endif %}
-            </h3>
-            {% if request.event.cfp.request_biography %}
-                <p class="card-text">
-                    <h5>{% translate "Biography" %}:</h5>
-                    {{ speaker.profile.biography|rich_text|default:"-" }}
-                </p>
-            {% endif %}
-            <p class="card-text">
-                {% if speaker.other_submissions %}
-                    <h5>{% translate "Other proposals by this speaker:" %}</h5>
-                    <ul>
-                        {% for submission in speaker.other_submissions %}
-                            <li>
-                                <a href="{{ submission.orga_urls.base }}">{{ submission.title }}</a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                {% endif %}
-            </p>
-            {% if can_edit_speakers %}
-                {% if can_send_mails %}
-                    <a class="btn btn-outline-info" href="{{ request.event.orga_urls.compose_mails_sessions }}?speakers={{ speaker.user.code }}">
-                        <i class="fa fa-envelope"></i>
-                        {% translate "Send email" %}
-                    </a>
-                {% endif %}
-                <a href="{% url "orga:speakers.view" event=request.event.slug code=speaker.user.code %}"
-                   class="btn btn-info">
-                    <i class="fa fa-edit"></i> {{ phrases.base.edit }}
-                </a>
-                <a href="{{ submission.orga_urls.delete_speaker }}?id={{ speaker.user.id }}"
-                   class="btn btn-danger">
-                    <i class="fa fa-trash"></i> {% translate "Remove" %}
-                </a>
-            {% endif %}
-        </div></div>
-    {% endfor %}
+  {% for speaker in speakers %}
+    <div class="card mb-3"><div class="card-body">
+      <h3 class="card-title">
+        <a href="{% url "orga:speakers.view" event=request.event.slug code=speaker.user.code %}">
+          {{ speaker.user.get_display_name }}
+        </a>
+        {% if speaker.user.avatar %}
+          <div class="speaker-avatar">
+            <a href="{{ speaker.user.avatar.url }}" data-lightbox="{{ speaker.user.avatar.url }}">
+              <img loading="lazy" width="100%" src="{{ speaker.user.avatar|thumbnail:"default" }}" alt="{% translate "The speaker’s profile picture" %}">
+            </a>
+          </div>
+        {% endif %}
+      </h3>
+      {% if request.event.cfp.request_biography %}
+        <p class="card-text">
+          <h5>{% translate "Biography" %}:</h5>
+          {{ speaker.profile.biography|rich_text|default:"-" }}
+        </p>
+      {% endif %}
+      <p class="card-text">
+        {% if speaker.other_submissions %}
+          <h5>{% translate "Other proposals by this speaker:" %}</h5>
+          <ul>
+            {% for submission in speaker.other_submissions %}
+              <li>
+                <a href="{{ submission.orga_urls.base }}">{{ submission.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </p>
+      {% if can_edit_speakers %}
+        {% if can_send_mails %}
+          <a class="btn btn-outline-info" href="{{ request.event.orga_urls.compose_mails_sessions }}?speakers={{ speaker.user.code }}">
+            <i class="fa fa-envelope"></i>
+            {% translate "Send email" %}
+          </a>
+        {% endif %}
+        <a href="{% url "orga:speakers.view" event=request.event.slug code=speaker.user.code %}"
+           class="btn btn-info">
+          <i class="fa fa-edit"></i> {{ phrases.base.edit }}
+        </a>
+        <a href="{{ submission.orga_urls.delete_speaker }}?id={{ speaker.user.id }}"
+           class="btn btn-danger">
+          <i class="fa fa-trash"></i> {% translate "Remove" %}
+        </a>
+      {% endif %}
+    </div></div>
+  {% endfor %}
 
-    <span id="vars" remoteUrl="{{ request.event.organiser.orga_urls.user_search }}"></span>
-    {% compress js %}
-        <script defer src="{% static "orga/js/speakers.js" %}"></script>
-    {% endcompress %}
+  <span id="vars" remoteUrl="{{ request.event.organiser.orga_urls.user_search }}"></span>
+  {% compress js %}
+    <script defer src="{% static "orga/js/speakers.js" %}"></script>
+  {% endcompress %}
 {% endblock submission_content %}

--- a/src/pretalx/orga/templates/orga/submission/state_change.html
+++ b/src/pretalx/orga/templates/orga/submission/state_change.html
@@ -5,34 +5,34 @@
 {% block submission_title %}→ {{ target }} :: {% endblock submission_title %}
 
 {% block submission_content %}
-    <div class="col-md-9 offset-md-3">
-        <h3>
+  <div class="col-md-9 offset-md-3">
+    <h3>
 
-            {% include "cfp/event/fragment_state.html" with state=submission.state as_badge=True %}
+      {% include "cfp/event/fragment_state.html" with state=submission.state as_badge=True %}
 
-            <i class="fa fa-arrow-right"></i>
+      <i class="fa fa-arrow-right"></i>
 
-            {% include "cfp/event/fragment_state.html" with state=target as_badge=True %}
+      {% include "cfp/event/fragment_state.html" with state=target as_badge=True %}
 
-        </h3>
-        <p>{% translate "Please confirm that you really want to change the state of this proposal." %}</p>
+    </h3>
+    <p>{% translate "Please confirm that you really want to change the state of this proposal." %}</p>
 
-    </div>
-    <form method="post">
-        {% csrf_token %}
-        <input type="hidden" name="next" value="{{ next }}">
-        {{ form.pending.as_field_group }}
+  </div>
+  <form method="post">
+    {% csrf_token %}
+    <input type="hidden" name="next" value="{{ next }}">
+    {{ form.pending.as_field_group }}
 
-        <div class="submit-group" id="submission-state-change"><span></span><span>
-            <a
-                class="btn btn-lg btn-outline-info"
-                href="{% if request.GET.next %}{{ request.GET.next }}{% else %}{{ submission.orga_urls.base }}{% endif %}"
-            >
-                {{ phrases.base.back_button }}
-            </a>
-            <button type="submit" class="btn btn-lg submission-state-{{ target }}">
-                {% translate "Do it" %}
-            </button>
-        </span></div>
-    </form>
+    <div class="submit-group" id="submission-state-change"><span></span><span>
+      <a
+        class="btn btn-lg btn-outline-info"
+        href="{% if request.GET.next %}{{ request.GET.next }}{% else %}{{ submission.orga_urls.base }}{% endif %}"
+      >
+        {{ phrases.base.back_button }}
+      </a>
+      <button type="submit" class="btn btn-lg submission-state-{{ target }}">
+        {% translate "Do it" %}
+      </button>
+    </span></div>
+  </form>
 {% endblock submission_content %}

--- a/src/pretalx/orga/templates/orga/submission/state_dropdown.html
+++ b/src/pretalx/orga/templates/orga/submission/state_dropdown.html
@@ -1,75 +1,75 @@
 {% load i18n %}
 
 <details class="dropdown submission-state-dropdown submission-state-{{ submission.state }}{% if submission.pending_state %} submission-state-pending-{{ submission.pending_state }}{% endif %}" aria-haspopup="menu" role="menu">
-    <summary class="btn">
-        <h4>
+  <summary class="btn">
+    <h4>
 
-            {% include "cfp/event/fragment_state.html" with state=submission.state %}
+      {% include "cfp/event/fragment_state.html" with state=submission.state %}
 
-            {% if submission.pending_state %}
-                <span class="pending-indicator">
-                    (<i class="fa fa-arrow-right"></i> {% include "cfp/event/fragment_state.html" with state=submission.pending_state %})
-                </span>
-            {% endif %}
-        </h4>
-        <i class="fa fa-caret-down"></i>
-    </summary>
-    <div class="dropdown-content dropdown-content-s submission-dropdown-menu">
-        {% if submission.state != "submitted" or submission.pending_state %}
-            <a
-                class="dropdown-item submission-state-submitted"
-                role="menuitem" tabindex="-1"
-                href="{{ submission.orga_urls.make_submitted }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
-                {% include "cfp/event/fragment_state.html" with state="submitted" %}
-            </a>
-        {% endif %}
-        {% if submission.state != "accepted" or submission.pending_state %}
-            <a
-                class="dropdown-item submission-state-accepted"
-                role="menuitem" tabindex="-1"
-                href="{{ submission.orga_urls.accept }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
-                {% include "cfp/event/fragment_state.html" with state="accepted" %}
-            </a>
-        {% endif %}
-        {% if submission.state != "confirmed" or submission.pending_state %}
-            <a
-                class="dropdown-item submission-state-confirmed"
-                role="menuitem" tabindex="-1"
-                href="{{ submission.orga_urls.confirm }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
-                {% include "cfp/event/fragment_state.html" with state="confirmed" %}
-            </a>
-        {% endif %}
-        {% if submission.state != "rejected" or submission.pending_state %}
-            <a
-                class="dropdown-item submission-state-rejected"
-                role="menuitem" tabindex="-1"
-                href="{{ submission.orga_urls.reject }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
-                {% include "cfp/event/fragment_state.html" with state="rejected" %}
-            </a>
-        {% endif %}
-        {% if submission.state != "canceled" or submission.pending_state %}
-            <a
-                class="dropdown-item submission-state-canceled"
-                role="menuitem" tabindex="-1"
-                href="{{ submission.orga_urls.cancel }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
-                {% include "cfp/event/fragment_state.html" with state="canceled" %}
-            </a>
-        {% endif %}
-        {% if submission.state != "withdrawn" or submission.pending_state %}
-            <a
-                class="dropdown-item submission-state-withdrawn"
-                role="menuitem" tabindex="-1"
-                href="{{ submission.orga_urls.withdraw }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
-                {% include "cfp/event/fragment_state.html" with state="withdrawn" %}
-            </a>
-        {% endif %}
-        {% if submission.state != "deleted" or submission.pending_state %}
-            <a
-                class="dropdown-item submission-state-deleted"
-                role="menuitem" tabindex="-1"
-                href="{{ submission.orga_urls.delete }}?{% if submission.code not in request.path %}next={{ request.path|urlencode }}%3F{% endif %}{{ request.META.QUERY_STRING|urlencode }}">
-                {% include "cfp/event/fragment_state.html" with state="deleted" %}
-            </a>
-        {% endif %}
-    </div>
+      {% if submission.pending_state %}
+        <span class="pending-indicator">
+          (<i class="fa fa-arrow-right"></i> {% include "cfp/event/fragment_state.html" with state=submission.pending_state %})
+        </span>
+      {% endif %}
+    </h4>
+    <i class="fa fa-caret-down"></i>
+  </summary>
+  <div class="dropdown-content dropdown-content-s submission-dropdown-menu">
+    {% if submission.state != "submitted" or submission.pending_state %}
+      <a
+        class="dropdown-item submission-state-submitted"
+        role="menuitem" tabindex="-1"
+        href="{{ submission.orga_urls.make_submitted }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
+        {% include "cfp/event/fragment_state.html" with state="submitted" %}
+      </a>
+    {% endif %}
+    {% if submission.state != "accepted" or submission.pending_state %}
+      <a
+        class="dropdown-item submission-state-accepted"
+        role="menuitem" tabindex="-1"
+        href="{{ submission.orga_urls.accept }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
+        {% include "cfp/event/fragment_state.html" with state="accepted" %}
+      </a>
+    {% endif %}
+    {% if submission.state != "confirmed" or submission.pending_state %}
+      <a
+        class="dropdown-item submission-state-confirmed"
+        role="menuitem" tabindex="-1"
+        href="{{ submission.orga_urls.confirm }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
+        {% include "cfp/event/fragment_state.html" with state="confirmed" %}
+      </a>
+    {% endif %}
+    {% if submission.state != "rejected" or submission.pending_state %}
+      <a
+        class="dropdown-item submission-state-rejected"
+        role="menuitem" tabindex="-1"
+        href="{{ submission.orga_urls.reject }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
+        {% include "cfp/event/fragment_state.html" with state="rejected" %}
+      </a>
+    {% endif %}
+    {% if submission.state != "canceled" or submission.pending_state %}
+      <a
+        class="dropdown-item submission-state-canceled"
+        role="menuitem" tabindex="-1"
+        href="{{ submission.orga_urls.cancel }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
+        {% include "cfp/event/fragment_state.html" with state="canceled" %}
+      </a>
+    {% endif %}
+    {% if submission.state != "withdrawn" or submission.pending_state %}
+      <a
+        class="dropdown-item submission-state-withdrawn"
+        role="menuitem" tabindex="-1"
+        href="{{ submission.orga_urls.withdraw }}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
+        {% include "cfp/event/fragment_state.html" with state="withdrawn" %}
+      </a>
+    {% endif %}
+    {% if submission.state != "deleted" or submission.pending_state %}
+      <a
+        class="dropdown-item submission-state-deleted"
+        role="menuitem" tabindex="-1"
+        href="{{ submission.orga_urls.delete }}?{% if submission.code not in request.path %}next={{ request.path|urlencode }}%3F{% endif %}{{ request.META.QUERY_STRING|urlencode }}">
+        {% include "cfp/event/fragment_state.html" with state="deleted" %}
+      </a>
+    {% endif %}
+  </div>
 </details>

--- a/src/pretalx/orga/templates/orga/submission/stats.html
+++ b/src/pretalx/orga/templates/orga/submission/stats.html
@@ -5,73 +5,73 @@
 {% load static %}
 
 {% block stylesheets %}
-    <link rel="stylesheet" type="text/css" href="{% static "vendored/apexcharts/apexcharts.css" %}" />
+  <link rel="stylesheet" type="text/css" href="{% static "vendored/apexcharts/apexcharts.css" %}" />
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "vendored/apexcharts/apexcharts.min.js" %}"></script>
-        <script defer src="{% static "orga/js/stats.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "vendored/apexcharts/apexcharts.min.js" %}"></script>
+    <script defer src="{% static "orga/js/stats.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}{% translate "Statistics" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <div id="stats">
-        <h2 class="d-flex w-100 justify-content-between align-items-start">
-            {% translate "Proposal Statistics" %}
-            <div class="toggle-group mr-3">
-                <label for="toggle-button" class="toggle-label">{% translate "Proposals" %}</label>
-                <input type="checkbox" id="toggle-button" name="stats-toggle" role="button">
-                <label for="toggle-button" class="toggle-label">{{ phrases.schedule.sessions }}</label>
-            </div>
-        </h2>
+  <div id="stats">
+    <h2 class="d-flex w-100 justify-content-between align-items-start">
+      {% translate "Proposal Statistics" %}
+      <div class="toggle-group mr-3">
+        <label for="toggle-button" class="toggle-label">{% translate "Proposals" %}</label>
+        <input type="checkbox" id="toggle-button" name="stats-toggle" role="button">
+        <label for="toggle-button" class="toggle-label">{{ phrases.schedule.sessions }}</label>
+      </div>
+    </h2>
 
-        <div id="global-data" class="d-none" data-url="{{ request.event.orga_urls.submissions }}?" data-mapping="{{ id_mapping }}" data-annotations="{{ timeline_annotations }}"></div>
+    <div id="global-data" class="d-none" data-url="{{ request.event.orga_urls.submissions }}?" data-mapping="{{ id_mapping }}" data-annotations="{{ timeline_annotations }}"></div>
 
-        {% if submission_timeline_data %}
-            <div class="card stats-timeline">
-                <div class="card-header submissions">{% translate "Proposals by submission date" %}</div>
-                <div class="card-header talks d-none">{% translate "Sessions by submission date" %}</div>
-                <div id="submission-timeline-data" class="d-none" data-timeline="{{ submission_timeline_data }}" data-label="{% translate "Proposals" %}"></div>
-                <div id="talk-timeline-data" class="d-none" data-timeline="{{ talk_timeline_data }}" data-label="{{ phrases.schedule.sessions }}"></div>
-                <div id="total-submission-timeline-data" class="d-none" data-timeline="{{ total_submission_timeline_data }}" data-label="{% translate "Total proposals" %}"></div>
-                <div id="timeline" class="card-body submissions"></div>
-            </div>
-        {% endif %}
+    {% if submission_timeline_data %}
+      <div class="card stats-timeline">
+        <div class="card-header submissions">{% translate "Proposals by submission date" %}</div>
+        <div class="card-header talks d-none">{% translate "Sessions by submission date" %}</div>
+        <div id="submission-timeline-data" class="d-none" data-timeline="{{ submission_timeline_data }}" data-label="{% translate "Proposals" %}"></div>
+        <div id="talk-timeline-data" class="d-none" data-timeline="{{ talk_timeline_data }}" data-label="{{ phrases.schedule.sessions }}"></div>
+        <div id="total-submission-timeline-data" class="d-none" data-timeline="{{ total_submission_timeline_data }}" data-label="{% translate "Total proposals" %}"></div>
+        <div id="timeline" class="card-body submissions"></div>
+      </div>
+    {% endif %}
 
-        {% if submission_type_data and show_submission_types %}
-            <div class="card">
-                <div class="card-header submissions">{% translate "Proposals by session type" %}</div>
-                <div class="card-header talks d-none">{% translate "Sessions by session type" %}</div>
-                <div id="submission-type-data" class="d-none" data-states="{{ submission_type_data }}"></div>
-                <div id="talk-type-data" class="d-none" data-states="{{ talk_type_data }}"></div>
-                <div id="submission-type" class="pie card-body submissions"></div>
-                <div id="talk-type" class="pie card-body talks d-none"></div>
-            </div>
-        {% endif %}
+    {% if submission_type_data and show_submission_types %}
+      <div class="card">
+        <div class="card-header submissions">{% translate "Proposals by session type" %}</div>
+        <div class="card-header talks d-none">{% translate "Sessions by session type" %}</div>
+        <div id="submission-type-data" class="d-none" data-states="{{ submission_type_data }}"></div>
+        <div id="talk-type-data" class="d-none" data-states="{{ talk_type_data }}"></div>
+        <div id="submission-type" class="pie card-body submissions"></div>
+        <div id="talk-type" class="pie card-body talks d-none"></div>
+      </div>
+    {% endif %}
 
-        {% if submission_track_data and show_tracks %}
-            <div class="card">
-                <div class="card-header submissions">{% translate "Proposals by track" %}</div>
-                <div class="card-header talks d-none">{% translate "Sessions by track" %}</div>
-                <div id="submission-track-data" class="d-none" data-states="{{ submission_track_data }}"></div>
-                <div id="talk-track-data" class="d-none" data-states="{{ talk_track_data }}"></div>
-                <div id="submission-track" class="pie card-body submissions"></div>
-                <div id="talk-track" class="pie card-body talks d-none"></div>
-            </div>
-        {% endif %}
+    {% if submission_track_data and show_tracks %}
+      <div class="card">
+        <div class="card-header submissions">{% translate "Proposals by track" %}</div>
+        <div class="card-header talks d-none">{% translate "Sessions by track" %}</div>
+        <div id="submission-track-data" class="d-none" data-states="{{ submission_track_data }}"></div>
+        <div id="talk-track-data" class="d-none" data-states="{{ talk_track_data }}"></div>
+        <div id="submission-track" class="pie card-body submissions"></div>
+        <div id="talk-track" class="pie card-body talks d-none"></div>
+      </div>
+    {% endif %}
 
-        {% if submission_state_data %}
-            <div class="card">
-                <div class="card-header submissions">{% translate "Proposals by state" %}</div>
-                <div class="card-header talks d-none">{% translate "Sessions by state" %}</div>
-                <div id="submission-state-data" class="d-none" data-states="{{ submission_state_data }}"></div>
-                <div id="talk-state-data" class="d-none" data-states="{{ talk_state_data }}"></div>
-                <div id="submission-state" class="pie card-body submissions"></div>
-                <div id="talk-state" class="pie card-body talks d-none"></div>
-            </div>
-        {% endif %}
-    </div>
+    {% if submission_state_data %}
+      <div class="card">
+        <div class="card-header submissions">{% translate "Proposals by state" %}</div>
+        <div class="card-header talks d-none">{% translate "Sessions by state" %}</div>
+        <div id="submission-state-data" class="d-none" data-states="{{ submission_state_data }}"></div>
+        <div id="talk-state-data" class="d-none" data-states="{{ talk_state_data }}"></div>
+        <div id="submission-state" class="pie card-body submissions"></div>
+        <div id="talk-state" class="pie card-body talks d-none"></div>
+      </div>
+    {% endif %}
+  </div>
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/submission/tag_form.html
+++ b/src/pretalx/orga/templates/orga/submission/tag_form.html
@@ -8,25 +8,25 @@
 {% endblock stylesheets %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static "vendored/vanilla-picker/vanilla-picker.min.js" %}"></script>
-        <script defer src="{% static "orga/js/colorpicker.js" %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static "vendored/vanilla-picker/vanilla-picker.min.js" %}"></script>
+    <script defer src="{% static "orga/js/colorpicker.js" %}"></script>
+  {% endcompress %}
 {% endblock scripts %}
 
 {% block extra_title %}
-    {% if form.instance.tag %}{% translate "Tag" %} {{ quotation_open }}{{ form.instance.tag }}{{ quotation_close }}{% else %}{% translate "New tag" %}{% endif %} ::
+  {% if form.instance.tag %}{% translate "Tag" %} {{ quotation_open }}{{ form.instance.tag }}{{ quotation_close }}{% else %}{% translate "New tag" %}{% endif %} ::
 {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% if form.instance.tag %}
-            {% translate "Tag" %} {{ quotation_open }}{{ form.instance.tag }}{{ quotation_close }}
-        {% else %}
-            {% translate "New tag" %}
-        {% endif %}
-    </h2>
+  <h2>
+    {% if form.instance.tag %}
+      {% translate "Tag" %} {{ quotation_open }}{{ form.instance.tag }}{{ quotation_close }}
+    {% else %}
+      {% translate "New tag" %}
+    {% endif %}
+  </h2>
 
-    {% include "orga/includes/base_form.html" %}
+  {% include "orga/includes/base_form.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/submission/tag_list.html
+++ b/src/pretalx/orga/templates/orga/submission/tag_list.html
@@ -6,50 +6,50 @@
 {% block extra_title %}{% translate "Tags" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Tags" %}</h2>
-    {% has_perm "orga.add_tags" request.user request.event as can_edit_tags %}
-    {% if can_edit_tags %}
-        <div class="d-flex justify-content-end mb-3">
-            <a class="btn btn-info" href="{{ request.event.orga_urls.new_tag }}">
-                <i class="fa fa-plus"></i>
-                {% translate "New tag" %}
-            </a>
-        </div>
-    {% endif %}
-    <div class="table-responsive-sm">
-        <table class="table table-sm table-hover table-flip table-sticky">
-            <thead>
-                <tr>
-                    <th>{% translate "Tag" %}</th>
-                    <th>{% translate "Color" %}</th>
-                    <th class="numeric">{% translate "Proposals" %}</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for tag in tags %}
-                    <tr>
-                        <td>
-                            <a href="{{ tag.urls.edit }}">{{ tag.tag }}</a>
-                        </td>
-                        <td>
-                            <div class="color-square" style="background: {{ tag.color }}"></div>
-                        </td>
-                        <td class="numeric">{{ tag.submissions.all.count }}</td>
-                        <td class="text-right">
-                            <a href="{{ tag.urls.edit }}" class="btn btn-sm btn-info">
-                                <i class="fa fa-edit"></i>
-                            </a>
-                            <a href="{{ tag.urls.delete }}" class="btn btn-sm btn-danger">
-                                <i class="fa fa-trash"></i>
-                            </a>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+  <h2>{% translate "Tags" %}</h2>
+  {% has_perm "orga.add_tags" request.user request.event as can_edit_tags %}
+  {% if can_edit_tags %}
+    <div class="d-flex justify-content-end mb-3">
+      <a class="btn btn-info" href="{{ request.event.orga_urls.new_tag }}">
+        <i class="fa fa-plus"></i>
+        {% translate "New tag" %}
+      </a>
     </div>
+  {% endif %}
+  <div class="table-responsive-sm">
+    <table class="table table-sm table-hover table-flip table-sticky">
+      <thead>
+        <tr>
+          <th>{% translate "Tag" %}</th>
+          <th>{% translate "Color" %}</th>
+          <th class="numeric">{% translate "Proposals" %}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for tag in tags %}
+          <tr>
+            <td>
+              <a href="{{ tag.urls.edit }}">{{ tag.tag }}</a>
+            </td>
+            <td>
+              <div class="color-square" style="background: {{ tag.color }}"></div>
+            </td>
+            <td class="numeric">{{ tag.submissions.all.count }}</td>
+            <td class="text-right">
+              <a href="{{ tag.urls.edit }}" class="btn btn-sm btn-info">
+                <i class="fa fa-edit"></i>
+              </a>
+              <a href="{{ tag.urls.delete }}" class="btn btn-sm btn-danger">
+                <i class="fa fa-trash"></i>
+              </a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
-    {% include "orga/includes/pagination.html" %}
+  {% include "orga/includes/pagination.html" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/user.html
+++ b/src/pretalx/orga/templates/orga/user.html
@@ -5,24 +5,24 @@
 {% load static %}
 
 {% block scripts %}
-    {% compress js %}
-        <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
-        <script defer src="{% static 'common/js/password_strength.js' %}"></script>
-    {% endcompress %}
+  {% compress js %}
+    <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
+    <script defer src="{% static 'common/js/password_strength.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block extra_title %}{% translate "User settings" %} :: {% endblock extra_title %}
 {% block content %}
-    <fieldset class="m-2">
-        <legend>{% translate "User settings" %}</legend>
-        {% include "orga/includes/base_form.html" with form=profile_form submit_name="form" submit_value="profile" %}
-    </fieldset>
+  <fieldset class="m-2">
+    <legend>{% translate "User settings" %}</legend>
+    {% include "orga/includes/base_form.html" with form=profile_form submit_name="form" submit_value="profile" %}
+  </fieldset>
 
-    <fieldset class="m-2 password-input-form">
-        <legend>{% translate "Login settings" %}</legend>
-        {% include "orga/includes/base_form.html" with form=login_form submit_name="form" submit_value="login" %}
-    </fieldset>
+  <fieldset class="m-2 password-input-form">
+    <legend>{% translate "Login settings" %}</legend>
+    {% include "orga/includes/base_form.html" with form=login_form submit_name="form" submit_value="login" %}
+  </fieldset>
 
-    {% include "common/user_api_token.html" with orga="true" %}
+  {% include "common/user_api_token.html" with orga="true" %}
 
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/widgets/header_option.html
+++ b/src/pretalx/orga/templates/orga/widgets/header_option.html
@@ -1,6 +1,6 @@
 {% include "django/forms/widgets/input.html" %}
 
 <label {% if widget.attrs.id %}for="{{ widget.attrs.id }}"{% endif %} class="header-pattern-label">
-    <div class="header mini-header {{ widget.value }}"
-         data-label="{{ widget.label }}"></div>
+  <div class="header mini-header {{ widget.value }}"
+       data-label="{{ widget.label }}"></div>
 </label>

--- a/src/pretalx/orga/templates/orga/widgets/multi_languages_widget.html
+++ b/src/pretalx/orga/templates/orga/widgets/multi_languages_widget.html
@@ -2,9 +2,9 @@
 
 {% include "django/forms/widgets/input_option.html" %}
 {% if not widget.official %}
-    {% if widget.percentage %}
-        <a href="#">
-            <span class="badge badge-pill color-{% if widget.percentage >= 90 %}success{% elif widget.percentage >= 80 %}warning{% else %}danger{% endif %}">
-                {% blocktranslate trimmed with percentage=widget.percentage %}{{ percentage }} % translated{% endblocktranslate %}</span></a> {# We need to avoid trailing whitespace here, sadly #}
-    {% endif %}
+  {% if widget.percentage %}
+    <a href="#">
+      <span class="badge badge-pill color-{% if widget.percentage >= 90 %}success{% elif widget.percentage >= 80 %}warning{% else %}danger{% endif %}">
+        {% blocktranslate trimmed with percentage=widget.percentage %}{{ percentage }} % translated{% endblocktranslate %}</span></a> {# We need to avoid trailing whitespace here, sadly #}
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Because of the nature of HTML with deep nesting levels, 2-space is a popular choice for indentation.

The files are formated with `djhtml`. This tool doesn't support configuration file, the config has to be passed as command line options. I will add another PR for how to run this command.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Chores:
- Reformatted multiple Django template files to use consistent 2-space indentation