### PR TITLE
Add "My orders" entry to dropdown menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ pyrightconfig.json
 .DS_Store
 
 .pytest_cache
+.mypy_cache
 *.cfg
 
 # django-perf-rec

--- a/src/pretalx/frontend/global-nav-menu/package-lock.json
+++ b/src/pretalx/frontend/global-nav-menu/package-lock.json
@@ -8,17 +8,18 @@
       "name": "@eventyay-talk/global-nav-menu",
       "version": "0.0.0",
       "dependencies": {
-        "@biomejs/biome": "^1.9.4",
         "vue": "^3.5.13"
       },
       "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
         "@iconify-json/fa": "^1.2.1",
-        "@vitejs/plugin-vue": "^5.2.1",
+        "@unocss/preset-web-fonts": "^66.1.1",
+        "@vitejs/plugin-vue": "^5.2.4",
         "@vue/tsconfig": "^0.7.0",
-        "typescript": "~5.7.2",
-        "unocss": "^66.1.0-beta.8",
-        "vite": "^6.2.0",
-        "vue-tsc": "^2.2.4"
+        "typescript": "5.8.3",
+        "unocss": "^66.1.1",
+        "vite": "^6.3.5",
+        "vue-tsc": "^2.2.10"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -36,14 +37,14 @@
       }
     },
     "node_modules/@antfu/install-pkg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.0.0.tgz",
-      "integrity": "sha512-xvX6P/lo1B3ej0OsaErAjqgFYzYVcJpamjLAFLYh9vRJngBrMoUG7aVnrGTeqM7yxbyTD5p3F2+0/QUEh8Vzhw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "package-manager-detector": "^0.2.8",
-        "tinyexec": "^0.3.2"
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -109,6 +110,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
       "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -139,6 +141,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -155,6 +158,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -171,6 +175,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -187,6 +192,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -203,6 +209,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -219,6 +226,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -235,6 +243,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -251,6 +260,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -772,16 +782,16 @@
       }
     },
     "node_modules/@polka/url": {
-      "version": "1.0.0-next.28",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
-      "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@quansync/fs": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-0.1.2.tgz",
-      "integrity": "sha512-ezIadUb1aFhwJLd++WVqVpi9rnlX8vnd4ju7saPhwLHJN1mJgOv0puePTGV+FbtSnWtwoHDT8lAm4kagDZmpCg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-0.1.3.tgz",
+      "integrity": "sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1082,15 +1092,15 @@
       "license": "MIT"
     },
     "node_modules/@unocss/astro": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/astro/-/astro-66.1.0-beta.8.tgz",
-      "integrity": "sha512-DduCTg44Dk9Mn2Soa4nzgiawWMlk/SZY+p850ChvyUZNugYoKZL0eqJZdhfeOhlKSSYIoC8YAUvLBeVEqjLRXw==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/astro/-/astro-66.1.1.tgz",
+      "integrity": "sha512-/wteVem8orDq5B4xhAol81WcK1eEwg6FCeWZhtWnP5u/1e0zI5h1rLTbyzb+qqXVNcGgqUo/jSYLLJ+dNQa99g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/reset": "66.1.0-beta.8",
-        "@unocss/vite": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1",
+        "@unocss/reset": "66.1.1",
+        "@unocss/vite": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -1105,16 +1115,16 @@
       }
     },
     "node_modules/@unocss/cli": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/cli/-/cli-66.1.0-beta.8.tgz",
-      "integrity": "sha512-fBOxxlzb3LZMwVJKPQgNWVqIiKjf2SgJoS9yh8ai46nQCCNg6I2ubPr+Lap7kQzusy0f8qMdY1hf3ur0uq+kAQ==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/cli/-/cli-66.1.1.tgz",
+      "integrity": "sha512-1bZ+iQJNt21bkBK+kmZymqSLt2W3zpawlx3w9SvQPuOy4xK8B6HkKaUcBnr9Wy3MymrI5Qwccr5f4vXweBkAxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
-        "@unocss/config": "66.1.0-beta.8",
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/preset-uno": "66.1.0-beta.8",
+        "@unocss/config": "66.1.1",
+        "@unocss/core": "66.1.1",
+        "@unocss/preset-uno": "66.1.1",
         "cac": "^6.7.14",
         "chokidar": "^3.6.0",
         "colorette": "^2.0.20",
@@ -1122,7 +1132,7 @@
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
         "perfect-debounce": "^1.0.0",
-        "tinyglobby": "^0.2.12",
+        "tinyglobby": "^0.2.13",
         "unplugin-utils": "^0.2.4"
       },
       "bin": {
@@ -1136,14 +1146,14 @@
       }
     },
     "node_modules/@unocss/config": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/config/-/config-66.1.0-beta.8.tgz",
