### PR TITLE
Implement secondary menu on Talk component to match Tickets component

### DIFF
--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -26,6 +26,7 @@ from pretalx.common.text.daterange import daterange
 from pretalx.common.text.path import path_with_hash
 from pretalx.common.text.phrases import phrases
 from pretalx.common.urls import EventUrls
+from urllib.parse import urlparse
 
 # Slugs need to start and end with an alphanumeric character,
 # but may contain dashes and dots in between.
@@ -380,6 +381,14 @@ class Event(PretalxModel):
         questions = "{base}questions/"
         answers = "{base}answers/"
         tags = "{base}tags/"
+    
+    class tickets_urls(EventUrls):
+        _full_base_path = settings.EVENTYAY_TICKET_BASE_PATH
+        base_path = urlparse(_full_base_path).path.rstrip('/')
+        base = "{base_path}/control/"
+        common = "{base_path}/common/"
+        tickets_home_common = "{common}event/{self.organiser.slug}/{self.slug}/"
+        tickets_dashboard_url = "{base}event/{self.organiser.slug}/{self.slug}/"
 
     class Meta:
         ordering = ("date_from",)

--- a/src/pretalx/orga/templates/orga/cfp/access_code_form.html
+++ b/src/pretalx/orga/templates/orga/cfp/access_code_form.html
@@ -7,13 +7,16 @@
 {% block extra_title %}{% if form.instance.pk %}{{ form.instance.code }}{% else %}{% translate "New access code" %}{% endif %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% if form.instance.pk %}
-            {% translate "Edit access code" %}
-        {% else %}
-            {% translate "New access code" %}
-        {% endif %}
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% if form.instance.pk %}
+                {% translate "Edit access code" %}
+            {% else %}
+                {% translate "New access code" %}
+            {% endif %}
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     {% if form.instance.pk and form.instance.submissions.exists %}
         <div class="alert alert-info">
             <span>

--- a/src/pretalx/orga/templates/orga/cfp/access_code_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/access_code_view.html
@@ -22,12 +22,15 @@
 {% block extra_title %}{% translate "Access codes" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% translate "Access codes" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% translate "Access codes" %}
+            <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+                <i class="fa fa-question-circle-o text-info"></i>
+            </span>
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <dialog class="info-dialog" id="info-dialog">
         <div class="alert alert-info">
             {% blocktranslate trimmed %}

--- a/src/pretalx/orga/templates/orga/cfp/flow.html
+++ b/src/pretalx/orga/templates/orga/cfp/flow.html
@@ -28,7 +28,10 @@
 {% block extra_title %}{% translate "CfP Editor" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h1>{% translate "CfP Editor" %}</h1>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>{% translate "CfP Editor" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <p>
         {% blocktranslate trimmed %}
             This is the {{ site_name }} CfP editor. This page allows you to change the

--- a/src/pretalx/orga/templates/orga/cfp/question_form.html
+++ b/src/pretalx/orga/templates/orga/cfp/question_form.html
@@ -24,13 +24,16 @@
 {% endblock scripts %}
 
 {% block content %}
-    <h2>
-        {% if form.instance.question %}
-            {% translate "Question" %}: {{ form.instance.question }}
-        {% else %}
-            {% translate "New question" %}
-        {% endif %}
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% if form.instance.question %}
+                {% translate "Question" %}: {{ form.instance.question }}
+            {% else %}
+                {% translate "New question" %}
+            {% endif %}
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
         {% include "common/forms/errors.html" %}

--- a/src/pretalx/orga/templates/orga/cfp/question_remind.html
+++ b/src/pretalx/orga/templates/orga/cfp/question_remind.html
@@ -5,7 +5,10 @@
 {% block extra_title %}{% translate "Send out reminders" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Send out reminders" %}</h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>{% translate "Send out reminders" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <div>
         <p>
             {% blocktranslate trimmed %}

--- a/src/pretalx/orga/templates/orga/cfp/question_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/question_view.html
@@ -22,12 +22,15 @@
 {% endblock scripts %}
 
 {% block content %}
-    <h2>
-        {% translate "Questions" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% translate "Questions" %}
+            <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+                <i class="fa fa-question-circle-o text-info"></i>
+            </span>
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <dialog id="info-dialog">
         <div class="alert alert-info">
             {% blocktranslate trimmed %}

--- a/src/pretalx/orga/templates/orga/cfp/submission_type_form.html
+++ b/src/pretalx/orga/templates/orga/cfp/submission_type_form.html
@@ -7,13 +7,16 @@
 {% block extra_title %}{% if form.instance.name %}{{ form.instance.name }}{% else %}{% translate "New Session Type" %}{% endif %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% if form.instance.name %}
-            {% translate "Session type" %}: {{ form.instance.name }}
-        {% else %}
-            {% translate "New Session Type" %}
-        {% endif %}
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% if form.instance.name %}
+                {% translate "Session type" %}: {{ form.instance.name }}
+            {% else %}
+                {% translate "New Session Type" %}
+            {% endif %}
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% include "orga/includes/base_form.html" %}
 

