### PR TITLE
Schedule exporter visibility for ticket holders

### DIFF
--- a/src/pretalx/agenda/views/utils.py
+++ b/src/pretalx/agenda/views/utils.py
@@ -8,7 +8,7 @@ from pretalx.common.signals import register_data_exporters, register_my_data_exp
 
 def is_visible(exporter, request, public=False):
     if not public:
-        return request.user.has_perm("orga.view_schedule", request.event)
+        return request.user.is_authenticated
     if not request.user.has_perm("agenda.view_schedule", request.event):
         return False
     if hasattr(exporter, "is_public"):


### PR DESCRIPTION
Fixes: #388 

The admin, organizer and authenticated user can now view exports.
But unauthenticated user can not.

## Summary by Sourcery

Bug Fixes:
- Allow any authenticated user to view non-public schedule exports and prevent unauthenticated users from accessing them