### PR TITLE
Django command to notify Video site about schedule update

### DIFF
--- a/src/pretalx/agenda/management/commands/notify-video-about-schedule-update.py
+++ b/src/pretalx/agenda/management/commands/notify-video-about-schedule-update.py
@@ -1,0 +1,66 @@
+import logging
+from argparse import ArgumentParser
+from urllib.parse import urljoin, urlparse
+
+import requests
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from pretalx.event.models import Event
+
+
+# The name of the Video container
+VIDEO_CONTAINER_NAME = 'eventyay-video'
+logger = logging.getLogger(__name__)
+
+
+def replace_hostname(url: str) -> str:
+    '''
+    Replace the hostname of the URL with the name of the Video container.
+    '''
+    parsed_url = urlparse(url)
+    parsed_url = parsed_url._replace(netloc=VIDEO_CONTAINER_NAME, scheme='http')
+    return parsed_url.geturl()
+
+
+def push_to_video_site(event: Event):
+    url = urljoin(event.venueless_settings.url, 'schedule_update')
+    logger.info('Saved video API URL: %s', url)
+    # In development with Docker, we use fake domain, so the URL can not reach the video site,
+    # we need to replace the hostname.
+    url = replace_hostname(url)
+    # I haven't found the page to retrieve this token.
+    # In development, I get it from ShortToken model in Video container.
+    token = event.venueless_settings.token
+    logger.info('To push schedule to rewritten video API URL instead: %s', url)
+    post_data = {
+        'domain': event.custom_domain or settings.SITE_URL,
+        'event': event.slug,
+    }
+    logger.info('With post data: %s', post_data)
+    logger.info('Authenticated with token: %s', token)
+    response = requests.post(
+        url,
+        json=post_data,
+        headers={
+            'Authorization': f'Bearer {token}',
+        },
+    )
+    if not response.ok:
+        logger.error('Failed to push schedule to video site: %s', response.text)
+        raise CommandError(f'Failed to push schedule to video site: {response.text}')
+    logger.info('Response: %s', response.content)
+    logger.info('Schedule pushed to video site successfully.')
+
+
+class Command(BaseCommand):
+    '''
+    Inform the video site that the schedule has been updated.
+    '''
+    def add_arguments(self, parser: ArgumentParser):
+        parser.add_argument('event_slug', type=str)
+
+    def handle(self, event_slug: str, **options):
+        event = Event.objects.get(slug=event_slug)
+        push_to_video_site(event)
+

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -229,7 +229,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "default": {
-            "format": "%(levelname)s %(asctime)s %(name)s %(module)s %(message)s"
+            "format": "%(levelname)s %(asctime)s %(module)s %(message)s"
         }
     },
     "handlers": {
@@ -279,7 +279,7 @@ LOGGING = {
             # We deliberately want to collect DEBUG logs for our app from production,
             # because some bugs are only exposed in production environment.
             "level": "DEBUG",
-            "propagate": True,
+            "propagate": False,
         },
     },
 }


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of https://github.com/fossasia/eventyay-video/issues/383

This PR create a Django command to push notification to Video component, and workaround the intercommunication issue for local Docker setup.
This command is not enough for the fossasia/eventyay-video/issues/383, though. We may need to add a similar command in Video site to pull data from Talk site.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Introduce a new Django management command to notify the Video service of schedule updates and refine logging configuration.

New Features:
- Add ‘notify-video-about-schedule-update’ command to post schedule changes to the eventyay-video service with Docker-friendly hostname replacement and token authentication

Enhancements:
- Update logging format to remove module name and disable handler propagation by default