-      "integrity": "sha512-o4Lhbpvho/kqt0NmpniQ9siOElDDClqXVIMaaQxWdGR8C7SjDjl/KkaG4EAMEvpfmW7z6an4pgGLOtkCUUwVhw==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/config/-/config-66.1.1.tgz",
+      "integrity": "sha512-Fg4sRw5dncNHxh/SM6guRzAveBI1FErw2ncb70Qe0LzCY7+IfUqrOBep/HIHP7NA1Mcj2JxHlM61ITLqrcYKpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
-        "unconfig": "^7.3.1"
+        "@unocss/core": "66.1.1",
+        "unconfig": "^7.3.2"
       },
       "engines": {
         "node": ">=14"
@@ -1153,9 +1163,9 @@
       }
     },
     "node_modules/@unocss/core": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/core/-/core-66.1.0-beta.8.tgz",
-      "integrity": "sha512-j56/9COPQ09+g0EittHtAmddRU4X0HgQ+Fz5hK+I894boljGNG6kI1vj5Gi0C/tllddrH/CbTdJ1K6RumSAK8w==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/core/-/core-66.1.1.tgz",
+      "integrity": "sha512-EOewEnipyB7Y6ne0YQmxdCG1hbMjYJ7oPMeHKfQuCZz60DPzkYwV6zVMa35ySMs1xljb/vFTHVFcJA8du3i8XA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1163,27 +1173,27 @@
       }
     },
     "node_modules/@unocss/extractor-arbitrary-variants": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/extractor-arbitrary-variants/-/extractor-arbitrary-variants-66.1.0-beta.8.tgz",
-      "integrity": "sha512-h9cXkuK2bsEGoYGHl22iavRM8x2yp5Be0OiEFly1kkH9MPGx5cAGchsP18ij8BQJRaW4d6JXm99pHr6ILnteGw==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/extractor-arbitrary-variants/-/extractor-arbitrary-variants-66.1.1.tgz",
+      "integrity": "sha512-hDbdXm2+LjQ18zkUniU6tCGdyBHxnMZ0M2LFF21iGEbDvK3ukX4uEVAhzASEmhkEE0nULyEJg0HkU4CRNBupBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/inspector": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/inspector/-/inspector-66.1.0-beta.8.tgz",
-      "integrity": "sha512-/ggP2MJERiXH4B6OfZe3gJWybrmYJu81+ooyveuqn6rle4l1mQNbFIdjxBYRAk4Z/v0JfJHPQiNCtDVRw+nwJQ==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/inspector/-/inspector-66.1.1.tgz",
+      "integrity": "sha512-112uYliXR7VLYqdPfDWy/cL65An36IabFL7xU9dRPBDYmlB5qyVks9l5Sqd8uMafsZYjbMhpkjPRkXTmLMieEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/rule-utils": "66.1.0-beta.8",
+        "@unocss/core": "66.1.1",
+        "@unocss/rule-utils": "66.1.1",
         "colorette": "^2.0.20",
         "gzip-size": "^6.0.0",
         "sirv": "^3.0.1",
@@ -1194,18 +1204,18 @@
       }
     },
     "node_modules/@unocss/postcss": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/postcss/-/postcss-66.1.0-beta.8.tgz",
-      "integrity": "sha512-zgBGVjULAVnV5G9nLwc/fAuGvKjAgSzRiaXktCW9qaLDVMrr9HJ3oQpFXyYEYcyKNQInQy1OoMQ0S7OHOlPYbg==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/postcss/-/postcss-66.1.1.tgz",
+      "integrity": "sha512-+CTeYbUGDk8ESrwxRN6wkaIAJYfJekt7NvUSp1us9zws+2Ev3pH7GXztbGmTz8HCkSqLB/3MOQ6sIpviS1A7/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/config": "66.1.0-beta.8",
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/rule-utils": "66.1.0-beta.8",
+        "@unocss/config": "66.1.1",
+        "@unocss/core": "66.1.1",
+        "@unocss/rule-utils": "66.1.1",
         "css-tree": "^3.1.0",
         "postcss": "^8.5.3",
-        "tinyglobby": "^0.2.12"
+        "tinyglobby": "^0.2.13"
       },
       "engines": {
         "node": ">=14"
@@ -1218,27 +1228,27 @@
       }
     },
     "node_modules/@unocss/preset-attributify": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-attributify/-/preset-attributify-66.1.0-beta.8.tgz",
