### PR TITLE
Fix: Global Nav JS/CSS files are missing from Docker container

### DIFF
--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -608,7 +608,8 @@ STATICFILES_DIRS = [static_path] if static_path.exists() else []
 # Note that those apps must be built before running collectstatic.
 FRONTEND_DIR = BASE_DIR / "pretalx" / "frontend"
 # Note: We must assume that the directory exists,
-# because `collectstatic` only reads the settings before Vite runs.
+# because when `collectstatic` was invoked by `rebuild` command,
+# it only sees the settings before Vite runs.
 STATICFILES_DIRS.append(FRONTEND_DIR / "global-nav-menu" / "dist")
 
 STORAGES = {

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -607,9 +607,9 @@ STATICFILES_DIRS = [static_path] if static_path.exists() else []
 # tell Django to collect their compiled output files.
 # Note that those apps must be built before running collectstatic.
 FRONTEND_DIR = BASE_DIR / "pretalx" / "frontend"
-_GLOBAL_NAV_MENU_DIR = FRONTEND_DIR / "global-nav-menu" / "dist"
-if _GLOBAL_NAV_MENU_DIR.exists():
-    STATICFILES_DIRS.append(_GLOBAL_NAV_MENU_DIR)
+# Note: We must assume that the directory exists,
+# because `collectstatic` only reads the settings before Vite runs.
+STATICFILES_DIRS.append(FRONTEND_DIR / "global-nav-menu" / "dist")
 
 STORAGES = {
     "default": {


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #331.

It does so by changing Django settings to alway include the output directory of this Vue 3 app.

## How has this been tested?

Checked the content of the container after build, to make sure that those files are collected to _static.dist_ dir.

![image](https://github.com/user-attachments/assets/4aeda115-2e47-4c82-80db-b10e0b2847e7)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Modify Django settings to always include the output directory for the Global Nav Vue 3 app in static files collection

Bug Fixes:
- Ensure Global Nav JS/CSS files are included in the Docker container by unconditionally adding the dist directory to STATICFILES_DIRS

Chores:
- Updated static files configuration to handle Vue app static file collection more robustly