### PR TITLE
Show red asterisk for required fields on public form

### DIFF
--- a/src/pretalx/common/templates/common/forms/field.html
+++ b/src/pretalx/common/templates/common/forms/field.html
@@ -3,7 +3,10 @@
     {% block field_label_left %}
         {% if field.field.widget.input_type != "checkbox" or field.field.widget.allow_multiple_selected %}
             <label for="{{ field.auto_id }}" class="{{ label_class }}">
-                {{ field.label }}
+                <span>
+                    {{ field.label }}
+                    {% if field.field.required %}<span class="text-danger ms-1">*</span>{% endif %}
+                </span>
                 {% if not field.field.required %}<span class="optional">{% translate "Optional" %}</span>{% endif %}
             </label>
         {% endif %}


### PR DESCRIPTION
Fixes: fossasia/eventyay-tickets#986 
Show red asterisk for required fields on public form
and show text "Optional" for optional fields

<img width="1915" height="892" alt="Screenshot from 2025-07-12 00-39-44" src="https://github.com/user-attachments/assets/bf0deedb-4142-47d2-9a38-6d512f0bc2e1" />

## Summary by Sourcery

Enhancements:
- Provide visual cues for form fields by adding a red asterisk to required fields and displaying “Optional” for optional fields.