-      "integrity": "sha512-Lz82t+KOpp9MMF+G5rPVSP1gwxZaO+yQTdpsgA6PbdD77K1lWA2a7KPnxv7/Co5FO0aTG4ArrX0nhNG24nU93w==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-attributify/-/preset-attributify-66.1.1.tgz",
+      "integrity": "sha512-PQC0L5CVt8JRCPBHWX1YD/XmGVWT5HZLa3NHZkl2nezoZNAiSSmwe9f5kq+bZDUZYvtbAY6jltF+G4rUAdWvJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-icons": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-icons/-/preset-icons-66.1.0-beta.8.tgz",
-      "integrity": "sha512-5rnu8/DoVG4NEfIeEHHBNdxKiMS8SazKJczIZoxKatqoJ6Woexv2xCyqW6dLCTkhHAi6g9GrbjNMVDX3U9Fxfw==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-icons/-/preset-icons-66.1.1.tgz",
+      "integrity": "sha512-F8NZKJfGzlv7tCxbo5cDXouxm1azKMzGOV11zbDTuZFDacyH5WprQ9zNMffUdUuVDy+rwAN+OoR0GEyggt4zww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@iconify/utils": "^2.3.0",
-        "@unocss/core": "66.1.0-beta.8",
+        "@unocss/core": "66.1.1",
         "ofetch": "^1.4.1"
       },
       "funding": {
@@ -1246,67 +1256,67 @@
       }
     },
     "node_modules/@unocss/preset-mini": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-mini/-/preset-mini-66.1.0-beta.8.tgz",
-      "integrity": "sha512-xIk2OOweFi3TljlklHOKmMo3xQo8EFxUHWKbDVTbhyBwaJ/chXWqM4azkdW/zgo+mZaeD30ZvQh8/1TUlXYnSg==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-mini/-/preset-mini-66.1.1.tgz",
+      "integrity": "sha512-VRv1BWqnKaDQZb4EGZ6bV03+jLios9R8CmlOKAjr9AIAUuZv3OKP7LoSA9Jo0bci1wQUdHxNs8IvD2c1mDz+Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/extractor-arbitrary-variants": "66.1.0-beta.8",
-        "@unocss/rule-utils": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1",
+        "@unocss/extractor-arbitrary-variants": "66.1.1",
+        "@unocss/rule-utils": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-tagify": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-tagify/-/preset-tagify-66.1.0-beta.8.tgz",
-      "integrity": "sha512-Ahr4Cv/kf73TFa4IZmCWq5dggWCeZ4VgZ2nLnVuO3894U+jt2nNb9Lb3hqFZNJeSbWYr2Kwz0hHkK986KL+Nzw==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-tagify/-/preset-tagify-66.1.1.tgz",
+      "integrity": "sha512-cC4MjyRVu3w4xxdlvz+mrkElNEYJpgCx/HVQehK9aXDBP9L9NgpEr+7Mqefhv5ES4a2U82MPNSElyFIwm3bOUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-typography": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-typography/-/preset-typography-66.1.0-beta.8.tgz",
-      "integrity": "sha512-PLgRtN4owWdxFchM6UYvUhcWXJ7Nj3pDpyobtkTfddb2HtIDClQpkrSWIh8kmCjjFiMrJPjNTPQka+gJL0UABQ==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-typography/-/preset-typography-66.1.1.tgz",
+      "integrity": "sha512-FB8leh/TANJB7U8sUuEG0pM+Nqhw65A1k+xJEXlYKAbfIdUN6mGNvFirh6c2WJXUg6rHe06l//TZAAvwJiS29Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/preset-mini": "66.1.0-beta.8",
-        "@unocss/rule-utils": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1",
+        "@unocss/preset-mini": "66.1.1",
+        "@unocss/rule-utils": "66.1.1"
       }
     },
     "node_modules/@unocss/preset-uno": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-uno/-/preset-uno-66.1.0-beta.8.tgz",
-      "integrity": "sha512-3XavbUmH7wC1/21fQSevy09sqQwzS5MYai3l8UtvImSfLVW3ZZjqLU25lNlxvixR/Gaq42nG2lMsaYFh/bdaGw==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-uno/-/preset-uno-66.1.1.tgz",
+      "integrity": "sha512-2gfayXo7He9ecCIp4KzpRpCjc6bFtukAahdLf5WoW66GRxoTDAsOuWQitG+B2IiExIX0fci8uahFudMNyLpjMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/preset-wind3": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1",
+        "@unocss/preset-wind3": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-web-fonts": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-web-fonts/-/preset-web-fonts-66.1.0-beta.8.tgz",
-      "integrity": "sha512-sDeDaQeMPSVm7YbiNuOoboJKLszqPCwXaJwfQasqlAoBOL527Cp0iVTivImhcHsd4uXBRG5pxqB+d9pKqYAJeA==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-web-fonts/-/preset-web-fonts-66.1.1.tgz",
+      "integrity": "sha512-vVjidprhFWsZ0ClRIfGhH3evsdtDgXPSoyv8MlN8dP5RqkpH817h5PqmInxHkYeC5Mg/HsUy5HA0NryBQix0vQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
+        "@unocss/core": "66.1.1",
         "ofetch": "^1.4.1"
       },
       "funding": {
@@ -1314,53 +1324,53 @@
       }
     },
     "node_modules/@unocss/preset-wind": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-wind/-/preset-wind-66.1.0-beta.8.tgz",