--- a/src/pretalx/orga/templates/orga/cfp/submission_type_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/submission_type_view.html
@@ -20,12 +20,15 @@
 {% block extra_title %}{% translate "Session types" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% translate "Session types" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% translate "Session types" %}
+            <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+                <i class="fa fa-question-circle-o text-info"></i>
+            </span>
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <dialog class="info-dialog" id="info-dialog">
         <div class="alert alert-info">
             {% blocktranslate trimmed %}

--- a/src/pretalx/orga/templates/orga/cfp/text.html
+++ b/src/pretalx/orga/templates/orga/cfp/text.html
@@ -20,12 +20,15 @@
 {% block extra_title %}{% translate "Call for Proposals" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% translate "Call for Proposals" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% translate "Call for Proposals" %}
+            <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+                <i class="fa fa-question-circle-o text-info"></i>
+            </span>
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <dialog class="info-dialog" id="info-dialog">
         <div class="alert alert-info">
             <span>

--- a/src/pretalx/orga/templates/orga/cfp/track_form.html
+++ b/src/pretalx/orga/templates/orga/cfp/track_form.html
@@ -17,13 +17,16 @@
 {% block extra_title %}{% if form.instance.name %}{{ form.instance.name }}{% else %}{% translate "New track" %}{% endif %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% if form.instance.name %}
-            {% translate "Track" %}: {{ form.instance.name }}
-        {% else %}
-            {% translate "New track" %}
-        {% endif %}
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% if form.instance.name %}
+                {% translate "Track" %}: {{ form.instance.name }}
+            {% else %}
+                {% translate "New track" %}
+            {% endif %}
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% include "orga/includes/base_form.html" %}
 

--- a/src/pretalx/orga/templates/orga/cfp/track_view.html
+++ b/src/pretalx/orga/templates/orga/cfp/track_view.html
@@ -21,12 +21,16 @@
 {% endblock scripts %}
 
 {% block content %}
-    <h2>
-        {% translate "Tracks" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% translate "Tracks" %}
+            <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+                <i class="fa fa-question-circle-o text-info"></i>
+            </span>
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
+
     <dialog id="info-dialog">
         <div class="alert alert-info">
             {% blocktranslate trimmed %}

--- a/src/pretalx/orga/templates/orga/event/component_link.html
+++ b/src/pretalx/orga/templates/orga/event/component_link.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<div class="navigation-button">
+    {% if request.event %}
+        <a href="{{ request.event.tickets_urls.tickets_home_common.full }}" class="header-nav btn btn-outline-success">
+            <i class="fa fa-home"></i> {% translate "Home" %}
+        </a>
+        <a href="{{ request.event.tickets_urls.tickets_dashboard_url.full }}" class="header-nav btn btn-outline-success">
+            <i class="fa fa-ticket"></i> {% translate "Tickets" %}
+        </a>
+        <a href="#" class="header-nav btn btn-success active">
+            <i class="fa fa-group"></i> {% translate "Talk" %}
+        </a>
+    {% endif %}
+</div>

