### PR TITLE
Let organizer join online video, without checking ticket

### DIFF
--- a/src/pretalx/agenda/views/talk.py
+++ b/src/pretalx/agenda/views/talk.py
@@ -354,12 +354,11 @@ class OnlineVideoJoin(EventPermissionRequired, View):
         token = jwt.encode(
             payload, venueless_settings.secret, algorithm="HS256"
         )
-
+        redirect_url = urljoin(venueless_settings.join_url, f'#token={token}')
+        logger.info('Redirect URL to Video: %s', redirect_url)
         return JsonResponse(
             {
-                "redirect_url": "{}/#token={}".format(
-                    venueless_settings.join_url, token
-                ).replace("//#", "/#")
+                'redirect_url': redirect_url
             },
             status=HTTPStatus.OK,
         )

--- a/src/pretalx/agenda/views/talk.py
+++ b/src/pretalx/agenda/views/talk.py
@@ -1,5 +1,9 @@
+from enum import StrEnum
+import logging
 import datetime as dt
-from urllib.parse import unquote, urlparse
+from http import HTTPStatus
+from urllib.parse import unquote, urlparse, urljoin
+from typing import TypeVar
 
 import jwt
 import requests
@@ -23,9 +27,27 @@ from pretalx.common.views.mixins import (
     PermissionRequired,
     SocialMediaCardMixin,
 )
+from pretalx.person.models import User
 from pretalx.schedule.models import Schedule, TalkSlot
+from pretalx.event.models import Event
 from pretalx.submission.forms import FeedbackForm
 from pretalx.submission.models import QuestionTarget, Submission, SubmissionStates
+
+
+logger = logging.getLogger(__name__)
+
+
+class TicketCheckResult(StrEnum):
+    HAS_TICKET = 'has_ticket'
+    MISCONFIGURED = 'missing_configuration'
+    NO_TICKET = 'no_ticket'
+
+
+class VideoJoinError(StrEnum):
+    # The string value looks diffrent from the enum name
+    # because other code may depend on this string value.
+    NOT_ALLOWED = 'user_not_allowed'
+    MISCONFIGURED = 'missing_configuration'
 
 
 class TalkMixin(PermissionRequired):
@@ -270,88 +292,118 @@ class OnlineVideoJoin(EventPermissionRequired, View):
     permission_required = "agenda.view_schedule"
 
     def get(self, request, *args, **kwargs):
-        # First check video is configured or not
-        if (
-            "pretalx_venueless" not in request.event.plugin_list
-            or not request.event.venueless_settings
-            or not request.event.venueless_settings.join_url
-            or not request.event.venueless_settings.secret
-            or not request.event.venueless_settings.issuer
-            or not request.event.venueless_settings.audience
-        ):
-            return HttpResponse(status=403, content="missing_configuration")
-
         if not request.user.is_authenticated:
-            # redirect to login page if user not logged in yet
-            return HttpResponse(status=403, content="user_not_allowed")
+            return HttpResponse(status=HTTPStatus.FORBIDDEN, content=VideoJoinError.NOT_ALLOWED)
 
-        # prepare event data to check from ticket
-        if "ticket_link" not in request.event.display_settings:
-            return HttpResponse(status=403, content="missing_configuration")
+        # First check video is configured or not
+        if 'pretalx_venueless' not in request.event.plugin_list:
+            logger.info('pretalx_venueless plugin is not enabled.')
+            return HttpResponse(status=HTTPStatus.FORBIDDEN, content=VideoJoinError.MISCONFIGURED)
+        event = request.event
+        logger.info('To check settings for event %s', event)
+        if not (venueless_settings := event.venueless_settings):
+            logger.info('venueless settings is missing.')
+            return HttpResponse(status=HTTPStatus.FORBIDDEN, content=VideoJoinError.MISCONFIGURED)
+        if not venueless_settings.join_url:
+            logger.info('venueless_settings.join_url is missing.')
+            return HttpResponse(status=HTTPStatus.FORBIDDEN, content=VideoJoinError.MISCONFIGURED)
+        if not venueless_settings.secret:
+            logger.info('venueless_settings.secret is missing.')
+            return HttpResponse(status=HTTPStatus.FORBIDDEN, content=VideoJoinError.MISCONFIGURED)
+        if not venueless_settings.issuer:
+            logger.info('venueless_settings.issuer is missing.')
+            return HttpResponse(status=HTTPStatus.FORBIDDEN, content=VideoJoinError.MISCONFIGURED)
+        if not venueless_settings.audience:
+            logger.info('venueless_settings.audience is missing.')
+            return HttpResponse(status=HTTPStatus.FORBIDDEN, content=VideoJoinError.MISCONFIGURED)
 