-      "integrity": "sha512-vTbedyKiwEsM6PzW8ixj0YyrDQ7CEnb7AcFl7k/osb12I9MV69+XZFyvg1JehExWLFSXUoBGlLeL1bJETekHFw==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-wind/-/preset-wind-66.1.1.tgz",
+      "integrity": "sha512-+C66yMgJe6/Xu3ZoP+8XMqL5N3RkLIZVVbVXtnhSvCF8qd4rJ+d4/odeQ8M/WUcQXSysIckkDfnYC2FGSTEakw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/preset-wind3": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1",
+        "@unocss/preset-wind3": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-wind3": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-wind3/-/preset-wind3-66.1.0-beta.8.tgz",
-      "integrity": "sha512-5Ssx/yT4Crg3S5TsK2ATKLM5zSfT7KQRhE8t2U23ifnLIH1EC4BvE13GdcC/Z4b0KFxwjVxRwZOVVal3a4f0ZA==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-wind3/-/preset-wind3-66.1.1.tgz",
+      "integrity": "sha512-Z8SqXaubPJHltD0+dneYei0spxH+spzGNiOWI7qffsByxvc6B/kOdJFOhVWE5DhYO33KJWyGxZdXzCq7Xxdm9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/preset-mini": "66.1.0-beta.8",
-        "@unocss/rule-utils": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1",
+        "@unocss/preset-mini": "66.1.1",
+        "@unocss/rule-utils": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-wind4": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-wind4/-/preset-wind4-66.1.0-beta.8.tgz",
-      "integrity": "sha512-EWLC226yzh8nZAVm696K7voKth9/WJE6KiVtmwY1KYzthtU6JPEtaQaseIO3p97uJzTCUon9zVp8URA6jM6XEA==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-wind4/-/preset-wind4-66.1.1.tgz",
+      "integrity": "sha512-p7YU0xcYF/+DUcsV//QkrXVEvORefSmXNOHnZ3HqawWdOABQJD/pu3QMk64jnEdrjQg07s4Wd1Zh5DAhSXFmLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/extractor-arbitrary-variants": "66.1.0-beta.8",
-        "@unocss/rule-utils": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1",
+        "@unocss/extractor-arbitrary-variants": "66.1.1",
+        "@unocss/rule-utils": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/reset": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/reset/-/reset-66.1.0-beta.8.tgz",
-      "integrity": "sha512-2HBIV3UXr18p6nXVhKEgQDGbHWlh7+Qp2n5Oq6jpqy+ke2rBhlwSn0qvsECfiuzogOzEy6nldTsNwQw8rJjjAA==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/reset/-/reset-66.1.1.tgz",
+      "integrity": "sha512-WrI3sStMd/EXTcb3SaTVH10Wc9NKutW4+/HktQy470wEpncXdvihrXgCYwJH6LEEL4KOto3o+KKSD5xenWE7Aw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1368,13 +1378,13 @@
       }
     },
     "node_modules/@unocss/rule-utils": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/rule-utils/-/rule-utils-66.1.0-beta.8.tgz",
-      "integrity": "sha512-NamsfYZKEiDFNyiHwlllz21nvDoI25oVCc4ihHUh0OkQohVgPshp8Amx3WNogDllQf3VqRC9l7pWO6kjLjRvIw==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/rule-utils/-/rule-utils-66.1.1.tgz",
+      "integrity": "sha512-a7xe3FsvsI6T6u8QtXcQF22jnElB68X92aHjuSRt512gRjhhu/5kSzLJbMkv9RsclHJbmjnz6OUkk/mlTTxcFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "^66.1.0-beta.8",
+        "@unocss/core": "^66.1.1",
         "magic-string": "^0.30.17"
       },
       "engines": {
@@ -1385,70 +1395,71 @@
       }
     },
     "node_modules/@unocss/transformer-attributify-jsx": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/transformer-attributify-jsx/-/transformer-attributify-jsx-66.1.0-beta.8.tgz",
