### PR TITLE
chore: modified docker file to maintain compatibility with macOS and reduce gid conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     mkdir /etc/pretalx && \
     mkdir /data && \
     mkdir /public && \
-    groupadd -g $GID pretalxuser && \
+    groupadd -o -g $GID pretalxuser && \
     useradd -r -u $UID -g pretalxuser -d /pretalx -ms /bin/bash pretalxuser && \
     echo 'pretalxuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 


### PR DESCRIPTION
added -o option to facilitate mac users non-breaking 
adding the -o option to groupadd -o -g $GID pretalxuser allows the reuse of an existing GID (Group ID). particularly useful in case of containers

## Summary by Sourcery

Build:
- Allow reuse of existing GID by adding -o flag to groupadd in Dockerfile