### PR TITLE
Update Talk dashboard sidebar header to show label and icon inst…

### DIFF
--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -6,7 +6,7 @@
 {% load rules %}
 {% load static %}
 {% load vite %}
-{% blocktranslate with site_name=site_config.name asvar logo_alt_text %}The {{ site_name }} logo{% endblocktranslate %}
+{% blocktranslate trimmed with site_name=site_config.name asvar logo_alt_text %}The {{ site_name }} logo{% endblocktranslate %}
 
 <!DOCTYPE html>
 <html lang="{{ html_locale }}"{% if rtl %} dir="rtl" class="rtl"{% endif %}>
@@ -121,7 +121,7 @@
                 {% endif %}
                 {% block navbar_right %}{% endblock navbar_right %}
                 <li class="nav-item d-none d-md-block">
-                    <a class="nav-link active" href="#">
+                    <a class="nav-link active" href="{% url "orga:user.view" %}">
                         <i class="fa fa-user"></i>
                         {{ request.user.get_display_name }}
                     </a>
@@ -166,36 +166,38 @@
             {% if request.user.is_authenticated %}
             <aside class="nav flex-column sidebar">
                 <div class="dropdown nav-link p-0" id="nav-search-wrapper">
-                    <a href="{% get_dashboard_url %}" style="text-decoration: none; color: inherit;">
-                        <div id="nav-search" class="dropdown-toggle summary-div" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <div class="d-flex justify-content-between align-items-center">
-                                <span id="search-context-icon" class="fa-stack fa-lg">
-                                    <i class="fa fa-circle fa-stack-2x"></i>
-                                    <i class="fa {% get_top_menu_item_icon_class %} fa-stack-1x fa-inverse"></i>
-                                </span>
-                                <div id="search-context-text">
-                                    {% if request.event %}
-                                        <span class="context-name font-weight-bold">{{ request.event.name }}</span>
-                                        <span class="context-meta">{{ request.event.get_date_range_display }}</span>
-                                    {% elif request.organiser %}
-                                        <span class="context-name font-weight-bold">{{ request.organiser.name }}</span>
-                                        <span class="context-meta">{% translate "Organiser account" %}</span>
-                                    {% else %}
-                                        <span class="context-name font-weight-bold">{% translate "Talk dashboard" %}</span>
-                                    {% endif %}
+                    {% block nav_top_header %}
+                        <a href="{% get_dashboard_url %}" style="text-decoration: none; color: inherit;">
+                            <div id="nav-search" class="dropdown-toggle summary-div" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <span id="search-context-icon" class="fa-stack fa-lg">
+                                        <i class="fa fa-circle fa-stack-2x"></i>
+                                        <i class="fa {% get_top_menu_item_icon_class %} fa-stack-1x fa-inverse"></i>
+                                    </span>
+                                    <div id="search-context-text">
+                                        {% if request.event %}
+                                            <span class="context-name font-weight-bold">{{ request.event.name }}</span>
+                                            <span class="context-meta">{{ request.event.get_date_range_display }}</span>
+                                        {% elif request.organiser %}
+                                            <span class="context-name font-weight-bold">{{ request.organiser.name }}</span>
+                                            <span class="context-meta">{% translate "Organiser account" %}</span>
+                                        {% else %}
+                                            <span class="context-name font-weight-bold">{% translate "Talk dashboard" %}</span>
+                                        {% endif %}
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <div id="nav-search-input-wrapper" class="d-none dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url 'orga:nav.typeahead' %}" data-event-typeahead data-organiser="{% if request.event %}{{ request.event.organiser.pk }}{% elif request.organiser %}{{ request.organiser.pk }}{% endif %}">
-                            <div class="query-holder">
-                                <div class="form-box">
-                                    <input type="search" class="form-control" placeholder="{% translate 'Search' %} (Alt + k)" data-typeahead-query>
+                            <div id="nav-search-input-wrapper" class="d-none dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url 'orga:nav.typeahead' %}" data-event-typeahead data-organiser="{% if request.event %}{{ request.event.organiser.pk }}{% elif request.organiser %}{{ request.organiser.pk }}{% endif %}">
+                                <div class="query-holder">
+                                    <div class="form-box">
+                                        <input type="search" class="form-control" placeholder="{% translate 'Search' %} (Alt + k)" data-typeahead-query>
+                                    </div>
                                 </div>
+                                <ul id="search-results">
+                                </ul>
                             </div>