-      "integrity": "sha512-hEkHXYLbXs7Wr+R4Uc/Hci+cPRIVZNsfs1ysAuFx7bl4LSnogiz4vN0qGhEE3+0ngcrUNaHy63RzhkbBZLZsUQ==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/transformer-attributify-jsx/-/transformer-attributify-jsx-66.1.1.tgz",
+      "integrity": "sha512-HE/O9xdPLrf20ZynvYsJOUwPQagExDUQSVdo9zYPwoUQ7O+Ep5uwRBp1vpT/suZfU87RwWSvKSFOHmFoKiJBCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/transformer-compile-class": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/transformer-compile-class/-/transformer-compile-class-66.1.0-beta.8.tgz",
-      "integrity": "sha512-89J/idQXI0X/6tofNjgd8NJD+LPk84ERH/PCqpkP5/rujvYd84jTnLZRicxhJzTJiKOwofFxo7IU+ndw/m/AlQ==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/transformer-compile-class/-/transformer-compile-class-66.1.1.tgz",
+      "integrity": "sha512-tptWeOEaR56XNLeJy+MtoTagYCH5giRYrlaOdQPX57NDnRqRB0KJYHew2YpgH6j6eZ1WbQ4WK8j1PzAmr1FVgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/transformer-directives": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/transformer-directives/-/transformer-directives-66.1.0-beta.8.tgz",
-      "integrity": "sha512-XOQq16DniCbDzbtWgnOZrhaqya6Md1zW0qN1a0Hf+fzsnO9KiAJWW2KoQet+kVIg/myS7zwDf5MC8M2N3i2aig==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/transformer-directives/-/transformer-directives-66.1.1.tgz",
+      "integrity": "sha512-qj2oUc9P+cY6PD+vTmbyb830GTofKm1IMeT+lhH4eyMX3lpfbDxj1LTjyJzouhK8s5VD56gWXx8wFdTuaEQ2Ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/rule-utils": "66.1.0-beta.8",
+        "@unocss/core": "66.1.1",
+        "@unocss/rule-utils": "66.1.1",
         "css-tree": "^3.1.0"
       }
     },
     "node_modules/@unocss/transformer-variant-group": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/transformer-variant-group/-/transformer-variant-group-66.1.0-beta.8.tgz",
-      "integrity": "sha512-8ZyCBY1iY3x+/nHeGnsEySYmsg9fc7thFKweOB2yrcQbQz53a+ule0NTPP8Y8x1+NSbzH1Mf66zn7emg0+Apcg==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/transformer-variant-group/-/transformer-variant-group-66.1.1.tgz",
+      "integrity": "sha512-opU9y9c6iGUtTXPa+bDfkihSAth+5PVO9hLbPWlDIiN6mDF7WHzAbnhg0Q+FixjAI+n772XWKoLdrPn3yM2NZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.1.0-beta.8"
+        "@unocss/core": "66.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/vite": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@unocss/vite/-/vite-66.1.0-beta.8.tgz",
-      "integrity": "sha512-GIN9knnrRrnluIh2VJiNLZtW0lJeFRgf/RNOFjQbuAKZAPBLN6qyu6MWOdxAKX4vUL4iJOiEPzMjpxwSlF4wRA==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/@unocss/vite/-/vite-66.1.1.tgz",
+      "integrity": "sha512-+ddMVpMxvm+2r8Je3YJRGYiZ/p/7LPD69VKT3vjFG3lT3IbfXtt18q6kYwBi+9lcnI68qgh3/s4qXQ2Q/iX5NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
-        "@unocss/config": "66.1.0-beta.8",
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/inspector": "66.1.0-beta.8",
+        "@unocss/config": "66.1.1",
+        "@unocss/core": "66.1.1",
+        "@unocss/inspector": "66.1.1",
         "chokidar": "^3.6.0",
         "magic-string": "^0.30.17",
-        "tinyglobby": "^0.2.12",
+        "pathe": "^2.0.3",
+        "tinyglobby": "^0.2.13",
         "unplugin-utils": "^0.2.4"
       },
       "funding": {
@@ -1459,9 +1470,9 @@
       }
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.3.tgz",
-      "integrity": "sha512-IYSLEQj4LgZZuoVpdSUCw3dIynTWQgPlaRP6iAvMle4My0HdYwr5g5wQAfwOeHQBmYwEkqF70nRpSilr6PoUDg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1563,9 +1574,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.8.tgz",
-      "integrity": "sha512-rrzB0wPGBvcwaSNRriVWdNAbHQWSf0NlGqgKHK5mEkXpefjUlVRP62u03KvwZpvKVjRnBIQ/Lwre+Mx9N6juUQ==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.10.tgz",
+      "integrity": "sha512-+yNoYx6XIKuAO8Mqh1vGytu8jkFEOH5C8iOv3i8Z/65A7x9iAOXA97Q+PqZ3nlm2lxf5rOJuIGI/wDtx/riNYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1776,9 +1787,9 @@
       "license": "MIT"
     },
     "node_modules/confbox": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.1.tgz",