--- a/src/pretalx/orga/templates/orga/event/dashboard.html
+++ b/src/pretalx/orga/templates/orga/event/dashboard.html
@@ -24,12 +24,15 @@
             {% endblocktranslate %}
         </div>
     {% endif %}
-    <h2 id="main-title">
-        <span>
-            {{ request.event.name }}
-            <small class="text-muted small">{{ request.event.get_date_range_display }}</small>
-        </span>
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            <span>
+                {{ request.event.name }}
+                <small class="text-muted small">{{ request.event.get_date_range_display }}</small>
+            </span>
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <div id="timeline-steps" class="stages">
         {% for stp in timeline %}
             <div {% if stp.phase == "done" and stp.url %}href="{{ stp.url }}"{% endif %} class="step step-{{ stp.phase }}">

--- a/src/pretalx/orga/templates/orga/mails/compose_choice.html
+++ b/src/pretalx/orga/templates/orga/mails/compose_choice.html
@@ -5,7 +5,10 @@
 {% block extra_title %}{% translate "Send emails" %} :: {% endblock extra_title %}
 
 {% block content %}
-  <h1>{% translate "Send emails" %}</h1>
+  <div class="d-md-flex justify-content-between">
+      <h2>{% translate "Send emails" %}</h2>
+      {% include "orga/event/component_link.html" %}
+  </div>
   <ul class="list-group">
     <a class="list-group-item list-group-item-action" href="{{ request.event.orga_urls.compose_mails_sessions }}">
       <h4>

--- a/src/pretalx/orga/templates/orga/mails/outbox_form.html
+++ b/src/pretalx/orga/templates/orga/mails/outbox_form.html
@@ -14,7 +14,10 @@
     {% endif %}
     <form method="post">
         {% csrf_token %}
-        <h2>{% translate "Mail Editor" %}</h2>
+        <div class="d-md-flex justify-content-between">
+            <h2>{% translate "Mail Editor" %}</h2>
+            {% include "orga/event/component_link.html" %}
+        </div>
 
         {% if not form.read_only %}
             {{ form }}

--- a/src/pretalx/orga/templates/orga/mails/outbox_list.html
+++ b/src/pretalx/orga/templates/orga/mails/outbox_list.html
@@ -3,16 +3,19 @@
 {% load i18n %}
 
 {% block mail_content %}
-    <h2>
-        <span>
-            {{ page_obj.paginator.count }}
-            {% blocktranslate trimmed count count=page_obj.paginator.count %}
-                pending mail
-            {% plural %}
-                pending mails
-            {% endblocktranslate %}
-        </span>
-    </h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>
+            <span>
+                {{ page_obj.paginator.count }}
+                {% blocktranslate trimmed count count=page_obj.paginator.count %}
+                    pending mail
+                {% plural %}
+                    pending mails
+                {% endblocktranslate %}
+            </span>
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <div class="submit-group">
         <div>
             {% include "common/includes/search_form.html" with omit_wrapper=True %}

--- a/src/pretalx/orga/templates/orga/mails/sent_list.html
+++ b/src/pretalx/orga/templates/orga/mails/sent_list.html
@@ -3,10 +3,13 @@
 {% load i18n %}
 
 {% block mail_content %}
-    <h2>
-        {{ page_obj.paginator.count }}
-        {% translate "Sent Mails" %}
-    </h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>
+            {{ page_obj.paginator.count }}
+            {% translate "Sent Mails" %}
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     {% include "common/includes/search_form.html" %}
     <div class="table-responsive-sm">
         <table class="table table-sm table-hover table-flip table-sticky">

--- a/src/pretalx/orga/templates/orga/mails/template_list.html
+++ b/src/pretalx/orga/templates/orga/mails/template_list.html
@@ -12,16 +12,23 @@
 {% endblock scripts %}
 
 {% block mail_content %}
