### PR TITLE
Starred google calander fix

### DIFF
--- a/src/pretalx/agenda/urls.py
+++ b/src/pretalx/agenda/urls.py
@@ -23,8 +23,10 @@ def get_schedule_urls(regex_prefix, name_prefix=""):
             (".xcal", schedule.ExporterView.as_view(), "export.schedule.xcal"),
             (".json", schedule.ExporterView.as_view(), "export.schedule.json"),
             (".ics", schedule.ExporterView.as_view(), "export.schedule.ics"),
-            ("/export/google-calendar", schedule.GoogleCalendarRedirectView.as_view(), "export.google-calendar"),
-            ("/export/my-google-calendar", schedule.GoogleCalendarRedirectView.as_view(), "export.my-google-calendar"),
+            ("/export/google-calendar", schedule.CalendarRedirectView.as_view(), "export.google-calendar"),
+            ("/export/my-google-calendar", schedule.CalendarRedirectView.as_view(), "export.my-google-calendar"),
+            ("/export/webcal", schedule.CalendarRedirectView.as_view(), "export.webcal"),
+            ("/export/my-webcal", schedule.CalendarRedirectView.as_view(), "export.my-webcal"),
             ("/export/<name>", schedule.ExporterView.as_view(), "export"),
             ("/widgets/schedule.json", widget.widget_data, "widget.data"),
             # Legacy widget data URL, but expected in old widget code.

--- a/src/pretalx/agenda/urls.py
+++ b/src/pretalx/agenda/urls.py
@@ -45,6 +45,11 @@ urlpatterns = [
                     widget.widget_script,
                     name="widget.script",
                 ),
+                path(
+                    "export/<str:name>/<str:token>/",
+                    schedule.ExporterView.as_view(),
+                    name="export-tokenized",
+                ),
                 path("static/event.css", widget.event_css, name="event.css"),
                 path(
                     "schedule/changelog/",

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -429,20 +429,33 @@ class FavedICalExporter(BaseExporter):
         return f"{self.event.slug}-favs.ics", "text/calendar", cal.serialize()
 
 
-class BaseGoogleCalendarExporter(BaseExporter):
+class BaseCalendarExporter(BaseExporter):
     public = True
     show_qrcode = False
-    icon = "fa-google"
+    icon = "fa-calendar"
+    
     @property
     def show_public(self):
         return self.ical_exporter_cls(self.event).show_public
 
-class GoogleCalendarExporter(BaseGoogleCalendarExporter):
+class GoogleCalendarExporter(BaseCalendarExporter):
     identifier = "google-calendar"
     verbose_name = "Add to Google Calendar"
+    icon = "fa-google"
     ical_exporter_cls = ICalExporter
 
-class MyGoogleCalendarExporter(BaseGoogleCalendarExporter):
+class MyGoogleCalendarExporter(BaseCalendarExporter):
     identifier = "my-google-calendar"
+    icon = "fa-google"
     verbose_name = "Add My ⭐ Sessions to Google Calendar"
+    ical_exporter_cls = MyICalExporter
+
+class WebcalExporter(BaseCalendarExporter):
+    identifier = "webcal"
+    verbose_name = "Add to Other Calendar"
+    ical_exporter_cls = ICalExporter
+
+class MyWebcalExporter(BaseCalendarExporter):
+    identifier = "my-webcal"
+    verbose_name = "Add My ⭐ Sessions to Other Calendar"
     ical_exporter_cls = MyICalExporter

--- a/src/pretalx/schedule/signals.py
+++ b/src/pretalx/schedule/signals.py
@@ -90,3 +90,13 @@ def register_google_calendar_exporter(sender, **kwargs):
 def register_my_google_calendar_exporter(sender, **kwargs):
     from .exporters import MyGoogleCalendarExporter
     return MyGoogleCalendarExporter
+
+@receiver(register_data_exporters, dispatch_uid="exporter_builtin_webcal")
+def register_webcal_exporter(sender, **kwargs):
+    from .exporters import WebcalExporter
+    return WebcalExporter
+
+@receiver(register_my_data_exporters, dispatch_uid="exporter_builtin_my_webcal")
+def register_my_webcal_exporter(sender, **kwargs):
+    from .exporters import MyWebcalExporter
+    return MyWebcalExporter


### PR DESCRIPTION
Fixes fossasia/eventyay-tickets#989 
Google Exporters now uses HTTP, and a new calendar option has been added to support webcal-based calendars

## Summary by Sourcery

Add support for tokenized starred session exports and a unified calendar redirect handler for both Google and other calendar protocols

New Features:
- Support tokenized ICS exports for users’ starred sessions with signed tokens and expiry checks
- Add webcal and my-webcal exporter options alongside existing Google Calendar endpoints

Enhancements:
- Replace GoogleCalendarRedirectView with a unified CalendarRedirectView handling public and starred exports and redirect logic for Google and webcal schemes
- Refactor exporter classes by introducing a BaseCalendarExporter base, updating icons, and registering new WebcalExporter and MyWebcalExporter