-      "integrity": "sha512-hkT3yDPFbs95mNCy1+7qNKC6Pro+/ibzYxtM2iqEigpf0sVw+bg4Zh9/snjsBcf990vfIsg5+1U7VyiyBb3etg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1918,9 +1929,9 @@
       "license": "MIT"
     },
     "node_modules/exsolve": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.4.tgz",
-      "integrity": "sha512-xsZH6PXaER4XoV+NiT7JHp1bJodJVT+cxeSH1G0f0tlT0lJqYuHUP3bUx2HtfTDvOagMINYp8rsqusxud3RXhw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.5.tgz",
+      "integrity": "sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2221,14 +2232,11 @@
       }
     },
     "node_modules/package-manager-detector": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
-      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.3.0.tgz",
+      "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quansync": "^0.2.7"
-      }
+      "license": "MIT"
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
@@ -2405,20 +2413,20 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.3",
+        "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
       },
       "engines": {
@@ -2429,9 +2437,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2480,9 +2488,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2501,9 +2509,9 @@
       "license": "MIT"
     },
     "node_modules/unconfig": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-7.3.1.tgz",
-      "integrity": "sha512-LH5WL+un92tGAzWS87k7LkAfwpMdm7V0IXG2FxEjZz/QxiIW5J5LkcrKQThj0aRz6+h/lFmKI9EUXmK/T0bcrw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-7.3.2.tgz",
+      "integrity": "sha512-nqG5NNL2wFVGZ0NA/aCFw0oJ2pxSf1lwg4Z5ill8wd7K4KX/rQbHlwbh+bjctXL5Ly1xtzHenHGOK0b+lG6JVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2517,31 +2525,31 @@
       }
     },
     "node_modules/unocss": {
-      "version": "66.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/unocss/-/unocss-66.1.0-beta.8.tgz",
-      "integrity": "sha512-oxPwPLlJdGLDShJmbj75LUsYoQgnfqnaGEBBAhO2nJ4N2v1FJ9y2JNIzov3yE+qEyFqR8W8og4j7wSJ6P6+RBQ==",
+      "version": "66.1.1",
+      "resolved": "https://registry.npmjs.org/unocss/-/unocss-66.1.1.tgz",
+      "integrity": "sha512-GD/y7AsvbO6bG9Zu+5xf6UNIPyIwOUffTqLgFaWXHOqO6xXpbH9SWz2B+ATMdjwsRGr/JJHn3pLFo8lHGsHKsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/astro": "66.1.0-beta.8",
-        "@unocss/cli": "66.1.0-beta.8",
-        "@unocss/core": "66.1.0-beta.8",
-        "@unocss/postcss": "66.1.0-beta.8",
-        "@unocss/preset-attributify": "66.1.0-beta.8",
-        "@unocss/preset-icons": "66.1.0-beta.8",
-        "@unocss/preset-mini": "66.1.0-beta.8",
-        "@unocss/preset-tagify": "66.1.0-beta.8",
-        "@unocss/preset-typography": "66.1.0-beta.8",
-        "@unocss/preset-uno": "66.1.0-beta.8",
-        "@unocss/preset-web-fonts": "66.1.0-beta.8",
-        "@unocss/preset-wind": "66.1.0-beta.8",
-        "@unocss/preset-wind3": "66.1.0-beta.8",
-        "@unocss/preset-wind4": "66.1.0-beta.8",
-        "@unocss/transformer-attributify-jsx": "66.1.0-beta.8",
-        "@unocss/transformer-compile-class": "66.1.0-beta.8",
-        "@unocss/transformer-directives": "66.1.0-beta.8",
-        "@unocss/transformer-variant-group": "66.1.0-beta.8",
-        "@unocss/vite": "66.1.0-beta.8"
+        "@unocss/astro": "66.1.1",
+        "@unocss/cli": "66.1.1",
+        "@unocss/core": "66.1.1",
+        "@unocss/postcss": "66.1.1",
+        "@unocss/preset-attributify": "66.1.1",
+        "@unocss/preset-icons": "66.1.1",
+        "@unocss/preset-mini": "66.1.1",
+        "@unocss/preset-tagify": "66.1.1",
+        "@unocss/preset-typography": "66.1.1",
+        "@unocss/preset-uno": "66.1.1",
+        "@unocss/preset-web-fonts": "66.1.1",
+        "@unocss/preset-wind": "66.1.1",
+        "@unocss/preset-wind3": "66.1.1",
+        "@unocss/preset-wind4": "66.1.1",
+        "@unocss/transformer-attributify-jsx": "66.1.1",
+        "@unocss/transformer-compile-class": "66.1.1",
+        "@unocss/transformer-directives": "66.1.1",
+        "@unocss/transformer-variant-group": "66.1.1",
+        "@unocss/vite": "66.1.1"
       },
       "engines": {
         "node": ">=14"
@@ -2550,7 +2558,7 @@
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
-        "@unocss/webpack": "66.1.0-beta.8",
+        "@unocss/webpack": "66.1.1",
         "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0"
       },
       "peerDependenciesMeta": {
@@ -2593,15 +2601,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2664,6 +2675,34 @@
         }
       }
     },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -2703,14 +2742,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.8.tgz",
