### PR TITLE
Update top-left eventyay icon to link to /common dashboard

### DIFF
--- a/src/pretalx/orga/context_processors.py
+++ b/src/pretalx/orga/context_processors.py
@@ -1,6 +1,7 @@
 import logging
 from configparser import RawConfigParser
 from typing import cast
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -33,6 +34,7 @@ def orga_events(request):
     site_config = dict(config.items("site"))
     context["site_config"] = site_config
     context["base_path"] = settings.BASE_PATH
+    context["tickets_common"] = urljoin(settings.EVENTYAY_TICKET_BASE_PATH, "common")
     # Login button label
     key = site_config.get("call_for_speaker_login_button_label", "default")
     button_label = CALL_FOR_SPEAKER_LOGIN_BTN_LABELS.get(key)

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -4,6 +4,7 @@
 {% load rules %}
 {% load static %}
 {% load vite %}
+{% blocktranslate with site_name=site_config.name asvar logo_alt_text %}The {{ site_name }} logo{% endblocktranslate %}
 
 <!DOCTYPE html>
 <html lang="{{ html_locale }}"{% if rtl %} dir="rtl" class="rtl"{% endif %}>
@@ -75,8 +76,8 @@
                     </a>
                 </li>
             </ul>
-            <a class="navbar-brand" href="{% url "orga:event.list" %}">
-                <img loading="lazy" src="{% static "common/img/icons/icon.svg" %}" alt="{% translate "The {{ site_config.name }} logo" %}">
+            <a class="navbar-brand" href="{{ tickets_common }}">
+                <img loading="lazy" src="{% static 'common/img/icons/icon.svg' %}" alt="{{ logo_alt_text }}">
                 {{ site_config.name }}
             </a>
             <div class="navbar-collapse" id="navbartoggle">


### PR DESCRIPTION
Fixes: #338 

[338.webm](https://github.com/user-attachments/assets/5daa2d6f-2175-4f36-8f3c-99e679d3d47b)

## Summary by Sourcery

Update the navbar brand link to point to the centralized common dashboard by adding a `tickets_common` URL context variable in the OrgA context processor and using it in the base template.

Bug Fixes:
- Link the top-left navbar brand icon to the shared dashboard URL instead of the event list view.

Enhancements:
- Introduce a new `tickets_common` context variable to generate the common dashboard link from settings.