### PR TITLE
Match dashboard colors with eventyay-tickets

### DIFF
--- a/src/pretalx/static/common/css/_forms.css
+++ b/src/pretalx/static/common/css/_forms.css
@@ -573,10 +573,9 @@ input.password_strength {
   justify-content: space-between;
   flex-grow: 1;
   flex-wrap: wrap;
-  background-color: var(--color-grey-lightest);
+  background-color: var(--color-grey-pale);
   padding: 16px;
   margin-bottom: 16px;
-  border-radius: var(--size-border-radius);
 
   button {
     align-self: flex-end;

--- a/src/pretalx/static/common/css/_variables.css
+++ b/src/pretalx/static/common/css/_variables.css
@@ -47,6 +47,8 @@
 
   --color-white: #fff;
   --color-offwhite: #f8f9fa;
+  --color-grey-ultralight: #f8f8f8;
+  --color-grey-pale: #eeeeee;
   --color-grey-lightest: color-mix(in srgb, #f8f9fa 95%, var(--color-primary));
   --color-grey-lighter: color-mix(in srgb, #e9ecef 95%, var(--color-primary));
   --color-grey-light: color-mix(in srgb, #dae0e4 90%, var(--color-primary));

--- a/src/pretalx/static/common/css/base.css
+++ b/src/pretalx/static/common/css/base.css
@@ -109,11 +109,12 @@ table {
   tr {
     vertical-align: middle;
     &:hover {
-      background-color: var(--color-grey-lightest);
+      background-color: var(--color-grey-ultralight);
     }
   }
   a:hover {
     text-decoration: none;
+    color: var(--color-primary-text-dark);
   }
 }
 

--- a/src/pretalx/static/orga/css/_layout.css
+++ b/src/pretalx/static/orga/css/_layout.css
@@ -154,7 +154,7 @@ details.card {
   }
 }
 aside.sidebar {
-  background-color: var(--color-grey-lightest);
+  background-color: var(--color-grey-ultralight);
   box-shadow: var(--shadow-lighter);
   width: 45px;
   height: 100vh;
@@ -191,7 +191,7 @@ aside.sidebar {
   }
 
   a {
-    color: var(--color-text-lighter);
+    color: var(--color-primary);
     font-weight: bold;
     &:hover {
       text-decoration: none;
@@ -202,7 +202,7 @@ aside.sidebar {
   #nav-search-wrapper {
     .arrow {
       flex-grow: 0;
-      color: var(--color-text-lighter);
+      color: var(--color-primary);
       width: 40px;
       border: none;
       display: flex;
@@ -236,7 +236,7 @@ aside.sidebar {
   .nav-link,
   .nav-fold {
     display: block;
-    border-top: 1px solid var(--color-grey-light);
+    border-top: 1px solid #e7e7e7;
     div > a {
       display: none;
     }
@@ -246,7 +246,7 @@ aside.sidebar {
     padding: 10px 15px;
 
     &:last-child {
-      border-bottom: 1px solid var(--color-grey-light);
+      border-bottom: 1px solid #e7e7e7;
     }
   }
 
@@ -271,14 +271,18 @@ aside.sidebar {
   }
 
   .nav-link.active,
+  .nav-link.nav-link-second-level.active {
+    background-color: var(--color-grey-pale);
+  }
   .nav-link.active:hover,
-  .nav-link.nav-link-second-level.active,
   .nav-link.nav-link-second-level.active:hover {
-    background-color: var(--color-primary-lighter);
+    background-color: var(--color-grey-pale);
+    color: var(--color-primary-text-dark);
   }
   .nav-link:hover,
   .nav-link.nav-link-second-level:hover {
-    background-color: var(--color-grey-lighter);
+    color: var(--color-primary-text-dark);
+    background-color: var(--color-grey-pale);
   }
   #nav-search {
     display: flex;

--- a/src/pretalx/static/orga/css/dashboard.css
+++ b/src/pretalx/static/orga/css/dashboard.css
@@ -13,13 +13,7 @@
     width: 340px;
     max-width: calc(100% - 16px);
     border-radius: 4px;
-    box-shadow: var(--shadow-lighter);
-    border-radius: var(--size-border-radius);
     user-select: none;
-
-    &:hover {
-      box-shadow: var(--shadow-light);
-    }
   }
 
   .dashboard-block-wrapper {
@@ -71,13 +65,14 @@
 
   .dashboard-block {
     color: var(--color-primary);
-    background: var(--color-grey-lightest);
+    background: var(--color-grey-ultralight);
     overflow-wrap: break-word;
     &.dashboard-block-extended {
       min-height: 100px;
     }
     &:hover {
-      color: var(--color-primary);
+      color: var(--color-primary-text-dark);
+      background-color: var(--color-grey-pale);
       text-decoration: none;
     }
 


### PR DESCRIPTION
Fixes: #343 

[343.webm](https://github.com/user-attachments/assets/10a76157-1923-4415-965e-8031b6c714c7)


## Summary by Sourcery

Align the dashboard and general UI color palette with the eventyay-tickets theme by introducing new grey shades and applying them across layout, dashboard, forms, and base styles.

Enhancements:
- Add new CSS variables for ultra-light and pale grey shades to support the updated theme
- Update sidebar backgrounds, link borders, and nav-item active/hover states to use the new grey variables and primary text colors
- Adjust dashboard block backgrounds and hover styles to use updated grey variables and primary-text-dark for hover
- Revise password strength input container background to the pale grey shade
- Modify table row hover backgrounds and anchor hover text color for consistency