### PR TITLE
Remove left-hand dropdown and link top-left title to dashboard

### DIFF
--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -1,4 +1,6 @@
 {% load compress %}
+{% load context_icons %}
+{% load context_urls %}
 {% load event_tags %}
 {% load i18n %}
 {% load rules %}
@@ -160,50 +162,46 @@
             </div>
         {% endif %}
         <div id="page-wrapper">
-            {% if not request.user.is_anonymous %}<aside class="nav flex-column sidebar">
-                <details class="dropdown nav-link p-0" id="nav-search-wrapper">
-                    <summary id="nav-search" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span id="search-context-icon" class="fa-stack fa-lg">
-                            <i class="fa fa-circle fa-stack-2x"></i>
-                            <i class="fa fa-{% if request.event %}calendar{% elif request.organiser %}group{% else %}user{% endif %} fa-stack-1x fa-inverse"></i>
-                        </span>
-                        <div id="search-context-text">
-                            {% if request.event %}
-                                <span class="context-name">{{ request.event.name }}</span>
-                                <span class="context-meta">{{ request.event.get_date_range_display }}</span>
-                            {% elif request.organiser %}
-                                <span class="context-name">{{ request.organiser.name }}</span>
-                                <span class="context-meta">{% translate "Organiser account" %}</span>
-                            {% else %}
-                                <span class="context-name">{{ request.user.get_display_name }}</span>
-                            {% endif %}
-                        </div>
-                        <div class="arrow">
-                            <i class="fa fa-angle-down"></i>
-                        </div>
-                    </summary>
-                    <div id="nav-search-input-wrapper" class="dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url "orga:nav.typeahead" %}" data-event-typeahead data-organiser="{% if request.event %}{{ request.event.organiser.pk }}{% elif request.organiser %}{{ request.organiser.pk }}{% endif %}">
-                        <div class="query-holder">
-                            <div class="form-box">
-                                <input type="search" class="form-control" placeholder="{% translate "Search" %} (Alt + k)" data-typeahead-query>
+            {% if request.user.is_authenticated %}
+            <aside class="nav flex-column sidebar">
+                <div class="dropdown nav-link p-0" id="nav-search-wrapper">
+                    <a href="{% get_dashboard_url %}" style="text-decoration: none; color: inherit;">
+                        <div id="nav-search" class="dropdown-toggle summary-div" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <span id="search-context-icon" class="fa-stack fa-lg">
+                                    <i class="fa fa-circle fa-stack-2x"></i>
+                                    <i class="fa {% get_top_menu_item_icon_class %} fa-stack-1x fa-inverse"></i>
+                                </span>
+                                <div id="search-context-text">
+                                    {% if request.event %}
+                                        <span class="context-name font-weight-bold">{{ request.event.name }}</span>
+                                        <span class="context-meta">{{ request.event.get_date_range_display }}</span>
+                                    {% elif request.organiser %}
+                                        <span class="context-name font-weight-bold">{{ request.organiser.name }}</span>
+                                        <span class="context-meta">{% translate "Organiser account" %}</span>
+                                    {% else %}
+                                        <span class="context-name font-weight-bold">{{ request.user.get_display_name }}</span>
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
-                        <ul id="search-results">
-                        </ul>
-                    </div>
-                </details>
+                        <div id="nav-search-input-wrapper" class="d-none dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url 'orga:nav.typeahead' %}" data-event-typeahead data-organiser="{% if request.event %}{{ request.event.organiser.pk }}{% elif request.organiser %}{{ request.organiser.pk }}{% endif %}">
+                            <div class="query-holder">
+                                <div class="form-box">
+                                    <input type="search" class="form-control" placeholder="{% translate 'Search' %} (Alt + k)" data-typeahead-query>
+                                </div>
+                            </div>
+                            <ul id="search-results">
+                            </ul>
+                        </div>
+                    </a>
+                </div>
                 {% if request.event %}
                     {% has_perm "orga.view_orga_area" request.user request.event as can_see_orga_area %}
                     {% has_perm "orga.change_submissions" request.user request.event as can_see_orga_exclusive %}
                     {% has_perm "orga.change_teams" request.user request.event as can_change_teams %}
                     {% has_perm "orga.change_settings" request.user request.event as can_change_settings %}
                     {% has_perm "orga.view_speakers" request.user request.event as can_view_speakers %}