-    <h2 class="d-flex">
-        {% translate "Templates" %}
-        <span class="dialog-anchor ml-2" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-        <a href="{{ request.event.orga_urls.new_template }}" class="btn btn-success flip ml-auto">
-            <i class="fa fa-plus"></i>
-            {% translate "New custom template" %}
-        </a>
-    </h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>
+            {% translate "Templates" %}
+            <span class="dialog-anchor ml-2" data-target="#info-dialog" data-toggle="dialog">
+                <i class="fa fa-question-circle-o text-info"></i>
+            </span>
+        </h2>
+        <div class="d-flex">
+            <div class="mr-2">
+                <a href="{{ request.event.orga_urls.new_template }}" class="btn btn-success flip ml-auto">
+                    <i class="fa fa-plus"></i>
+                    {% translate "New custom template" %}
+                </a>
+            </div>
+            {% include "orga/event/component_link.html" %}
+        </div>
+    </div>
     <dialog class="info-dialog" id="info-dialog">
         <div class="alert alert-info">
             <div>

--- a/src/pretalx/orga/templates/orga/plugins.html
+++ b/src/pretalx/orga/templates/orga/plugins.html
@@ -4,7 +4,10 @@
 
 {% block extra_title %}{% translate "Plugins" %} :: {% endblock extra_title %}
 {% block content %}
-    <h2>{% translate "Plugins" %}</h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>{% translate "Plugins" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% if grouped_plugins %}
         {% include "orga/includes/tablist.html" %}