-      "integrity": "sha512-jBYKBNFADTN+L+MdesNX/TB3XuDSyaWynKMDgR+yCSln0GQ9Tfb7JS2lr46s2LiFUT1WsmfWsSvIElyxzOPqcQ==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.10.tgz",
+      "integrity": "sha512-jWZ1xSaNbabEV3whpIDMbjVSVawjAyW+x1n3JeGQo7S0uv2n9F/JMgWW90tGWNFRKya4YwKMZgCtr0vRAM7DeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "~2.4.11",
-        "@vue/language-core": "2.2.8"
+        "@vue/language-core": "2.2.10"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/src/pretalx/frontend/global-nav-menu/package.json
+++ b/src/pretalx/frontend/global-nav-menu/package.json
@@ -9,16 +9,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@biomejs/biome": "^1.9.4",
     "vue": "^3.5.13"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@iconify-json/fa": "^1.2.1",
-    "@vitejs/plugin-vue": "^5.2.1",
+    "@unocss/preset-web-fonts": "^66.1.1",
+    "@vitejs/plugin-vue": "^5.2.4",
     "@vue/tsconfig": "^0.7.0",
-    "typescript": "~5.7.2",
-    "unocss": "^66.1.0-beta.8",
-    "vite": "^6.2.0",
-    "vue-tsc": "^2.2.4"
+    "typescript": "5.8.3",
+    "unocss": "^66.1.1",
+    "vite": "^6.3.5",
+    "vue-tsc": "^2.2.10"
   }
 }

--- a/src/pretalx/frontend/global-nav-menu/src/App.vue
+++ b/src/pretalx/frontend/global-nav-menu/src/App.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ref, useTemplateRef, onMounted, onBeforeUnmount } from 'vue'
 
-const ENTRY_CLASSES = ' text-gray-700 hover:bg-gray-100 p-2 block no-underline hover:underline'
+const ENTRY_CLASSES = 'text-[#1a69a4] hover:text-white hover:bg-[#1a69a4] px-4 py-2 block no-underline'
 const WITH_ICON_CLASSES = 'flex flex-row items-center space-x-2'
+const WITH_BORDER_CLASSES = 'border-t border-s-0 border-e-0 border-b-0 border-solid border-gray-300'
 const open = ref(false)
 const subOpen = ref(false)
 const container = useTemplateRef('container')
@@ -40,15 +41,15 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class='relative' ref='container'>
+  <div class='relative font-sans text-sm' ref='container'>
     <button class='text-xl cursor-pointer' @click='showMenu'><div class='i-fa-caret-down h-4 w-4' /></button>
-    <div v-if='open' ref='main-menu' class='absolute z-1 end-1 grid grid-cols-1 shadow shadow-lg min-w-32 bg-white'>
+    <div v-if='open' ref='main-menu' class='absolute z-1 end-1 grid grid-cols-1 shadow shadow-lg min-w-48 bg-white'>
       <div class='relative cursor-pointer' @mouseover='subOpen = true' @mouseleave='subOpen = false'>
         <div class='flex flex-row items-center space-x-2' :class='ENTRY_CLASSES' >
           <div class='i-fa-tachometer h-3 w-3'></div>
           <div class=''>Dashboard</div>
         </div>
-        <ul v-if='subOpen' class='absolute z-2 top-0 -translate-x-full list-none m-0 p-s-0 bg-white shadow-lg min-w-42'>
+        <ul v-if='subOpen' class='absolute z-2 top-0 -translate-x-full list-none m-0 p-s-0 bg-white shadow-lg min-w-56'>
           <li>
             <a href='/common/' :class='[ENTRY_CLASSES, WITH_ICON_CLASSES]' class='block'>
               <div class='i-fa-tachometer h-3 w-3'></div>