-                            <ul id="search-results">
-                            </ul>
-                        </div>
-                    </a>
+                        </a>
+                    {% endblock %}
                 </div>
                 {% if request.event %}
                     {% has_perm "orga.view_orga_area" request.user request.event as can_see_orga_area %}

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -121,7 +121,7 @@
                 {% endif %}
                 {% block navbar_right %}{% endblock navbar_right %}
                 <li class="nav-item d-none d-md-block">
-                    <a class="nav-link active" href="{% url "orga:user.view" %}">
+                    <a class="nav-link active" href="#">
                         <i class="fa fa-user"></i>
                         {{ request.user.get_display_name }}
                     </a>
@@ -181,7 +181,7 @@
                                         <span class="context-name font-weight-bold">{{ request.organiser.name }}</span>
                                         <span class="context-meta">{% translate "Organiser account" %}</span>
                                     {% else %}
-                                        <span class="context-name font-weight-bold">{{ request.user.get_display_name }}</span>
+                                        <span class="context-name font-weight-bold">{% translate "Talk dashboard" %}</span>
                                     {% endif %}
                                 </div>
                             </div>

--- a/src/pretalx/orga/templates/orga/user.html
+++ b/src/pretalx/orga/templates/orga/user.html
@@ -1,6 +1,7 @@
 {% extends "orga/base.html" %}
 
 {% load compress %}
+{% load context_urls %}
 {% load i18n %}
 {% load static %}
 
@@ -9,6 +10,31 @@
         <script defer src="{% static 'vendored/zxcvbn.js' %}"></script>
         <script defer src="{% static 'common/js/password_strength.js' %}"></script>
     {% endcompress %}
+{% endblock %}
+
+{% block nav_top_header %}
+    <a href="#" style="text-decoration: none; color: inherit;">
+        <div id="nav-search" class="dropdown-toggle summary-div" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <div class="d-flex justify-content-between align-items-center">
+                <span id="search-context-icon" class="fa-stack fa-lg">
+                    <i class="fa fa-circle fa-stack-2x"></i>
+                    <i class="fa fa-user fa-stack-1x fa-inverse"></i>
+                </span>
+                <div id="search-context-text">
+                    <span class="context-name font-weight-bold">{% translate "Account" %}</span>
+                </div>
+            </div>
+        </div>
+        <div id="nav-search-input-wrapper" class="d-none dropdown-content dropdown-menu dropdown-menu-left" aria-labelledby="nav-search" data-source="{% url 'orga:nav.typeahead' %}" data-event-typeahead data-organiser="{% if request.event %}{{ request.event.organiser.pk }}{% elif request.organiser %}{{ request.organiser.pk }}{% endif %}">
+            <div class="query-holder">
+                <div class="form-box">
+                    <input type="search" class="form-control" placeholder="{% translate 'Search' %} (Alt + k)" data-typeahead-query>
+                </div>
+            </div>
+            <ul id="search-results">
+            </ul>
+        </div>
+    </a>
 {% endblock %}
 
 {% block extra_title %}{% translate "User settings" %} :: {% endblock extra_title %}

--- a/src/pretalx/orga/templatetags/context_icons.py
+++ b/src/pretalx/orga/templatetags/context_icons.py
@@ -5,8 +5,4 @@ register = template.Library()
 @register.simple_tag(takes_context=True)
 def get_top_menu_item_icon_class(context):
     request = context['request']
-    if getattr(request, 'event', None):
-        return 'fa-tachometer'
-    elif getattr(request, 'organiser', None):
-        return 'fa-group'
-    return 'fa-user'
+    return 'fa-group' if getattr(request, 'organiser', None) else 'fa-tachometer'


### PR DESCRIPTION
Fixes: #355 

1. Rename sidebar menu header to "Talk dashboard"
2. Deleted the link to the user account page because the Ticket dashboard menu (in the navbar) doesn't link anywhere, so the Talk dashboard menu should be consistent.
The UI of the Talk dashboard menu in the navbar still needs to be updated accordingly.

![Talk_dashboard](https://github.com/user-attachments/assets/b1941cb5-0689-4a1d-b8c6-1ff71c0ace43)

## Summary by Sourcery

Update the Talk dashboard header and navbar link for consistency and adjust the top menu icon logic to match the new context

Enhancements:
- Rename the sidebar header label to “Talk dashboard”
- Remove the Talk dashboard link to the user account page
- Adjust the top menu icon tag to return fa-group for organiser context and fa-tachometer otherwise