### PR TITLE
Recover getContrastColor function in Schedule view

### DIFF
--- a/src/pretalx/static/agenda/js/pretalx-schedule.min.js
+++ b/src/pretalx/static/agenda/js/pretalx-schedule.min.js
@@ -18647,7 +18647,7 @@ function L_(e, t, n, r, i, s) {
         }, [
           W("div", {
             class: "tag-item",
-            style: it({ "background-color": o.color, color: e.getContrastColor(o.color) })
+            style: it({ "background-color": o.color, color: s.getContrastColor(o.color) })
           }, Te(o.tag), 5)
         ]))), 128))
       ]),
@@ -18779,6 +18779,13 @@ const z_ = ".c-linear-schedule-session,.break{z-index:10;display:flex;min-width:
   methods: {
     toggleFav() {
       console.log("toggling fav"), this.faved ? this.$emit("unfav", this.session.id) : this.$emit("fav", this.session.id);
+    },
+    getContrastColor(e) {
+      if (!e)
+        return "";
+      e = e.replace("#", "");
+      var t = parseInt(e.slice(0, 2), 16), n = parseInt(e.slice(2, 4), 16), r = parseInt(e.slice(4, 6), 16), i = (t * 299 + n * 587 + r * 114) / 1e3;
+      return i > 128 ? "black" : "white";
     }
   }
 }, Mu = /* @__PURE__ */ nn(R_, [["render", L_], ["styles", [z_]]]), j_ = { class: "c-linear-schedule" }, B_ = ["data-date"], V_ = {


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves #406 

Copied the fix from https://github.com/fossasia/eventyay-talk-schedule/pull/25

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.

## Summary by Sourcery

Reinstate the getContrastColor helper in the schedule view to ensure session titles and details use a readable text color against variable background colors

Enhancements:
- Reintroduced getContrastColor function in the schedule JavaScript
- Applied contrast-based text coloring to schedule items for improved readability