### PR TITLE
fix: open exporter in new tab

### DIFF
--- a/src/pretalx/agenda/templates/agenda/schedule.html
+++ b/src/pretalx/agenda/templates/agenda/schedule.html
@@ -24,7 +24,7 @@
             </a>
             <hr>
             {% for exporter in exporters %}
-                <a class="dropdown-item" href="{{ exporter.urls.base }}" role="menuitem" tabindex="-1">
+                <a class="dropdown-item" href="{{ exporter.urls.base }}" role="menuitem" tabindex="-1" target="_blank">
                     {% if exporter.icon|slice:":3" == "fa-" %}
                         <span class="fa {{ exporter.icon }} export-icon"></span>
                     {% else %}


### PR DESCRIPTION
completes #172

## Summary by Sourcery

Bug Fixes:
- Add target="_blank" attribute to exporter dropdown links to ensure they open in a new tab