### PR TITLE
Fix check-manifest in GH Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Python dependencies
         run: uv sync
       - name: Run check-manifest
-        run: uv run check-manifest
+        run: uv run --no-sync check-manifest
       - name: Run build
         run: uv build
       - name: Check package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ ignore = [
   "src/tests",
   "src/tests/*",
   "SECURITY.md",
+  "justfile",
 ]
 
 [tool.djlint]


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #323 

## How has this been tested?

Run the command in localhost.

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Update GitHub Actions workflow to run check-manifest without syncing dependencies

Bug Fixes:
- Fix check-manifest execution in GitHub Actions by adding --no-sync flag

CI:
- Modify build workflow to run check-manifest with --no-sync option

Chores:
- Add justfile to manifest ignore list