--- a/src/pretalx/orga/templates/orga/review/assignment-import.html
+++ b/src/pretalx/orga/templates/orga/review/assignment-import.html
@@ -8,7 +8,10 @@
 {% block extra_title %}{% translate "Assign reviewers" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Assign reviewers" %}</h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>{% translate "Assign reviewers" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <p>
         {% blocktranslate trimmed with href="#" %}
             You can upload your reviewer assignments from a JSON file here. You can either have the proposal codes (e.g. “UX3N1”) as keys, and user identification as values, or the other way around. User identification can be either the reviewer’s email address or their user code (e.g. “34KJN”). You can find an example file <a href="{{ href }}">here</a>.

--- a/src/pretalx/orga/templates/orga/review/assignment.html
+++ b/src/pretalx/orga/templates/orga/review/assignment.html
@@ -22,7 +22,10 @@
     {% compress js %}
         <script defer src="{% static "orga/js/reviewAssignment.js" %}"></script>
     {% endcompress %}
-    <h2>{% translate "Assign reviewers" %}</h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>{% translate "Assign reviewers" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% include "orga/includes/tablist.html" %}
 

--- a/src/pretalx/orga/templates/orga/review/dashboard.html
+++ b/src/pretalx/orga/templates/orga/review/dashboard.html
@@ -47,6 +47,10 @@
             {% endif %}
         </div>
     </div>
+    <div class="d-md-flex justify-content-between">
+        <h2>{% translate "Review Proposals" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     <div class="ml-auto mb-2 d-flex">
         <details class="dropdown flip ml-auto fix-height mr-2" aria-haspopup="menu" role="menu">

--- a/src/pretalx/orga/templates/orga/review/export.html
+++ b/src/pretalx/orga/templates/orga/review/export.html
@@ -5,7 +5,10 @@
 {% block extra_title %}{% translate "Export review data" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Export review data" %}</h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>{% translate "Export review data" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% include "orga/includes/tablist.html" %}
 

--- a/src/pretalx/orga/templates/orga/schedule/export.html
+++ b/src/pretalx/orga/templates/orga/schedule/export.html
@@ -7,7 +7,10 @@
 {% block extra_title %}{% translate "Export schedule data" %} :: {% endblock extra_title %}
 
 {% block schedule_content %}
-    <h2>{% translate "Export schedule data" %}</h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>{% translate "Export schedule data" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% include "orga/includes/tablist.html" %}
 

--- a/src/pretalx/orga/templates/orga/schedule/room_form.html
+++ b/src/pretalx/orga/templates/orga/schedule/room_form.html
@@ -9,13 +9,16 @@
 {% block content %}
     {% include "common/availabilities.html" %}
 
-    <h2>
-        {% if form.instance.pk %}
-            {% translate "Room" %} {{ quotation_open }}{{ form.instance.name }}{{ quotation_close }}
-        {% else %}
-            {% translate "New room" %}
-        {% endif %}
-    </h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>
+            {% if form.instance.pk %}
+                {% translate "Room" %} {{ quotation_open }}{{ form.instance.name }}{{ quotation_close }}
+            {% else %}
+                {% translate "New room" %}
+            {% endif %}
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <form method="post">
         {% csrf_token %}
         {% include "common/forms/errors.html" %}

--- a/src/pretalx/orga/templates/orga/schedule/room_list.html
+++ b/src/pretalx/orga/templates/orga/schedule/room_list.html
@@ -20,14 +20,17 @@
 
 {% block content %}
     <div>
-        <h2>
-            {{ request.event.rooms.count }}
-            {% blocktranslate trimmed count count=request.event.rooms.count context "Number of rooms" %}
-                Room
-            {% plural %}
-                Rooms
-            {% endblocktranslate %}
-        </h2>
+        <div class="d-md-flex justify-content-between">
+            <h2>
+                {{ request.event.rooms.count }}
+                {% blocktranslate trimmed count count=request.event.rooms.count context "Number of rooms" %}
+                    Room
+                {% plural %}
+                    Rooms
+                {% endblocktranslate %}
+            </h2>
+            {% include "orga/event/component_link.html" %}
+        </div>
 
         <div class="table-responsive-sm">
             <table class="table table-sm table-hover table-flip table-sticky">

--- a/src/pretalx/orga/templates/orga/settings/form.html
+++ b/src/pretalx/orga/templates/orga/settings/form.html
@@ -27,7 +27,10 @@
 {% block extra_title %}{% translate "Settings" %} :: {% endblock extra_title %}
 
 {% block settings_content %}
-    <h2>{% translate "Settings" %}</h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>{% translate "Settings" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
 

--- a/src/pretalx/orga/templates/orga/settings/mail.html
+++ b/src/pretalx/orga/templates/orga/settings/mail.html
@@ -22,12 +22,15 @@
 {% block settings_content %}
     <form method="post">
         {% csrf_token %}
-        <h2>
+        <div id="main-title" class="d-md-flex justify-content-between">
+            <h2>
             {% translate "Email settings" %}
             <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
                 <i class="fa fa-question-circle-o text-info"></i>
             </span>
-        </h2>
+            </h2>
+            {% include "orga/event/component_link.html" %}
+        </div>
         <dialog id="info-dialog">
             <div class="alert alert-info">
                 {% blocktranslate trimmed %}

--- a/src/pretalx/orga/templates/orga/settings/review.html
+++ b/src/pretalx/orga/templates/orga/settings/review.html
@@ -27,7 +27,10 @@
     <form method="post" class="d-flex flex-column">
         {% csrf_token %}
 
-        <h2>{% translate "Review settings" %}</h2>
+        <div id="main-title" class="d-md-flex justify-content-between">
+            <h2>{% translate "Review settings" %}</h2>
+            {% include "orga/event/component_link.html" %}
+        </div>
 
         {% include "orga/includes/tablist.html" %}
 

--- a/src/pretalx/orga/templates/orga/settings/widget.html
+++ b/src/pretalx/orga/templates/orga/settings/widget.html
@@ -21,12 +21,15 @@
 {% endblock scripts %}
 
 {% block settings_content %}
-    <h2>
-        {% translate "Widget settings" %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% translate "Widget settings" %}
+            <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+                <i class="fa fa-question-circle-o text-info"></i>
+            </span>
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <dialog id="info-dialog">
         <div class="alert alert-info flip ml-auto">
             {% blocktranslate trimmed %}

--- a/src/pretalx/orga/templates/orga/speaker/export.html
+++ b/src/pretalx/orga/templates/orga/speaker/export.html
@@ -6,7 +6,10 @@
 {% block extra_title %}{% translate "Export speaker data" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Export speaker data" %}</h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>{% translate "Export speaker data" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% include "orga/includes/tablist.html" %}
 

--- a/src/pretalx/orga/templates/orga/speaker/information_form.html
+++ b/src/pretalx/orga/templates/orga/speaker/information_form.html
@@ -5,13 +5,16 @@
 {% block extra_title %}{% blocktranslate trimmed count count=1 %}Speaker Information Note{% plural %}Speaker Information Notes{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% blocktranslate trimmed count count=1 %}
-            Speaker Information Note
-        {% plural %}
-            Speaker Information Notes
-        {% endblocktranslate %}
-    </h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>
+            {% blocktranslate trimmed count count=1 %}
+                Speaker Information Note
+            {% plural %}
+                Speaker Information Notes
+            {% endblocktranslate %}
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% include "orga/includes/base_form.html" %}
 

--- a/src/pretalx/orga/templates/orga/speaker/information_list.html
+++ b/src/pretalx/orga/templates/orga/speaker/information_list.html
@@ -19,17 +19,20 @@
 {% block extra_title %}{{ information.count }} {% blocktranslate trimmed count count=information.count %}Speaker Information Note{% plural %}Speaker Information Notes{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {{ information.count }}
-        {% blocktranslate trimmed count count=information.count %}
-            Speaker Information Note
-        {% plural %}
-            Speaker Information Notes
-        {% endblocktranslate %}
-        <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
-            <i class="fa fa-question-circle-o text-info"></i>
-        </span>
-    </h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>
+            {{ information.count }}
+            {% blocktranslate trimmed count count=information.count %}
+                Speaker Information Note
+            {% plural %}
+                Speaker Information Notes
+            {% endblocktranslate %}
+            <span class="dialog-anchor" data-target="#info-dialog" data-toggle="dialog">
+                <i class="fa fa-question-circle-o text-info"></i>
+            </span>
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     <dialog class="info-dialog" id="info-dialog">
         <div class="alert alert-info">
             {% blocktranslate trimmed %}

--- a/src/pretalx/orga/templates/orga/speaker/list.html
+++ b/src/pretalx/orga/templates/orga/speaker/list.html
@@ -6,14 +6,17 @@
 {% block extra_title %}{{ page_obj.paginator.count }} {% blocktranslate trimmed count count=page_obj.paginator.count %}submitter{% plural %}submitters{% endblocktranslate %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {{ page_obj.paginator.count }}
-        {% blocktranslate trimmed count count=page_obj.paginator.count %}
-            submitter
-        {% plural %}
-            submitters
-        {% endblocktranslate %}
-    </h2>
+    <div class="d-md-flex justify-content-between">
+        <h2>
+            {{ page_obj.paginator.count }}
+            {% blocktranslate trimmed count count=page_obj.paginator.count %}
+                submitter
+            {% plural %}
+                submitters
+            {% endblocktranslate %}
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% include "common/includes/search_form.html" %}
 

--- a/src/pretalx/orga/templates/orga/submission/base.html
+++ b/src/pretalx/orga/templates/orga/submission/base.html
@@ -34,19 +34,22 @@
         {% has_perm "submission.review_submission" request.user submission as can_review %}
         {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
         {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
-        <h2>
-            <span>
-                {{ quotation_open }}{% if can_view_speakers %}{{ submission.title }}{% else %}{{ submission.anonymised.title|default:submission.title }}{% endif %}{{ quotation_close }}
-                {% if submission.speakers.exists and can_view_speakers %}
-                    – {% include "orga/includes/submission_speaker_names.html" with lightbox=True %}
-                {% endif %}
-                {% if can_edit_submission %}
-                    {% include "orga/submission/state_dropdown.html" with submission=submission %}
-                {% else %}
-                    {% include "cfp/event/fragment_state.html" with state=submission.state as_badge=True %}
-                {% endif %}
-            </span>
-        </h2>
+        <div id="main-title" class="d-md-flex justify-content-between">
+            <h2>
+                <span>
+                    {{ quotation_open }}{% if can_view_speakers %}{{ submission.title }}{% else %}{{ submission.anonymised.title|default:submission.title }}{% endif %}{{ quotation_close }}
+                    {% if submission.speakers.exists and can_view_speakers %}
+                        – {% include "orga/includes/submission_speaker_names.html" with lightbox=True %}
+                    {% endif %}
+                    {% if can_edit_submission %}
+                        {% include "orga/submission/state_dropdown.html" with submission=submission %}
+                    {% else %}
+                        {% include "cfp/event/fragment_state.html" with state=submission.state as_badge=True %}
+                    {% endif %}
+                </span>
+            </h2>
+            {% include "orga/event/component_link.html" %}
+        </div>
 
         <div role="tablist" class="mb-4">
             <a role="tab" href="{{ submission.orga_urls.base }}" {% if "submissions.content" in url_name %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>

--- a/src/pretalx/orga/templates/orga/submission/content.html
+++ b/src/pretalx/orga/templates/orga/submission/content.html
@@ -24,7 +24,10 @@
     <form method="post" enctype="multipart/form-data">
         <fieldset>
             {% if not submission %}
-                <legend>{% translate "Create proposal" %}</legend>
+                <div id="main-title" class="d-md-flex justify-content-between">
+                    <h2>{% translate "Create proposal" %}</h2>
+                    {% include "orga/event/component_link.html" %}
+                </div>
             {% endif %}
 
             {% if submission.access_code %}

--- a/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
+++ b/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
@@ -7,7 +7,10 @@
 {% block extra_title %}{% translate "Attendee feedback" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2 class="d-flex w-100 justify-content-between align-items-start">{% translate "Attendee feedback" %}</h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>{% translate "Attendee feedback" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% regroup feedback|dictsort:"talk.title" by talk.title as feedbacks_list %}
 

--- a/src/pretalx/orga/templates/orga/submission/list.html
+++ b/src/pretalx/orga/templates/orga/submission/list.html
@@ -25,35 +25,40 @@
     {% has_perm "orga.change_submission_state" request.user request.event as can_change_submission %}
     {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
     {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
-    <h2 class="d-flex align-items-center">
+    <h2 class="d-md-flex align-items-center">
         <span>
             {{ page_obj.paginator.count }}
             {% blocktranslate trimmed count count=page_obj.paginator.count %}
                 session
             {% plural %}
                 sessions
-            {% endblocktranslate %}
+            {% endblocktranslate %} 
         </span>
         <p class="flip ml-auto">
-            {% if can_send_mails %}
-                <a class="btn btn-outline-info mt-2" href="{{ request.event.orga_urls.compose_mails_sessions }}{% querystring page="" %}">
-                    <i class="fa fa-envelope"></i>
-                    {% translate "Send email" %}
-                </a>
-            {% endif %}
-            {% if pending_changes and can_change_submission %}
-                <a class="btn btn-info mt-2" href="{{ request.event.orga_urls.apply_pending }}">
-                    {% translate "Apply pending changes" %} ({{ pending_changes }})
-                </a>
-            {% endif %}
-            {% if can_create_submission %}
-                <a href="{{ request.event.orga_urls.new_submission }}" class="btn btn-info mt-2">
-                    <i class="fa fa-plus"></i> {% translate "Add new session or proposal" %}
-                </a>
-                <a class="btn btn-link" href="{{ request.event.orga_urls.submission_feed }}" title="{% translate "Proposal feed" %}">
-                    <i class="fa fa-feed"></i>
-                </a>
-            {% endif %}
+            <div>
+                {% if can_send_mails %}
+                    <a class="btn btn-outline-info mt-2" href="{{ request.event.orga_urls.compose_mails_sessions }}{% querystring page="" %}">
+                        <i class="fa fa-envelope"></i>
+                        {% translate "Send email" %}
+                    </a>
+                {% endif %}
+                {% if pending_changes and can_change_submission %}
+                    <a class="btn btn-info mt-2" href="{{ request.event.orga_urls.apply_pending }}">
+                        {% translate "Apply pending changes" %} ({{ pending_changes }})
+                    </a>
+                {% endif %}
+                {% if can_create_submission %}
+                    <a href="{{ request.event.orga_urls.new_submission }}" class="btn btn-info mt-2">
+                        <i class="fa fa-plus"></i> {% translate "Add new session or proposal" %}
+                    </a>
+                    <a class="btn btn-link" href="{{ request.event.orga_urls.submission_feed }}" title="{% translate "Proposal feed" %}">
+                        <i class="fa fa-feed"></i>
+                    </a>
+                {% endif %}
+            </div>
+            <div>
+                {% include "orga/event/component_link.html" %}
+            </div>
         </p>
     </h2>
 

--- a/src/pretalx/orga/templates/orga/submission/stats.html
+++ b/src/pretalx/orga/templates/orga/submission/stats.html
@@ -25,6 +25,9 @@
                 <label for="toggle-button" class="toggle-label">{% translate "Proposals" %}</label>
                 <input type="checkbox" id="toggle-button" name="stats-toggle" role="button">
                 <label for="toggle-button" class="toggle-label">{{ phrases.schedule.sessions }}</label>
+                <div class="ml-2">
+                    {% include "orga/event/component_link.html" %}
+                </div>
             </div>
         </h2>
 

--- a/src/pretalx/orga/templates/orga/submission/tag_form.html
+++ b/src/pretalx/orga/templates/orga/submission/tag_form.html
@@ -19,13 +19,16 @@
 {% endblock extra_title %}
 
 {% block content %}
-    <h2>
-        {% if form.instance.tag %}
-            {% translate "Tag" %} {{ quotation_open }}{{ form.instance.tag }}{{ quotation_close }}
-        {% else %}
-            {% translate "New tag" %}
-        {% endif %}
-    </h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>
+            {% if form.instance.tag %}
+                {% translate "Tag" %} {{ quotation_open }}{{ form.instance.tag }}{{ quotation_close }}
+            {% else %}
+                {% translate "New tag" %}
+            {% endif %}
+        </h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
 
     {% include "orga/includes/base_form.html" %}
 

--- a/src/pretalx/orga/templates/orga/submission/tag_list.html
+++ b/src/pretalx/orga/templates/orga/submission/tag_list.html
@@ -6,7 +6,10 @@
 {% block extra_title %}{% translate "Tags" %} :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>{% translate "Tags" %}</h2>
+    <div id="main-title" class="d-md-flex justify-content-between">
+        <h2>{% translate "Tags" %}</h2>
+        {% include "orga/event/component_link.html" %}
+    </div>
     {% has_perm "orga.add_tags" request.user request.event as can_edit_tags %}
     {% if can_edit_tags %}
         <div class="d-flex justify-content-end mb-3">

--- a/src/pretalx/orga/urls.py
+++ b/src/pretalx/orga/urls.py
@@ -206,7 +206,7 @@ urlpatterns = [
                         ]
                     ),
                 ),
-                path("cfp/text", cfp.CfPTextDetail.as_view(), name="cfp.text.view"),
+                path("cfp/text/", cfp.CfPTextDetail.as_view(), name="cfp.text.view"),
                 path(
                     "cfp/types/",
                     cfp.SubmissionTypeList.as_view(),


### PR DESCRIPTION
This PR closes/references issue #251.

The Home menu item links to /tickets/common for the current event.
The Tickets menu item links to /tickets/control of the event.
The Talk menu item is links to # (i.e. same app)

I've added these menu items to most relevant pages. If any pages were missed or need the menu included, we can address that in a separate PR.

The Video menu item has not been included, as I couldn't identify a clear destination or reference link for it within the eventyay-tickets dashboard.

## Screenshot
![talk_secondary_menu](https://github.com/user-attachments/assets/9b6612f8-b898-4d25-a2ea-e254c2d7b1d2)

## Summary by Sourcery

Add a common secondary navigation bar to the Talk section by creating a shared component and wiring up event ticket URLs, and refactor headers to consistently accommodate the new menu.

New Features:
- Introduce a reusable secondary navigation menu in the Talk component with Home, Tickets, and Talk buttons

Bug Fixes:
- Normalize the `cfp/text/` URL to include a trailing slash

Enhancements:
- Update multiple Orga page templates to use a flex‐based header layout and include the new menu component
- Add `tickets_urls` definitions to the Event model for constructing the ticket links