@@ -69,6 +70,10 @@ onBeforeUnmount(() => {
           </li>
         </ul>
       </div>
+      <a :class='[ENTRY_CLASSES, WITH_ICON_CLASSES]' href='/tickets/common/orders/'>
+        <div class='i-fa-shopping-cart h-3 w-3'></div>
+        <div>My orders</div>
+      </a>
       <a :class='[ENTRY_CLASSES, WITH_ICON_CLASSES]' href='/tickets/common/events/'>
         <div class='i-fa-calendar h-3 w-3'></div>
         <div>My events</div>
@@ -77,21 +82,18 @@ onBeforeUnmount(() => {
         <div class='i-fa-users h-3 w-3'></div>
         <div>Organizers</div>
       </a>
-      <a class='border-t border-s-0 border-e-0 border-b-0 border-solid border-gray-300' :class='[ENTRY_CLASSES, WITH_ICON_CLASSES]' href='/tickets/common/account/'>
+      <a :class='[ENTRY_CLASSES, WITH_ICON_CLASSES, WITH_BORDER_CLASSES]' href='/tickets/common/account/'>
         <div class='i-fa-user h-3 w-3'></div>
         <div>Accounts</div>
       </a>
-      <a class='border-t border-s-0 border-e-0 border-b-0 border-solid border-gray-300' :class='[ENTRY_CLASSES, WITH_ICON_CLASSES]' href='/tickets/control/admin/'>
+      <a :class='[ENTRY_CLASSES, WITH_ICON_CLASSES, WITH_BORDER_CLASSES]' href='/tickets/control/admin/'>
         <div class='i-fa-cog h-3 w-3'></div>
         <div>Admin</div>
       </a>
-      <a class='border-t border-s-0 border-e-0 border-b-0 border-solid border-gray-300' :class='[ENTRY_CLASSES, WITH_ICON_CLASSES]' href='/tickets/control/logout'>
+      <a :class='[ENTRY_CLASSES, WITH_ICON_CLASSES, WITH_BORDER_CLASSES]' href='/tickets/control/logout'>
         <div class='i-fa-sign-out h-3 w-3'></div>
         <div>Logout</div>
       </a>
     </div>
   </div>
 </template>
-
-<style scoped>
-</style>

--- a/src/pretalx/frontend/global-nav-menu/uno.config.ts
+++ b/src/pretalx/frontend/global-nav-menu/uno.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig, presetWind3, presetIcons } from 'unocss'
+import { defineConfig, presetWind3, presetIcons, Preset } from 'unocss'
+import presetWebFonts from '@unocss/preset-web-fonts'
 
 export default defineConfig({
   presets: [
@@ -6,5 +7,12 @@ export default defineConfig({
       preflight: 'on-demand',
     }),
     presetIcons(),
+    presetWebFonts({
+      provider: 'google',
+      fonts: {
+        sans: 'Open Sans',
+        mono: 'Fira Code',
+      },
+    }) as Preset,
   ]
 })

--- a/src/pretalx/frontend/global-nav-menu/vite.config.ts
+++ b/src/pretalx/frontend/global-nav-menu/vite.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     UnoCSS({ mode: 'vue-scoped' }),
   ],
   build: {
-    // We don't minify generated code, because it will go through Django compressor.
-    minify: false,
-    cssMinify: false,
-    sourcemap: false,
     rollupOptions: {
       output: {
         // The compiled output should have predictable names, so that we can use them in the Django template.


### PR DESCRIPTION
Also make the color match other eventyay components.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of https://github.com/fossasia/eventyay-tickets/issues/618

## How has this been tested?

![image](https://github.com/user-attachments/assets/e5588f01-8484-4509-bb97-a0b2ca62e1aa)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Add a 'My orders' link to the user dropdown menu, refresh dropdown styling with brand colors and layout tweaks, introduce web font support via UnoCSS, and update build configuration and dependencies.

New Features:
- Add 'My orders' entry to the global navigation dropdown menu

Enhancements:
- Revise dropdown menu styling to use Eventyay brand colors, add separators, and adjust sizing and typography
- Integrate Open Sans and Fira Code fonts via UnoCSS web fonts preset

Build:
- Remove explicit Vite build minification and sourcemap flags to streamline the build process
- Bump dev dependencies: @unocss/preset-web-fonts, @vitejs/plugin-vue, unocss, typescript, vite, and vue-tsc