-        base_url, organizer, event = self.retrieve_info_from_url(
-            request.event.display_settings["ticket_link"]
-        )
+        # If the logged-in user does not have "orga.view_schedule" permission, we check
+        # if he/she owns a ticket.
+        if not request.user.has_perm('agenda.view_schedule', event):
+            res = check_user_owning_ticket(request.user, event)
+            if res == TicketCheckResult.NO_TICKET:
+                return HttpResponse(status=HTTPStatus.FORBIDDEN, content=VideoJoinError.NOT_ALLOWED)
+            if res == TicketCheckResult.MISCONFIGURED:
+                return HttpResponse(status=HTTPStatus.FORBIDDEN, content=VideoJoinError.MISCONFIGURED)
 
-        if not organizer or not event or not base_url:
-            return HttpResponse(status=403, content="missing_configuration")
+        # Redirect user to online event
+        iat = dt.datetime.now(dt.UTC)
+        exp = iat + dt.timedelta(days=30)
+        profile = {
+            "display_name": request.user.name,
+            "fields": {
+                "pretalx_id": request.user.code,
+            },
+        }
+        if request.user.avatar_url:
+            profile["profile_picture"] = request.user.get_avatar_url(request.event)
 
-        check_payload = {"user_email": request.user.email}
-
-        # call to ticket to check if user order ticket yet or not
-        response = requests.post(
-            f"{base_url}/api/v1/{organizer}/{event}/ticket-check", json=check_payload
-        )
-
-        if response.status_code != 200:
-            return HttpResponse(status=403, content="user_not_allowed")
-
-        else:
-            # Redirect user to online event
-            iat = dt.datetime.utcnow()
-            exp = iat + dt.timedelta(days=30)
-            profile = {
-                "display_name": request.user.name,
-                "fields": {
-                    "pretalx_id": request.user.code,
-                },
-            }
-            if request.user.avatar_url:
-                profile["profile_picture"] = request.user.get_avatar_url(request.event)
-
-            payload = {
-                "iss": request.event.venueless_settings.issuer,
-                "aud": request.event.venueless_settings.audience,
-                "exp": exp,
-                "iat": iat,
-                "uid": encode_email(request.user.email),
-                "profile": profile,
-                "traits": list(
-                    {
-                        f"eventyay-video-event-{request.event.slug}",
-                    }
-                ),
-            }
-            token = jwt.encode(
-                payload, request.event.venueless_settings.secret, algorithm="HS256"
-            )
-
-            return JsonResponse(
+        payload = {
+            "iss": venueless_settings.issuer,
+            "aud": venueless_settings.audience,
+            "exp": exp,
+            "iat": iat,
+            "uid": encode_email(request.user.email),
+            "profile": profile,
+            "traits": list(
                 {
-                    "redirect_url": "{}/#token={}".format(
-                        request.event.venueless_settings.join_url, token
-                    ).replace("//#", "/#")
-                },
-                status=200,
-            )
+                    f"eventyay-video-event-{request.event.slug}",
+                }
+            ),
+        }
+        token = jwt.encode(
+            payload, venueless_settings.secret, algorithm="HS256"
+        )
 