-                    {% if can_see_orga_area %}
-                        <a class="nav-link {% if url_name == "event.dashboard" %}active{% endif %}" href="{{ request.event.orga_urls.base }}">
-                            <i class="fa fa-tachometer"></i>
-                            <span class="sidebar-text">{% translate "Dashboard" %}</span>
-                        </a>
-                    {% endif %}
                     {% if can_see_orga_exclusive %}
                         {% if can_change_settings %}
                             <div class="nav-fold">
@@ -424,10 +422,6 @@
                         {% endfor %}
                     {% endif %}
                 {% elif request.organiser %}  {# if request.event #}
-                    <a class="nav-link {% if url_name == "organiser.dashboard" %} active{% endif %}" href="{{ request.organiser.orga_urls.base }}">
-                        <i class="fa fa-tachometer"></i>
-                        <span>{% translate "Dashboard" %}</span>
-                    </a>
                     <a class="nav-link {% if "/settings/" in request.path %} active{% endif %}" href="{{ request.organiser.orga_urls.settings }}">
                         <i class="fa fa-cog"></i>
                         <span>{% translate "Settings" %}</span>

--- a/src/pretalx/orga/templatetags/context_icons.py
+++ b/src/pretalx/orga/templatetags/context_icons.py
@@ -1,0 +1,12 @@
+from django import template
+
+register = template.Library()
+
+@register.simple_tag(takes_context=True)
+def get_top_menu_item_icon_class(context):
+    request = context['request']
+    if getattr(request, 'event', None):
+        return 'fa-tachometer'
+    elif getattr(request, 'organiser', None):
+        return 'fa-group'
+    return 'fa-user'

--- a/src/pretalx/orga/templatetags/context_urls.py
+++ b/src/pretalx/orga/templatetags/context_urls.py
@@ -1,0 +1,13 @@
+from django import template
+from django.urls import reverse
+
+register = template.Library()
+
+@register.simple_tag(takes_context=True)
+def get_dashboard_url(context):
+    request = context['request']
+    if getattr(request, 'event', None):
+        return request.event.orga_urls.base
+    elif getattr(request, 'organiser', None):
+        return request.organiser.orga_urls.base
+    return reverse('orga:event.list')

--- a/src/pretalx/static/orga/js/typeahead.js
+++ b/src/pretalx/static/orga/js/typeahead.js
@@ -1,6 +1,6 @@
 const initNavSearch = () => {
     const wrapper = document.querySelector("#nav-search-wrapper")
-    const summary = wrapper.querySelector("summary")
+    const summary = wrapper.querySelector(".summary-div")
     const searchInput = wrapper.querySelector("input")
     const searchWrapper = wrapper.querySelector("#nav-search-input-wrapper")
     const apiURL = searchWrapper.getAttribute("data-source")


### PR DESCRIPTION
Fixes: #339 

1. Event's top menu item links to Dashboard.
2. Organizer's top menu item links to Dashboard.
3. User's top menu item links to Event as shown in below video.

[339.webm](https://github.com/user-attachments/assets/48564d3a-43f5-4801-bc2a-0ee305b5f148)

## Summary by Sourcery

Simplify the sidebar navigation by removing the collapsible context dropdown and linking the top-left context title directly to the corresponding dashboard or event list; update icons, styling, and typeahead integration.

Enhancements:
- Replace the expandable nav context dropdown with a direct link wrapping the header to the appropriate base URL.
- Switch the event context icon to a tachometer and apply bold styling to context names.
- Remove redundant 'Dashboard' sidebar links under both event and organiser contexts.
- Rename the summary element and adjust the search input wrapper visibility and markup, updating typeahead.js to target the new element selector.