-    def retrieve_info_from_url(self, url):
-        parsed_url = urlparse(url)
-        ticket_host = settings.EVENTYAY_TICKET_BASE_PATH
-        path = parsed_url.path
-        parts = path.strip("/").split("/")
-        if len(parts) >= 2:
-            organizer, event = parts[-2:]
-            return ticket_host, unquote(organizer), unquote(event)
-        else:
-            return ticket_host, None, None
+        return JsonResponse(
+            {
+                "redirect_url": "{}/#token={}".format(
+                    venueless_settings.join_url, token
+                ).replace("//#", "/#")
+            },
+            status=HTTPStatus.OK,
+        )
+
+
+_T = TypeVar('_T', str, None)
+# We use TypeVar because the 2nd and 3rd items must be both `str` or both `None` at the same time.
+# The annotation `tuple[str, str | None, str | None]` doesn't satisfy this requirement.
+def extract_event_info_from_url(url: str) -> tuple[str, _T, _T]:
+    parsed_url = urlparse(url)
+    ticket_host = settings.EVENTYAY_TICKET_BASE_PATH
+    path = parsed_url.path
+    parts = path.strip("/").split("/")
+    if len(parts) >= 2:
+        organizer, event = parts[-2:]
+        return ticket_host, unquote(organizer), unquote(event)
+    return ticket_host, None, None
+
+
+def check_user_owning_ticket(user: User, event: Event) -> TicketCheckResult:
+    """
+    Call eventyay-ticket API to check if user owns ticket for this event.
+
+    # NOTE: It doesn't work with the Docker setup for development, because we use fake domain then,
+    and inside the container, the fake domain points to the container itself, not the host.
+    """
+    if 'ticket_link' not in event.display_settings:
+        logger.info('display_settings[ticket_link] is missing.')
+        return TicketCheckResult.MISCONFIGURED
+    base_url, organizer, event = extract_event_info_from_url(
+            event.display_settings['ticket_link']
+        )
+    if not organizer or not event or not base_url:
+        logger.info('display_settings[ticket_link] is not valid.')
+        return TicketCheckResult.MISCONFIGURED
+    check_payload = {'user_email': user.email}
+    # call to ticket to check if user order ticket yet or not
+    api_url = urljoin(base_url, f'api/v1/{organizer}/{event}/ticket-check')
+    logger.info('To call API %s', api_url)
+    # In development, we disable the SSL verification.
+    response = requests.post(api_url, json=check_payload, verify=(not settings.DEBUG))
+
+    if response.status_code != HTTPStatus.OK:
+        logger.debug('Response from eventyay-ticket: %s', response.text)
+        logger.info('user is not allowed to join online event.')
+        return TicketCheckResult.NO_TICKET
+    return TicketCheckResult.HAS_TICKET

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -274,6 +274,13 @@ LOGGING = {
             "level": "INFO",  # Do not output all the queries
             "propagate": True,
         },
+        "pretalx": {
+            "handlers": ["file", "console"],
+            # We deliberately want to collect DEBUG logs for our app from production,
+            # because some bugs are only exposed in production environment.
+            "level": "DEBUG",
+            "propagate": True,
+        },
     },
 }
 logging.getLogger("MARKDOWN").setLevel(logging.WARNING)


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Solve the "Video" link in issue #376.

We bypass the ticket-check if the logged-in user is an organizer.
Note that, it still doesn't resolve the issue of fake domain in Docker setup for development.

## How has this been tested?

We can know get the redirection URL to video, with access token attached. Note that on localhost it is only testable with org user.
To test with normal user, we have to test on the server.

<img width="990" height="787" alt="image" src="https://github.com/user-attachments/assets/ffb57a36-835d-45b5-8f9c-ada16c12c5b8" />


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Enable organizers to join online video sessions without a ticket, centralize and streamline video join logic with improved error handling, HTTP status responses, and logging, and update logging settings for better diagnostics

New Features:
- Allow organizers to bypass ticket ownership check when joining an online video session

Enhancements:
- Refactor OnlineVideoJoin.get to validate plugin configuration, permissions, and tickets with standardized HTTPStatus codes and JSON payloads
- Extract ticket validation logic into check_user_owning_ticket and extract_event_info_from_url utility functions
- Introduce TicketCheckResult and VideoJoinError enums and add detailed logging
- Add DEBUG-level logging configuration for the pretalx application